### PR TITLE
[repo] Add stylelint configuration

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "jest": "^27.5.1",
     "lint-staged": "^12.3.7",
     "markdownlint-cli": "^0.31.1",
+    "stylelint-config-standard": "^25.0.0",
     "ts-jest": "^27.1.4",
     "typescript": "^4.6.3",
     "unist-util-inspect": "6.0.0"

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -73,15 +73,15 @@ function Feature({
     Svg, link, title, description,
 }) {
     return (
-        <div className={clsx('col col--4 ') + styles.featuresBox}>
+        <div className={clsx('col col--4 ') + styles['features-box']}>
             <div>
                 <div className="text--center">
-                    <Svg className={styles.featureSvg} role="img" />
+                    <Svg className={styles['feature-svg']} role="img" />
                 </div>
                 <div className="text--center padding-horiz--md">
                     <Link
                         to={link}
-                        className={styles.featureLink}
+                        className={styles['feature-link']}
                     >
                         <h3>{title}</h3>
                     </Link>

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -5,21 +5,21 @@
   width: 100%;
 }
 
-.featuresBox {
-    position: relative;
+.features-box {
+  position: relative;
 }
 
-.featureSvg {
+.feature-svg {
   height: 200px;
   width: 200px;
 }
 
-.featureLink {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 1;
-    content: "";
+.feature-link {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+  content: "";
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -16,7 +16,7 @@
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
+[data-theme="dark"] {
   --ifm-color-primary: #f4963e;
   --ifm-color-primary-dark: #f28621;
   --ifm-color-primary-darker: #f27e13;
@@ -27,14 +27,14 @@
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgb(0 0 0 / 10%);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
-[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
+[data-theme="dark"] .docusaurus-highlight-code-line {
+  background-color: rgb(0 0 0 / 30%);
 }
 
 .docusaurus-hidden {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,7 +26,7 @@ import HomepageFeatures from '@site/src/components/HomepageFeatures';
 function HomepageHeader() {
     const { siteConfig } = useDocusaurusContext();
     return (
-        <header className={clsx('hero hero--primary', styles.heroBanner)}>
+        <header className={clsx('hero hero--primary', styles['hero-banner'])}>
             <div className="container">
                 <h1 className="hero__title">{siteConfig.title}</h1>
                 <p className="hero__subtitle">{siteConfig.tagline}</p>

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -3,7 +3,7 @@
  * and scoped locally.
  */
 
-.heroBanner {
+.hero-banner {
   padding: 4rem 0;
   text-align: center;
   position: relative;
@@ -12,7 +12,7 @@
 }
 
 @media screen and (max-width: 996px) {
-  .heroBanner {
+  .hero-banner {
     padding: 2rem;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11639,6 +11639,18 @@ stylehacks@^5.1.0:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
 
+stylelint-config-recommended@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz#7497372ae83ab7a6fffc18d7d7b424c6480ae15e"
+  integrity sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==
+
+stylelint-config-standard@^25.0.0:
+  version "25.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-25.0.0.tgz#2c916984e6655d40d6e8748b19baa8603b680bff"
+  integrity sha512-21HnP3VSpaT1wFjFvv9VjvOGDtAviv47uTp3uFmzcN+3Lt+RYRv6oAplLaV51Kf792JSxJ6svCJh/G18E9VnCA==
+  dependencies:
+    stylelint-config-recommended "^7.0.0"
+
 stylelint@^14.6.1:
   version "14.7.0"
   resolved "https://registry.yarnpkg.com/stylelint/-/stylelint-14.7.0.tgz#f2c4457a63ba813d72856818ab7d4141d2bdd6ab"


### PR DESCRIPTION
I discovered whilst working on another issue that I'd missed checking in
the stylelint configuration.

This makes use of `stylelint-config-standard`, which should cover most
of our usage.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/95"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

