### PR TITLE
[docs] Remove references to contact Helen in QA

### DIFF
--- a/general/development/process/testing/qa.md
+++ b/general/development/process/testing/qa.md
@@ -160,7 +160,7 @@ When the next QA cycle is prepared, any issue with the `qa_test_required` label 
 
 ## Updating tests
 
-QA tests may become out-of-date due to User Interface changes, feature changes, and new features. If you would like to help with updating tests, you'll need to be a member of the test writers group in the Tracker. Please contact Helen about being added.
+QA tests may become out-of-date due to User Interface changes, feature changes, and new features. If you would like to help with updating tests, you'll need to be a member of the test writers group in the Tracker.
 
 To update a QA test original:
 
@@ -175,7 +175,7 @@ If a test in the current QA cycle is marked as failed because it is out-of-date,
 
 ## Writing new tests
 
-Would you like to help with writing new QA tests? To write new QA tests you will need to be a member of the test writers group in the Tracker. Please contact Helen about being added.
+Would you like to help with writing new QA tests? To write new QA tests you will need to be a member of the test writers group in the Tracker.
 
 QA tests are needed for any features which can't be tested with automated testing, such as connecting to an external system, drag and drop functionality or a CLI script. Also if it requires a person to detect if something is 'correct' vs. present/absent on the page.
 


### PR DESCRIPTION
As discussed in https://github.com/moodle/devdocs/issues/41, it has
been agreed to remove references to Contact to Helen in QA testing
page. These changes has been done in https://docs.moodle.org/dev/QA_testing
and this commit is to remove also from the new page.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/72"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

