### PR TITLE
[repo] Stop linting mdx files for now

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,7 @@
 {
   "*.css": ["stylelint --allow-empty-input --fix"],
   "*.{js,jsx,ts,tsx,mjs}": ["eslint --fix"],
-  "*.{md,mdx}": [
+  "*.md": [
     "markdownlint --fix",
     "cspell --no-must-find-files --no-progress"
   ],


### PR DESCRIPTION
The markdown lint is not aware enough of MDX, and some of the properties
will regularly fail cspell.

We'll try this again later.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/112"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

