### PR TITLE
[docs] general: Fix migrated page

### DIFF
--- a/general/development/process/triage.md
+++ b/general/development/process/triage.md
@@ -164,6 +164,6 @@ In the [Tracker tips and tricks](../tracker/tips#creating-a-filter) page you'll 
 
 ## See also
 
-- [[Tracker guide]]
+- [Tracker guide](/general/development/tracker/guide)
 - [Process](./)
-- [Tracker tips](../tracker/tips)
+- [Tracker tips](/general/development/tracker/tips)


### PR DESCRIPTION
These two pages landed at the same time in different issues and I didn't
spot them when merging.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/79"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

