### PR TITLE
[docs] tracker/labels: Migrate tracker labels

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -10,12 +10,12 @@ Accessibility:
 Activity_modules:
 - filePath: "/docs/apis/plugintypes/mod/index.mdx"
   slug: "/docs/apis/plugintypes/mod"
-Bug_triage:
-- filePath: "/general/development/process/triage.md"
-  slug: "/general/development/process/triage"
 Antivirus_plugins:
 - filePath: "/docs/apis/plugintypes/antivirus/index.mdx"
   slug: "/docs/apis/plugintypes/antivirus"
+Bug_triage:
+- filePath: "/general/development/process/triage.md"
+  slug: "/general/development/process/triage"
 CodeSniffer:
 - filePath: "/general/development/tools/phpcs.md"
   slug: "/general/development/tools/phpcs"
@@ -154,6 +154,9 @@ Tracker_guide:
 Tracker_introduction:
 - filePath: "/general/development/tracker.md"
   slug: "/general/development/tracker"
+Tracker_issue_labels:
+- filePath: "/general/development/tracker/labels.md"
+  slug: "/general/development/tracker/labels"
 Tracker_tips:
 - filePath: "/general/development/tracker/tips.md"
   slug: "/general/development/tracker/tips"

--- a/general/development/process/integration-review.md
+++ b/general/development/process/integration-review.md
@@ -68,14 +68,14 @@ optimisations)
 11. Scalability - if master only - we're looking far future, stable branches may not be lucky to get such improvements.
 12. git authorship is correct vs committer + credits due are mentioned + email addresses
 13. Documentation / PHP Doc / readability
