### PR TITLE
[docs] process/testing/guide: Migrate testing instructions guide

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1,4 +1,3 @@
----
 Access_API:
 - filePath: "/docs/apis/access.md"
   slug: "/docs/apis/access"
@@ -71,6 +70,9 @@ Roadmap:
 Testing:
 - filePath: "/general/development/process/testing.md"
   slug: "/general/development/process/testing"
+Testing_instructions_guide:
+- filePath: "/general/development/process/testing/guide.md"
+  slug: "/general/development/process/testing/guide"
 Testing_of_integrated_issues:
 - filePath: "/general/development/process/testing/integrated-issues.md"
   slug: "/general/development/process/testing/integrated-issues"
@@ -80,4 +82,3 @@ Tracker_introduction:
 Tracker_tips:
 - filePath: "/general/development/tracker/tips.md"
   slug: "/general/development/tracker/tips"
-

--- a/general/development/process.md
+++ b/general/development/process.md
@@ -181,7 +181,7 @@ Click on _Request peer review_ button in the tracker.
 
 You need to fill in the information about your public git repository and which branches the fixes are on. Make sure you are listed as Assignee.
 
-This would be a good time to fill in the testing instructions (read the [[Testing instructions guide|instructions guide]]) for how to verify your fix is correct. You may also wish to add a comment in the bug.
+This would be a good time to fill in the testing instructions (read the [instructions guide](./process/testing/guide)) for how to verify your fix is correct. You may also wish to add a comment in the bug.
 
 Component leads should put issues, which affect code in their components, up for peer review to allow interested parties to provide feedback. However, if it is not reviewed in a week, a component lead may send the issue to integration. If integrators consider that the issue has not been given proper chance for peer review (for example is extremely large or complex) it can be decided to move the issue back in the process.
 
@@ -231,7 +231,7 @@ The following information is necessary for this:
   - repository URL
   - branch name(s)
   - diff URL
-- [[Testing instructions guide|Testing instructions]] for how to verify your fix is correct.
+- [Testing instructions](./process/testing/guide) for how to verify your fix is correct.
 If you have never contributed to Moodle and don't see a button _Request peer review_, just comment on the issue with the above information. The component lead or another user with sufficient privileges will then send the issue up for peer review for you.
 
 After your first fix is integrated you will be added to developers group and will be able to send issues for peer review yourself. In this case make sure you are listed as Assignee and click on _Request peer review_ button in the tracker.

--- a/general/development/process/peer-review.md
+++ b/general/development/process/peer-review.md
@@ -110,7 +110,7 @@ It is the developer's responsibility to test code before integration. Issues sho
 Ensure that:
 
 - There are specific testing instructions that state how, as well as what, to test. Please ensure that the testing instructions:
-  - Are in the [correct format](https://docs.moodle.org/dev/Testing_instructions_guide);
+  - Are in the [correct format](./testing/guide);
   - Are clear; and
   - Are concise;
   - They consider other perspectives of other users perhaps not considered by original developers e.g. Moodle mobile app users

--- a/general/development/process/testing.md
+++ b/general/development/process/testing.md
@@ -22,7 +22,7 @@ Code is tested as part of reviewing at some key parts of the [Moodle development
 
 :::info More info
 
-We recommend that you follow the [[Testing instructions guide]] to help you write clear manual testing instructions.
+We recommend that you follow the [Testing instructions guide](./testing/guide) to help you write clear manual testing instructions.
 
 :::
 

--- a/general/development/process/testing/guide.md
+++ b/general/development/process/testing/guide.md
@@ -1,0 +1,27 @@
+---
+title: Testing instructions guide
+tags:
+  - Processes
+---
+This page has suggestions for developers on how to write good testing instructions for the weekly [testing of integrated issues](./integrated-issues).
+
+We recommend that you:
+
+1. Number the steps in your test, and make use of sub-lists.
+2. Only put one action (preparation or validation) on each line - A step should only define a unique operation.
+3. Promote test validations - **Confirm**, **Verify** or **Ensure** - should be in **bold** so that they are easily identifiable.
+4. Make use of the [Jira Markdown formatting](https://tracker.moodle.org/secure/WikiRendererHelpAction.jspa?section=all).
+
+In addition, the following items may be included:
+
+1. Setup requirements. If so, explain them with detailed information and/or provide a link to the documentation, for example <https://docs.moodle.org/en/OAuth_2_services>.
+2. Whether testing involves git/shell interaction, SQL operations or commands in general, don't assume the tester knows how to perform that stuff. Instead, add them explicitly to the instructions.
+3. Whether multiple themes (for example boost, or classic) should be used.
+4. Whether more than one browser should be used.
+5. Whether extra testing around the issue is required.
+
+:::info Information for testers
+
+You should specify which themes and browsers have tested, and attach some screenshots.
+
+:::

--- a/general/development/process/testing/integrated-issues.md
+++ b/general/development/process/testing/integrated-issues.md
@@ -39,7 +39,7 @@ For test sessions, if you encounter a failure, please fail the issue add a comme
 
 ## Expectation from developer and peer-reviewer
 
-Testing instructions are clear, concise, complete, and accurate. Where possible they should be easy to perform. Please follow the [[Testing instructions guide]] recommendations.
+Testing instructions are clear, concise, complete, and accurate. Where possible they should be easy to perform. Please follow the [Testing instructions guide](./guide) recommendations.
 
 ## Expectations of the Integration team
 

--- a/general/development/process/testing/qa.md
+++ b/general/development/process/testing/qa.md
@@ -187,7 +187,7 @@ To create a new QA test:
 2. If not, in {tracker MDLQA-1} from the More menu select 'Create sub-task'.
 3. Enter a summary such as 'A teacher can ...'.
 4. Select 'Original' as affected version and select appropriate components.
-5. In the description field add the test steps (usually between 3 and 10), similar to the issue's [testing instructions](https://docs.moodle.org/dev/Testing_instructions_guide), starting with 'Log in as a teacher...' or similar. It's a good idea to try doing the steps yourself as you write the test.
+5. In the description field add the test steps (usually between 3 and 10), similar to the issue's [testing instructions](./guide), starting with 'Log in as a teacher...' or similar. It's a good idea to try doing the steps yourself as you write the test.
 6. Start some steps with 'Verify that ...' or similar.
 7. Click the Create button.
 8. Go to the MDL issue and create a ‘has a QA test’ link to the new QA test, adding a comment “This feature is now covered by the QA test MDLQA....”.

--- a/sidebars/general.js
+++ b/sidebars/general.js
@@ -55,6 +55,11 @@ const sidebars = {
                     type: 'category',
                     items: [
                         {
+                            label: 'Instructions guide',
+                            type: 'doc',
+                            id: 'development/process/testing/guide',
+                        },
+                        {
                             label: 'Integrated issues',
                             type: 'doc',
                             id: 'development/process/testing/integrated-issues',
@@ -69,7 +74,7 @@ const sidebars = {
                         type: 'doc',
                         id: 'development/process/testing',
                     },
-                }
+                },
             ],
             link: {
                 type: 'doc',


### PR DESCRIPTION
This patch migrates https://docs.moodle.org/dev/Testing_instructions_guide page (I've used the script in https://github.com/moodle/devdocs/pull/63 for migrating it) <3 