### PR TITLE
[repo] Ensure that mdx files are linted too

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,7 @@
 {
   "*.css": ["stylelint --allow-empty-input --fix"],
   "*.{js,jsx,ts,tsx,mjs}": ["eslint --fix"],
-  "*.md": [
+  "*.{md,mdx}": [
     "markdownlint --fix",
     "cspell --no-must-find-files --no-progress"
   ],


### PR DESCRIPTION
Markdown lint should be able to check mdx files too.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/98"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

