### PR TITLE
[repo] Correct expression to only run on moodle/devdocs

### DIFF
--- a/.github/workflows/update-wikimedia.yml
+++ b/.github/workflows/update-wikimedia.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   run:
     # Only run on the canonical repository.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.repository == 'moodle/devdocs'
     name: Push migated pages to Wikimedia
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Before it only ran if we pushed directly to main without a pull request.

We should be comparing the `github.repository`, documented at
https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
to the canonical repository.