### PR TITLE
[repo] Create a basic fetch script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "clsx": "^1.1.1",
     "commander": "5",
     "dotenv": "^16.0.0",
+    "hast-util-from-parse5": "^5.0.0",
     "js-yaml": "^4.1.0",
     "mdx-mermaid": "^1.2.2",
     "mermaid": "^8.14.0",
@@ -40,6 +41,8 @@
     "raw-loader": "^4.0.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "rehype-remark": "8.1",
+    "remark-stringify": "9",
     "stylelint": "^14.6.1",
     "winston": "^3.7.2"
   },
@@ -74,6 +77,7 @@
     "lint-staged": "^12.3.7",
     "markdownlint-cli": "^0.31.1",
     "ts-jest": "^27.1.4",
-    "typescript": "^4.6.3"
+    "typescript": "^4.6.3",
+    "unist-util-inspect": "6.0.0"
   }
 }

--- a/scripts/wikimedia-fetch.js
+++ b/scripts/wikimedia-fetch.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Moodle Pty Ltd.
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+const yaml = require('js-yaml');
+const { exec } = require('child_process');
+const { program } = require('commander');
+const { writeFile } = require('fs/promises');
+
+/* eslint-disable import/no-extraneous-dependencies */
+const unified = require('unified');
+const parse = require('remark-parse');
+const legacyDocLinks = require('../src/lib/legacyDocLinks');
+const VFile = require('vfile');
+const rehype2remark = require('rehype-remark');
+const stringify = require('remark-stringify');
+
+const {
+    getFetchDoc,
+    getClient,
+    getLogger,
+    getNormalizedPath,
+    addMigratedPage,
+    guessSlug,
+} = require('./utils');
+
+const remoteHost = 'docs.moodle.org/dev';
+
+const client = getClient(remoteHost);
+const logger = getLogger();
+const fetchDoc = getFetchDoc(logger)(client);
+
+const getFrontpage = (title, content) => {
+    const data = {
+        title: title.replaceAll('_', ' '),
+        tags: [],
+    };
+
+    const categoryRegexp = /\[\[Category:(?<categoryName>[^\]]*)\]\]/g;
+    data.tags = Array.from(content.matchAll(categoryRegexp))
+        .map((result) => result.groups.categoryName.replace(/\|.*$/, ''))
+        .filter((result) => !!result);
+
+    const frontpageMatter = yaml.dump(data);
+
+    return `---
+${frontpageMatter}---`;
+};
+
+program
+    .name('wikimedia-fetch')
+    .description('CLI to migrate a legacy page from https://docs.moodle.org/dev/')
+    .version('1.0.0');
+
+program
+    .command('migrate')
+    .description('Migrate a document to the new path')
+    .arguments('<title>', 'Title of doc to migrate')
+    .arguments('<newpath>', 'New path')
+    .action(async (title, newPath) => {
+        const doc = await fetchDoc(title);
+
+        const frontpageMatter = getFrontpage(title, doc.data);
+
+        const regexedData = doc.data
+            // Convert ordered lists to numbered ordered lists.
+            .replaceAll(/^###/gm, '      1. ')
+            .replaceAll(/^##/gm, '   1. ')
+            .replaceAll(/^#/gm, '1. ')
+
+            // Remove duplicate spaces after the ordered list number.
+            .replaceAll(/^(?<li>\d)+. {2}/gm, '$1. ')
+
+            // Convert bullet lists to -.
+            .replaceAll(/^\* +/gm, '- ')
+
+            // Convert heading in reverse order.
+            .replaceAll(/^==== ?(?<heading>[^=]+)====/gm, '#### $1')
+            .replaceAll(/^=== ?(?<heading>[^=]+)===/gm, '### $1')
+            .replaceAll(/^== ?(?<heading>[^=]+)==/gm, '## $1')
+
+            // Convert Wikimedia bold to markdown strong.
+            .replaceAll(/'''(?<value>[^']*)'''/g, '**$1**')
+
+            // Convert Wikimedia italic to markdown emphasis.
+            .replaceAll(/''(?<value>[^']*)''/g, '__$1__')
+
+            // Convert code blocks to a fenced codeblock.
+            .replaceAll(/^<syntaxhighlight lang="(?<language>[^"]*)">/gm, '```$1')
+            .replaceAll(/^<\/syntaxhighlight>/gm, '```')
+
+            // Remove trailing whitespace.
+            .replace(/ *$/m, '')
+            .replaceAll(/^\[\[Category:.*$/gm, '')
+        ; // eslint-disable-line semi-style
+
+        const newFile = getNormalizedPath(newPath);
+
+        // Write it initially as some of the remark plugins use the absolute path.
+        writeFile(newFile, regexedData);
+
+        // This section uses remark to convert the file to an AST tree and then pass it through some of the remark
+        // plugins.
+        // This allows us to do things like convert tracker links, update legacy doc links, and warn of obsolete doc
+        // links.
+        const vFile = new VFile({
+            path: newFile,
+            value: regexedData,
+        });
+
+        const tree = unified()
+            .use(parse)
+            .parse(regexedData);
+
+        legacyDocLinks.updateMarkdown(tree, vFile);
+
+        const remarkedContent = unified()
+            .use(rehype2remark)
+            .use(stringify, {
+                bullet: '-',
+                fence: '`',
+                fences: true,
+            })
+            .stringify(tree)
+
+            // Unescape \[[ to [[. This is markdown trying to parse our weird and wonderful wiki links.
+            .replaceAll('\\[[', '[[')
+
+            // Convert any non-interwiki link `[link this is a description]` into a markdown link.
+            // Basically:
+            // - `/\[*?!\[)`        look for any `[` which is not followed by another `[`.
+            //                      This excludes any Wiki links which start with [[.
+            // - `([^ ]+)( )`       The first capture is any character which is not a space, followed by a space.
+            //                      This is the link and a pointless second capture to work around super lineal
+            //                      backtracking exploits.
+            // - `([^\]]+)\](?!\])` The third capture group is any character which is not a `]` followed by another `]`
+            // - `(?![([])/`        And which matches a negative lookahead for either a `(` or a `[` chracter.
+            //                      These are used in some cases for other links - e.g. [Existing desc](link) or
+            //                      [Thumbnail][Description].
+            // eslint-disable-next-line prefer-named-capture-group
+            .replaceAll(/\[(?!\[)([^ ]+)( )([^\]]+)\](?!\])(?![([])/g, '[$3]($1)')
+        ; // eslint-disable-line semi-style
+
+        const pageContent = `${frontpageMatter}\n${remarkedContent}`;
+        writeFile(newFile, pageContent);
+
+        // Execute the lint twice as the first time seems to be able to introduce things which can then be fixed in a
+        // second run.
+        exec(`yarn markdownlint --fix ${newFile}`);
+        exec(`yarn markdownlint --fix ${newFile}`);
+
+        // Update the migratedPages file.
+        addMigratedPage(title.replaceAll(/ /g, '_'), newFile, guessSlug(newFile));
+    });
+program.parse();

--- a/src/lib/legacyDocLinks.js
+++ b/src/lib/legacyDocLinks.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Moodle Pty Ltd.
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* cspell:disable */
+
+/* eslint-disable import/no-extraneous-dependencies */
+const visit = require('unist-util-visit');
+const { isObsolete, isMigrated, getMigrationLink } = require('../../migratedPages');
+
+const getDescriptionFromString = (string) => {
+    const [linkComponent, description] = string.split('|');
+    if (description) {
+        // A description was present.
+        return description;
+    }
+
+    // No description present.
+    // We'll guess one based on the link itself.
+    const [page, bookmark] = linkComponent.split('#');
+    if (bookmark) {
+        // There was a bookmark. Just return a tidied version of that.
+        return bookmark.replaceAll('_', ' ');
+    }
+
+    // No bookmark. Return a tidied version of the page title.
+    return page.replaceAll('_', ' ');
+};
+
+const getLegacyMessage = (vfile, string, replacement) => `---
+- Use of legacy docs link found for migrated doc
+- File:  \t ${vfile.path}
+- Found: \t [[${string}]]
+- Replacement: \t ${replacement}
+---`;
+
+const getObsoleteMessage = (vfile, string) => `---
+- Use of obsoleted legacy doc link found for migrated doc
+- File:  \t ${vfile.path}
+- Found: \t [[${string}]]
+---`;
+
+const getLinkFromString = (vfile, string) => {
+    let [linkComponent] = string.split('|');
+
+    // Links never have spaces in them.
+    linkComponent = linkComponent.replaceAll(' ', '_');
+
+    // Split on the bookmark (if present).
+    let [pageComponent, bookmarkComponent] = linkComponent.split('#');
+
+    if (pageComponent) {
+        if (isMigrated(pageComponent)) {
+            if (bookmarkComponent) {
+                bookmarkComponent = `#${bookmarkComponent.replaceAll('_', '-')}`;
+            } else {
+                bookmarkComponent = '';
+            }
+            const migrationLink = getMigrationLink(pageComponent, vfile.path);
+            const replacement = `[${getDescriptionFromString(string)}](${migrationLink}${bookmarkComponent})`;
+
+            console.warn(getLegacyMessage(vfile, string, replacement));
+
+            return migrationLink + bookmarkComponent;
+        } else if (isObsolete(pageComponent)) {
+            console.warn(getObsoleteMessage(vfile, string));
+        }
+    }
+
+    if (linkComponent.substring(0, 1) === '#') {
+        // This is a relative link in the same page.
+        // Update it to meet the correct format.
+        return linkComponent.toLowerCase().replaceAll('_', '-');
+    }
+
+    // Point to a link on the old docs site.
+    return `https://docs.moodle.org/dev/${linkComponent}`;
+};
+
+/**
+ * Update a text representation of a link to legacy docs.
+ *
+ * These are in the format:
+ *
+ *     [[Link target|Optional description]]
+ *
+ * @param {Tree} node
+ * @param {Number} index
+ * @param {Tree} parent
+ */
+const updateLink = (vfile) => (node, index, parent) => {
+    if (parent.children[index - 1]?.type !== 'text') {
+        return null;
+    }
+
+    if (parent.children[index - 1]?.value.slice(-1) !== '[') {
+        return null;
+    }
+
+    if (parent.children[index + 1]?.type !== 'text') {
+        return null;
+    }
+
+    if (parent.children[index + 1]?.value.substr(0, 1) !== ']') {
+        return null;
+    }
+
+    const linkNode = {
+        type: 'link',
+        url: getLinkFromString(vfile, node.label),
+        children: [{
+            type: 'text',
+            value: getDescriptionFromString(node.label),
+        }],
+    };
+
+    parent.children[index - 1].value = parent.children[index - 1].value.slice(0, -1);
+    parent.children.splice(index, 1, linkNode);
+    parent.children[index + 1].value = parent.children[index + 1].value.slice(1);
+
+    return null;
+};
+
+const transformer = async (ast, vfile) => {
+    visit(ast, 'linkReference', updateLink(vfile));
+};
+
+module.exports = {
+    transformer,
+};

--- a/src/remark/legacyDocLinks.js
+++ b/src/remark/legacyDocLinks.js
@@ -1,120 +1,22 @@
-const visit = require('unist-util-visit');
-const {isObsolete, isMigrated, getMigrationLink} = require('../../migratedPages');
-
-const plugin = (options) => {
-    const transformer = async (ast, vfile) => {
-        visit(ast, 'linkReference', updateLink(vfile));
-    };
-    return transformer;
-};
-
-const getLinkFromString = (vfile, string) => {
-    let [linkComponent] = string.split('|');
-
-    // Links never have spaces in them.
-    linkComponent = linkComponent.replaceAll(' ', '_');
-
-    // Split on the bookmark (if present).
-    let [pageComponent, bookmarkComponent] = linkComponent.split('#');
-
-    if (pageComponent) {
-        if (isMigrated(pageComponent)) {
-            if (bookmarkComponent) {
-                bookmarkComponent = `#${bookmarkComponent.replaceAll('_', '-')}`;
-            } else {
-                bookmarkComponent = '';
-            }
-            const migrationLink = getMigrationLink(pageComponent, vfile.path);
-            const replacement = `[${getDescriptionFromString(string)}](${migrationLink}${bookmarkComponent})`;
-
-            let message = `---\n`;
-            message += `- Use of legacy docs link found for migrated doc\n`;
-            message += `- File:  \t ${vfile.path}\n`;
-            message += `- Found: \t [[${string}]]\n`;
-            message += `- Replacement: \t ${replacement}\n`;
-            message += `---\n`;
-            console.warn(message);
-
-            return migrationLink + bookmarkComponent;
-        } else if (isObsolete(pageComponent)) {
-            let message = `---\n`;
-            message += `- Use of obsoleted legacy doc link found for migrated doc\n`;
-            message += `- File:  \t ${vfile.path}\n`;
-            message += `- Found: \t [[${string}]]\n`;
-            message += `---\n`;
-            console.warn(message);
-        }
-    }
-
-    if (linkComponent.substring(0, 1) === '#') {
-        // This is a relative link in the same page.
-        // Update it to meet the correct format.
-        return linkComponent.toLowerCase().replaceAll('_', '-');
-    }
-
-    // Point to a link on the old docs site.
-    return `https://docs.moodle.org/dev/${linkComponent}`;
-};
-
-const getDescriptionFromString = string => {
-    const [linkComponent, description] = string.split('|');
-    if (description) {
-        // A description was present.
-        return description;
-    }
-
-    // No description present.
-    // We'll guess one based on the link itself.
-    const [page, bookmark] = linkComponent.split('#');
-    if (bookmark) {
-        // There was a bookmark. Just return a tidied version of that.
-        return bookmark.replaceAll('_', ' ');
-    }
-
-    // No bookmark. Return a tidied version of the page title.
-    return page.replaceAll('_', ' ');
-};
-
 /**
- * Update a text representation of a link to legacy docs.
+ * Copyright (c) Moodle Pty Ltd.
  *
- * These are in the format:
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- *     [[Link target|Optional description]]
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- * @param {Tree} node
- * @param {Number} index
- * @param {Tree} parent
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
  */
-const updateLink = (vfile) => (node, index, parent) => {
-    if (parent.children[index - 1]?.type !== 'text') {
-        return null;
-    }
 
-    if (parent.children[index - 1]?.value.slice(-1) !== '[') {
-        return null;
-    }
+/* cspell:disable */
 
-    if (parent.children[index + 1]?.type !== 'text') {
-        return null;
-    }
+const { transformer } = require('../lib/legacyDocLinks');
 
-    if (parent.children[index + 1]?.value.substr(0, 1) !== ']') {
-        return null;
-    }
-
-    const linkNode = {
-        type: 'link',
-        url: getLinkFromString(vfile, node.label),
-        children: [{
-            type: 'text',
-            value: getDescriptionFromString(node.label),
-        }],
-    };
-
-    parent.children[index - 1].value = parent.children[index - 1].value.slice(0, -1);
-    parent.children.splice(index, 1, linkNode);
-    parent.children[index + 1].value = parent.children[index + 1].value.slice(1);
-};
-
-module.exports = plugin;
+module.exports = () => transformer;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6900,6 +6900,13 @@ hast-to-hyperscript@^9.0.0:
     unist-util-is "^4.0.0"
     web-namespaces "^1.0.0"
 
+hast-util-embedded@^1.0.0:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/hast-util-embedded/-/hast-util-embedded-1.0.6.tgz#ea7007323351cc43e19e1d6256b7cde66ad1aa03"
+  integrity sha512-JQMW+TJe0UAIXZMjCJ4Wf6ayDV9Yv3PBDPsHD4ExBpAspJ6MOcCX+nzVF+UJVv7OqPcg852WEMSHQPoRA+FVSw==
+  dependencies:
+    hast-util-is-element "^1.1.0"
+
 hast-util-from-parse5@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/hast-util-from-parse5/-/hast-util-from-parse5-5.0.3.tgz#3089dc0ee2ccf6ec8bc416919b51a54a589e097c"
@@ -6923,6 +6930,16 @@ hast-util-from-parse5@^6.0.0:
     vfile-location "^3.2.0"
     web-namespaces "^1.0.0"
 
+hast-util-has-property@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz#9f137565fad6082524b382c1e7d7d33ca5059f36"
+  integrity sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==
+
+hast-util-is-element@^1.0.0, hast-util-is-element@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz#3b3ed5159a2707c6137b48637fbfe068e175a425"
+  integrity sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ==
+
 hast-util-parse-selector@^2.0.0:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz#d57c23f4da16ae3c63b3b6ca4616683313499c3a"
@@ -6944,6 +6961,24 @@ hast-util-raw@6.0.1:
     xtend "^4.0.0"
     zwitch "^1.0.0"
 
+hast-util-to-mdast@^7.0.0:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/hast-util-to-mdast/-/hast-util-to-mdast-7.1.3.tgz#e4ad9098929355501773aed5e66c8181559eee04"
+  integrity sha512-3vER9p8B8mCs5b2qzoBiWlC9VnTkFmr8Ufb1eKdcvhVY+nipt52YfMRshk5r9gOE1IZ9/xtlSxebGCv1ig9uKA==
+  dependencies:
+    extend "^3.0.0"
+    hast-util-has-property "^1.0.0"
+    hast-util-is-element "^1.1.0"
+    hast-util-to-text "^2.0.0"
+    mdast-util-phrasing "^2.0.0"
+    mdast-util-to-string "^1.0.0"
+    rehype-minify-whitespace "^4.0.3"
+    repeat-string "^1.6.1"
+    trim-trailing-lines "^1.1.0"
+    unist-util-is "^4.0.0"
+    unist-util-visit "^2.0.0"
+    xtend "^4.0.1"
+
 hast-util-to-parse5@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-6.0.0.tgz#1ec44650b631d72952066cea9b1445df699f8479"
@@ -6954,6 +6989,20 @@ hast-util-to-parse5@^6.0.0:
     web-namespaces "^1.0.0"
     xtend "^4.0.0"
     zwitch "^1.0.0"
+
+hast-util-to-text@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/hast-util-to-text/-/hast-util-to-text-2.0.1.tgz#04f2e065642a0edb08341976084aa217624a0f8b"
+  integrity sha512-8nsgCARfs6VkwH2jJU9b8LNTuR4700na+0h3PqCaEk4MAnMDeu5P0tP8mjk9LLNGxIeQRLbiDbZVw6rku+pYsQ==
+  dependencies:
+    hast-util-is-element "^1.0.0"
+    repeat-string "^1.0.0"
+    unist-util-find-after "^3.0.0"
+
+hast-util-whitespace@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz#e4fe77c4a9ae1cb2e6c25e02df0043d0164f6e41"
+  integrity sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A==
 
 hastscript@^5.0.0:
   version "5.1.2"
@@ -8621,6 +8670,11 @@ logform@^2.3.2, logform@^2.4.0:
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
 
+longest-streak@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
+  integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -8766,6 +8820,13 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
+mdast-util-phrasing@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-phrasing/-/mdast-util-phrasing-2.0.0.tgz#57e61f2be908be9f5fce54fcc2fa593687986267"
+  integrity sha512-G1rNlW/sViwzbBYD7+k3mKGtoWV2v4GBFky66OYHfktHe7Hg9R+hH4xpeoOtjYiwTvle8C8wlKMpgqPCkaeK8Q==
+  dependencies:
+    unist-util-is "^4.0.0"
+
 mdast-util-to-hast@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz#0cfc82089494c52d46eb0e3edb7a4eb2aea021eb"
@@ -8779,6 +8840,23 @@ mdast-util-to-hast@10.0.1:
     unist-util-generated "^1.0.0"
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
+
+mdast-util-to-markdown@^0.6.0:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
+  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    longest-streak "^2.0.0"
+    mdast-util-to-string "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.0.0"
+    zwitch "^1.0.0"
+
+mdast-util-to-string@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-string/-/mdast-util-to-string-1.1.0.tgz#27055500103f51637bd07d01da01eb1967a43527"
+  integrity sha512-jVU0Nr2B9X3MU4tSK7JP1CMkSvOj7X5l/GboG1tKRw52lLF1x2Ju92Ms9tNetCcbfX3hzlM73zYo2NKkWSfF/A==
 
 mdast-util-to-string@^2.0.0:
   version "2.0.0"
@@ -10446,6 +10524,16 @@ regjsparser@^0.8.2:
   dependencies:
     jsesc "~0.5.0"
 
+rehype-minify-whitespace@^4.0.3:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/rehype-minify-whitespace/-/rehype-minify-whitespace-4.0.5.tgz#5b4781786116216f6d5d7ceadf84e2489dd7b3cd"
+  integrity sha512-QC3Z+bZ5wbv+jGYQewpAAYhXhzuH/TVRx7z08rurBmh9AbG8Nu8oJnvs9LWj43Fd/C7UIhXoQ7Wddgt+ThWK5g==
+  dependencies:
+    hast-util-embedded "^1.0.0"
+    hast-util-is-element "^1.0.0"
+    hast-util-whitespace "^1.0.4"
+    unist-util-is "^4.0.0"
+
 rehype-parse@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/rehype-parse/-/rehype-parse-6.0.2.tgz#aeb3fdd68085f9f796f1d3137ae2b85a98406964"
@@ -10454,6 +10542,16 @@ rehype-parse@^6.0.2:
     hast-util-from-parse5 "^5.0.0"
     parse5 "^5.0.0"
     xtend "^4.0.0"
+
+rehype-remark@8.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/rehype-remark/-/rehype-remark-8.1.1.tgz#aa2e7a9b454aaf498788982e3095a0535241e7fa"
+  integrity sha512-8HCmub9Fcy208A7RGbjmVlxTMYZXGaF7jsUE2tuvNKuaGFrk9yrYuKAXoTVC7QFwBPzTvEc5AOZKpUiWRkamlw==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    "@types/unist" "^2.0.0"
+    hast-util-to-mdast "^7.0.0"
 
 relateurl@^0.2.7:
   version "0.2.7"
@@ -10526,6 +10624,13 @@ remark-squeeze-paragraphs@4.0.0:
   dependencies:
     mdast-squeeze-paragraphs "^4.0.0"
 
+remark-stringify@9:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-9.0.1.tgz#576d06e910548b0a7191a71f27b33f1218862894"
+  integrity sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==
+  dependencies:
+    mdast-util-to-markdown "^0.6.0"
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"
@@ -10537,7 +10642,7 @@ renderkid@^3.0.0:
     lodash "^4.17.21"
     strip-ansi "^6.0.1"
 
-repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
@@ -11724,7 +11829,7 @@ trim-newlines@^3.0.0:
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
-trim-trailing-lines@^1.0.0:
+trim-trailing-lines@^1.0.0, trim-trailing-lines@^1.1.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz#bd4abbec7cc880462f10b2c8b5ce1d8d1ec7c2c0"
   integrity sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==
@@ -11962,10 +12067,22 @@ unist-builder@2.0.3, unist-builder@^2.0.0:
   resolved "https://registry.yarnpkg.com/unist-builder/-/unist-builder-2.0.3.tgz#77648711b5d86af0942f334397a33c5e91516436"
   integrity sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==
 
+unist-util-find-after@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-after/-/unist-util-find-after-3.0.0.tgz#5c65fcebf64d4f8f496db46fa8fd0fbf354b43e6"
+  integrity sha512-ojlBqfsBftYXExNu3+hHLfJQ/X1jYY/9vdm4yZWjIbf0VuWF6CRufci1ZyoD/wV2TYMKxXUoNuoqwy+CkgzAiQ==
+  dependencies:
+    unist-util-is "^4.0.0"
+
 unist-util-generated@^1.0.0:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-1.1.6.tgz#5ab51f689e2992a472beb1b35f2ce7ff2f324d4b"
   integrity sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==
+
+unist-util-inspect@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-inspect/-/unist-util-inspect-6.0.0.tgz#56866c2170aacdb8e5199f8dae9c40b4a3b3629d"
+  integrity sha512-mwdQMGuDCIlsNpi48s4wSknJympqmROAc+oMjyNNmAfeU7ynytukfqjvEjEASnPdHrS2f4WMThly40rI8UCyzQ==
 
 unist-util-is@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
This is a really basic system to fetch a page from the legacy docs into
a new location on disk, and perform basic changes.

It does *NOT* catch everything and it can do better, but it's what I've
been doing manually.

At the moment it will:

- not convert any table
- complain about migrated pages but not fix them
- do nothing with tracker links
- not update the migratedDocs.yml file with it's existence

I've tried to merge some of the functions and utilities that I
previously wrote for the legacy wiki updater into a shared utils file
too.

Usage:

```
node scripts/fetchLegacyPage.js migrate [Legacy_Page_Title] [path/to/new/page.md]
```