-14. [[Tracker issue labels]] which might need adding. Particularly:
-    1. docs_required / dev_docs_required / release_notes: About which type of documentation is required for the issue.
-    2. ui_change / api_change: About the implications of the change.
-    3. unit_test_required / acceptance_test_required / qa_test_required: About the need to cover the issue with some test.
-    4. affects_mobileapp / affects_workplace / affects_moodlecloud: About issues that may affect other Moodle products and services
+14. [Tracker issue labels](/general/development/tracker/labels) which might need adding. Particularly:
+    1. `docs_required` / `dev_docs_required` / `release_notes`: About which type of documentation is required for the issue.
+    2. `ui_change` / `api_change`: About the implications of the change.
+    3. `unit_test_required` / `acceptance_test_required` / `qa_test_required`: About the need to cover the issue with some test.
+    4. `affects_mobileapp` / `affects_workplace` / `affects_moodlecloud`: About issues that may affect other Moodle products and services
 15. [[Tracker issue versions]] review. Particularly:
     1. Fixed Version after integration - is the versions that the issue is patched for. (A rule here: ["or stables or master"](https://docs.moodle.org/dev/Tracker_issue_versions#Some_general_and_simple_rules)).
-    2. Remove any "Must fix for X.Y" version once the issue is integrated.
+    2. Remove any `Must fix for X.Y` version once the issue is integrated.
 16. Whenever any of the points above or any other detail require extra information or action to be done by the assignee, and the integrator
 considers that they can be fixed without needing to discard/reopen, the issue will be sent to `Waiting for feedback` with all the details to
 complete. Once everything has been fulfilled, always within a reasonable amount of time (still to decide), the issue will be sent back to
@@ -194,9 +194,13 @@ Many issues can be appropriately classified as borderline bug-fix/improvements. 
 
 - Given the [general policy](#general-policy) above, only supported stable branches are candidates normally.
 - Also security, privacy, data-loss and regressions caused by any of the previous issue types are accepted to be fixed into security-only supported branches.
+
 :::note
-This doesn't include [`security_benefit` labelled issues](https://docs.moodle.org/dev/Tracker_issue_labels).
+
+This doesn't include [`security_benefit` labelled issues](/general/development/tracker/labels).
+
 ::::
+
 - Apart from the previous, issues required to keep the testing infrastructure working and passing (travis, behat, phpunit, random failures, new steps availability...) will also be accepted when possible into security-only branches.
 - Finally, backport to unsupported branches only will happen when the issue is a **direct regression caused by a bug fix** introduced by the very latest releases. This applies to both security-only and out-of-support branches.
 

--- a/general/development/process/peer-review.md
+++ b/general/development/process/peer-review.md
@@ -175,7 +175,7 @@ Ensure that:
 - The PHPdoc comments on all classes, methods and fields are useful. (Comments that just repeat the function name are not helpful! Add value.)
 - Where an API has been changed significantly, the relevant upgrade.txt file has been updated with information.
 - Where something has been deprecated, that the comments don't just say "do NOT use this any more!!!" but actually say what should be done instead.
-- Appropriate [labels](https://docs.moodle.org/dev/Tracker_issue_labels) have been added when there has been a function change, particularly
+- Appropriate [labels](/general/development/tracker/labels) have been added when there has been a function change, particularly
   - docs_required (any functional change, usually paired with `ui_change`),
   - dev_docs_required (any change to APIs, usually paired with `api_change`),
   - `ui_change` (any functional change, usually paired with docs_required, except ui_change remains permanently),
@@ -285,7 +285,7 @@ Thanks again for your contribution. I have reviewed the patch:
 I don't have permission to use the peer review buttons on this issue. I hope that someone with sufficient permissions will move the issue forwards soon.
 ```
 
-You should now add the '[ready_for_integration](https://docs.moodle.org/dev/Tracker_issue_labels)' tag to the issue to indicate you have passed the peer review and it can move to the next step.
+You should now add the '[ready_for_integration](/general/development/tracker/labels)' tag to the issue to indicate you have passed the peer review and it can move to the next step.
 
 Feedback to indicate the issue requires further work might look like the following;
 

--- a/general/development/process/triage.md
+++ b/general/development/process/triage.md
@@ -55,7 +55,7 @@ When you confirm that the issue is indeed a bug or a reasonable improvement requ
   - The issue is a bug in code that is present in the `master` branch only, in which case the next major version should be used. (The next major version should not be used in conjunction with previous released versions, this won't make sense later.)
   - The issue is a new feature and is unrelated to any existing code in Moodle, in which case the `Future dev` version should be used.
 - **Labels**
-  - Remove functionality tags that some reporters add as labels, only  [[Tracker_issue_labels|standard]] labels or partner-specific labels are used in Moodle
+  - Remove functionality tags that some reporters add as labels, only  [standard labels or partner-specific labels](/general/development/tracker/labels) are used in Moodle
   - Issues with proposed fixes should be labelled with `patch` so that they can be found easily and given attention. When this is the case, consider whether moving the issue to the `Waiting for peer review` state in the workflow might be more appropriate
   - Add the `addon_candidate` label if the functionality can be implemented as a plugin;
   - If you are the component lead or an HQ developer you may also add `triaged` label to indicate that the triage process is completed. Use it only when the issue has actually been added to the backlog

--- a/general/development/tracker/guide.md
+++ b/general/development/tracker/guide.md
@@ -1,5 +1,6 @@
 ---
 title: Tracker guide
+sidebar_label: Guide
 tags:
   - Tracker
 ---
@@ -66,7 +67,7 @@ Once an issue has been created, the following additional fields are able to be c
 | **URL**  | If possible, provide a URL address that demonstrates an example of this bug.  |   |
 | **Epic Name**  | A short name given to an issue of type Epic so that linked issues can be grouped by this name. It should only be a few words at most.  | Only applies to issues of type Epic.  |
 | **Epic Link**  | A link to an Epic issue. This can be added by providing the issue ID or Epic name. It is a way of organising related issues as part of a project.  | Only applies to issues that need to be collected together for a project.  |
-| **Labels**  | See [[Tracker issue labels]].  | <ul><li>Labels should be specific values used in filters and searches.</li><li>This is not a field for including generic keywords.</li></ul>  |
+| **Labels**  | See [Tracker issue labels](/general/development/tracker/labels).  | <ul><li>Labels should be specific values used in filters and searches.</li><li>This is not a field for including generic keywords.</li></ul>  |
 | **Pull...**  | Links to a code solution in a Git repository.  | <ul><li>These fields are used by developers.</li><li>There may be multiple solutions if the problem affects multiple Moodle versions.</li></ul>  |
 | **Documentation link**  | URL of related documentation.  | When changes require documentation to be updated, this field should be filled.  |
 | **Comment**  | <ul><li>Notes made by all interested parties.</li><li>A detailed register of all changes that relate to this bug.</li></ul>  |   |
@@ -82,7 +83,7 @@ Once an issue has been created, the following additional fields are able to be c
 - [Tracker introduction](./) - less scary version of this page for new users.
 - [Process](../process)
 - [Bug triage](/general/development/process/triage)
-- [[Tracker issue labels]]
+- [Tracker issue labels](/general/development/tracker/labels)
 - [Testing of integrated issues](../process/testing/integrated-issues)
 - Using Moodle [How to manipulate Moodle developers](http://moodle.org/mod/forum/discuss.php?d=43952) forum discussion
 - Wikipedia [Definition of a bug](http://en.wikipedia.org/wiki/Software_bug)

--- a/general/development/tracker/labels.md
+++ b/general/development/tracker/labels.md
@@ -1,0 +1,123 @@
+---
+title: Tracker issue labels
+sidebar_label: Issue labels
+tags:
+  - Tracker
+---
+
+The Moodle Tracker allows issues to be **labelled with tags**. This page lists common labels that we use to flag aspects about our MDL issues (bugs and feature requests about Moodle itself).
+
+:::note
+
+Labels can only be added by a user with permission to edit an issue, that is the issue reporter, members of the developers group, or members of certain other groups.
+
+:::
+
+## Labels
+
+- `triaged`<br/>
+This is set after a bug has been [triaged](/general/development/process/triage) by component lead or HQ developer. It indicates that the issue has been confirmed, with basic fields like "Priority" checked, and is now ready for a developer to look at.
+
+- [`triaging_in_progress`](https://tracker.moodle.org/issues/?jql=labels%20in%20(triaging_in_progress))<br/>
+Used to flag issues that are being triaged (sometimes an ongoing process for days or weeks). When the issue has been triaged the label should be removed and a `triaged` label should be added or when the issue is closed.
+
+- `mdlqa`<br/>
+Used to flag that an issue is a direct result of a [Moodle QA test](/general/development/process/testing/qa), conducted just before major releases. The bug should also be linked to the original MDLQA test, so that developers/integrators can reset the original MDLQA test (for re-testing) when the MDL issue is fixed. Once all the related MDLQA tests are passing the label can be deleted.
+
+- `mdlqa_conversion`<br/>
+Used to flag MDL issues that are converting MDLQA issues to behat features. The bug should also be linked to the MDLQA test being converted. Useful to know what's going and exclude some issues from manual QA. Once the MDL issue has been closed and the MDLQA has been moved to {tracker MDLQA-5249}, the label can be deleted.
+
+- [`unit_test_required`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20unit_test_required)<br/>
+Used to flag issues that should have their own unit tests.
+
+- [`acceptance_test_required`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20acceptance_test_required)<br/>
+Used to flag issues that should be regularly tested using the behat framework [[Acceptance_testing]]. Before a major release these issues will be reviewed and new feature files will be added.
+
+- [`qa_test_required`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20qa_test_required)<br/>
+Used to flag issues that cannot be covered by automated tests. When adding the label, a comment should be also added advising exactly what needs covering in the QA test, for example "steps 6-10 in testing instructions".
+
+- [`qa_identified`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20qa_identified)<br/>
+Used to flag issues identified in QA testing which we were not able to fix before the release. Hopefully such issues can be worked on shortly after release, removing the label once the issue is fixed.
+
+- [`docs_required`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20docs_required)<br/>
+Used to flag issues that have created a need for documentation work, such as new pages, changes, or even being added to upcoming release notes. Docs people will look for these issues periodically when working on documentation, removing the label once documentation has been written. For new features in the upcoming version of Moodle, please add documentation to the dev docs (adding a link to it from the tracker issue) or in a comment in the issue, then when the new version wiki is set up (3 weeks prior to release), the info can be transferred.
+
+- `cl_docs_required` ([all](https://tracker.moodle.org/issues/?jql=labels%20in%20(cl_docs_required)) | [yours](https://tracker.moodle.org/issues/?jql=labels%20in%20(cl_docs_required)%20AND%20assignee%20%3D%20currentUser()))<br/>
+Used to flag issues that contain features which need to be documented in the [[Component Library]]. The responsibility of creating/updating Component Library documentation falls to the developer assigned to each relevant issue. Normally the relevant documentation should be included in the issue, but in some cases this will not be the case. When the issue is resolved and component library documentation was not included, a new issue should be created for the Component Library changes, linking using the **Documents** and **is documented by** issue links, and the `cl_docs_required` label should be removed from the issue.
+
+- `dev_docs_required` ([all](https://tracker.moodle.org/issues/?jql=labels%20in%20(dev_docs_required)) | [yours](https://tracker.moodle.org/issues/?jql=labels%20in%20(dev_docs_required)%20AND%20assignee%20%3D%20currentUser()))<br/>
+Used to flag issues that need to be noted in the dev docs. The responsibility of creating/updating Dev docs falls to the developer assigned to each relevant issue. When the issue is resolved, documentation should be created/updated, an appropriate URL should be added to the **Documentation link** field of the issue and the `dev_docs_required` label should be removed from the issue.
+
+- `integration_held`<br/>
+Used to flag issues already sent to integration that, for any cause, have been postponed to next cycles. Used only by integrators when there is some dependency or time-period causing one issue not being immediately integrable. Must be cleaned when the held is over.
+
+- `unhold_requested`<br/>
+Used to ask for an issue (having the `integration_held` label) to become unblocked, this flag must be coupled with a reasoned comment. Anybody can use it as far as repeated requests are avoided. Development managers will decide ASAP about giving the issue an integration opportunity or keeping it held. See [During continuous integration.2FFreeze.2FQA period](../process/integration-review#during-continuous-integrationfreezeqa-period).
+
+- `security_held`<br/>
+Used to flag security issues that have been reviewed by integrators already but held from integration repository. These issues must be cleared during point releases.
+
+- `security_benefit`<br/>
+Used to flag issues which help to improve the security of Moodle, but are not directly exploitable security bugs (and therefore do not have a security level assigned). For example, {tracker MDL-66775} and {tracker MDL-65443}.
+
+- `partner`<br/>
+Moodle Partners apply this label to flag issues that are important to their clients. The Moodle HQ dev team takes this label into consideration when setting roadmap and bug fixing priorities.
+
+- `patch`<br/>
+This label indicates that a solution (patch) has been attached to the issue. However, if you can, it may be better to submit the issue for peer review, rather than using this label. This is useful to component leads and Moodle HQ when deciding what to work on next.
+
+- `cime`<br/>
+A developer can add the `cime` label to an issue to request that CiBot perform an [[Automated code review]].
+
+- [`performance`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20performance%20AND%20project%20%3D%20MDL)<br/>
+Used to flag any issues that developers think may affect Moodle's performance in some way (positively or negatively).
+
+- [`ui_change`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20ui_change)<br/>
+Used to identify issues that affect the interface presented to users. This label will usually be added together with the `docs_required` label, but the `ui_change` will remain permanently with the issue, while the `docs_required` label is removed after docs are created. This label is searched for during the preparation of release notes.
+
+- [`ux_review_required`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20%22ux_review_required%22)<br/>
+Used to identify issues that require review by Moodle HQ UX designers. This label will usually be added to issues that involve more than a trivial UI or workflow change, to ensure UX best practice is applied, with a consistent and human centered design approach. Adding this label will ensure the issue is placed on the UX backlog for review and input.
+
+- `api_change`<br/>
+Used to identify API changes. This label will usually be added together with the `dev_docs_required` label, but the `api_change` will remain permanently with the issue, while the `dev_docs_required` label is removed after docs are created. This label is searched for during the preparation of release notes.
+
+- [`release_notes`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20release_notes)<br/>
+Used to identify all issues to be listed in the release notes (minor or major).
+
+- [`upgrade_notes`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20upgrade_notes)<br/>
+Issues that need to be mentioned in the user documentation [under 'Possible issues that may affect you in Moodle X.0' (major versions).
+
+- `lost_functionality`<br/>
+Used to identify issues describing functionality which was available in an earlier version but which is no longer available in the latest version.
+
+- [`test_server_required`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20%20test_server_required)<br/>
+Used to identify QA tests which can't be tested on the [QA testing site](http://qa.moodle.net) such as upgrade testing.
+
+- [`credentials_required`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20credentials_required)<br/>
+Used to identify QA tests which require the tester to enter credentials such as a client ID and secret for configuring OAuth 2.
+
+- `new`<br/>
+Used to identify new tests in the current QA cycle for volunteers from the community to use as a basis for exploratory testing.
+
+- [`addon_candidate`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20addon_candidate)<br/>
+Used to identify suggestions for improvements/new features as possible candidates for add-on development. New and willing developers can be directed to these issues for projects.
+
+- `affects_mobileapp`<br/>
+Used to identify MDL issues that may affect the mobile app. It should be used when adding new features to functionalities supported by the app or when doing changes in existing ones. Examples are: {tracker MDL-372} and {tracker MDL-38158}.
+
+- `affects_moodlecloud`<br/>
+Used to identify MDL issues that may affect Moodlecloud.
+
+- `affects_workplace`<br/>
+Used to identify MDL issues that may affect Moodle Workplace.
+
+- `needs_user_stories`<br/>
+Used to identify issues that require further clarification of the requirements through adding user stories.
+
+- [`ready_for_integration`](https://tracker.moodle.org/issues/?filter=21824)<br/>
+Used to identify issues that already have been peer-reviewed but the user lacks permissions (pull-requester) to send the issue to integration. Any pull-requester can, on peer-reviewer's behalf, proceed with the transition. The label is removed once the issue has been transitioned.
+
+## See also
+
+- [Tracker](../tracker)
+- [Bug triage](../process/triage)


### PR DESCRIPTION
Migrated from: https://docs.moodle.org/dev/Tracker_issue_labels