### PR TITLE
Fix cspell config

### DIFF
--- a/cspell.config.js
+++ b/cspell.config.js
@@ -32,6 +32,8 @@ const config = {
         'softwareTerms',
         'companies',
         'lorem-ipsum',
+        'moodle-components',
+        'moodle-contributors',
         'project-words',
     ],
     dictionaryDefinitions: [
@@ -42,7 +44,7 @@ const config = {
         },
         {
             name: 'moodle-contributors',
-            path: './data/contributor-spelling.txt',
+            path: './data/moodle-contributors.txt',
             noSuggest: true,
         },
         {


### PR DESCRIPTION
The cspell config file is not declaring the new Moodle dictionaries for components and contributors.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/100"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

