### PR TITLE
[repo] Include vscode workspace config

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,4 @@
 {
-  "extends": "stylelint-config-standard"
+  "extends": "stylelint-config-standard",
+  "reportNeedlessDisables": true
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,15 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"davidanson.vscode-markdownlint",
+		"streetsidesoftware.code-spell-checker",
+		"dbaeumer.vscode-eslint",
+		"tberman.json-schema-validator",
+		"silvenon.mdx",
+		"gamunu.vscode-yarn"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": []
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${file}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-    "markdownlint.customRules": [
-    ]
+    "stylelint.packageManager": "yarn"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "markdownlint.customRules": [
+    ]
+}


### PR DESCRIPTION
This workspace configuration includes recommendations for the following
extensions:

- davidanson.vscode-markdownlint - Markdown Linting
- streetsidesoftware.code-spell-checker = Official cspell integration
- dbaeumer.vscode-eslint - Official Microsoft eslint integration
- tberman.json-schema-validator - JSON Schema validation
- silvenon.mdx - MDX syntax highlighter
- gamunu.vscode-yarn - Yarn integration

A second commit also configures stylelint configuration for the workspace.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/106"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

