### PR TITLE
Fix missing directional quotes

### DIFF
--- a/docs/guides/javascript/index.md
+++ b/docs/guides/javascript/index.md
@@ -298,13 +298,13 @@ Often you may want to link the JavaScript to a specific `DOMElement` in the temp
 You can use the `{{uniqid}}` Mustache tag to give that DOM Element a unique ID and then pass that into the Module.
 
 ```handlebars title=mod/forum/templates/discussion.mustache
-<div id=“mod_forum-discussion-wrapper-{{uniqid}}”>
+<div id="mod_forum-discussion-wrapper-{{uniqid}}">
     <!—- Your template content goes here. —->
 </div>
 
 {{#js}}
-require([‘mod_forum/discussion’], function(Discussion) {
-    Discussion.init(document.querySelector(“mod_forum-discussion-wrapper-{{uniqid}}”));
+require(['mod_forum/discussion'], function(Discussion) {
+    Discussion.init(document.querySelector("mod_forum-discussion-wrapper-{{uniqid}}"));
 });
 {{/js}}
 ```
@@ -341,7 +341,7 @@ You can also pass arguments to your function by passing an array as the third ar
 
 ```php
 // Call the `init` function on `mod_forum/discussion`.
-$PAGE->requires->js_call_amd(‘mod_forum/discussion’, ‘init’, [$course->id]);
+$PAGE->requires->js_call_amd('mod_forum/discussion', 'init', [$course->id]);
 ```
 
 If you pass a multi-dimensional array as the third argument, then you can use Array destructuring within the JavaScript to get named values.
@@ -350,9 +350,9 @@ If you pass a multi-dimensional array as the third argument, then you can use Ar
 <TabItem value="php-js_call_admin-args" label="PHP">
 
 ```php
-$PAGE->requires->js_call_amd(‘mod_forum/discussion’, ‘init’, [[
-    ‘courseid’ => $course->id,
-    ‘categoryid’ => $course->category,
+$PAGE->requires->js_call_amd('mod_forum/discussion', 'init', [[
+    'courseid' => $course->id,
+    'categoryid' => $course->category,
 ]]);
 ```
 

--- a/docs/moodleapp/development/setup/index.md
+++ b/docs/moodleapp/development/setup/index.md
@@ -140,10 +140,10 @@ If you want to run the application in an Android 5 emulator, you'll need to upgr
 Once you have [created your Android 5 virtual device](https://developer.android.com/studio/run/managing-avds), you'll need to do download [the apk for Webview 61](https://android.googlesource.com/platform/external/chromium-webview/+/refs/heads/oreo-m3-release/prebuilt/x86_64/) and run the following commands:
 
 ```bash
-# Open the folder where the “emulator” script is installed
+# Open the folder where the "emulator" script is installed
 cd $(dirname `which emulator`)
 
-# Boot the emulator in write mode (you can get a list of device names running “emulator -list-avds”)
+# Boot the emulator in write mode (you can get a list of device names running "emulator -list-avds")
 emulator @DeviceName -writable-system
 
 # In a different shell, make /system writable

--- a/versioned_docs/version-4.0/guides/javascript/index.md
+++ b/versioned_docs/version-4.0/guides/javascript/index.md
@@ -296,13 +296,13 @@ Often you may want to link the JavaScript to a specific `DOMElement` in the temp
 You can use the `{{uniqid}}` Mustache tag to give that DOM Element a unique ID and then pass that into the Module.
 
 ```mustache title=mod/forum/templates/discussion.mustache
-<div id=“mod_forum-discussion-wrapper-{{uniqid}}”>
+<div id="mod_forum-discussion-wrapper-{{uniqid}}">
     <!—- Your template content goes here. —->
 </div>
 
 {{#js}}
-require([‘mod_forum/discussion’], function(Discussion) {
-    Discussion.init(document.querySelector(“mod_forum-discussion-wrapper-{{uniqid}}”));
+require(['mod_forum/discussion'], function(Discussion) {
+    Discussion.init(document.querySelector("mod_forum-discussion-wrapper-{{uniqid}}"));
 });
 {{/js}}
 ```
@@ -324,7 +324,7 @@ A lot of this content is being migrated to use Mustache Templates which are the 
 Where content is generated in PHP you will need to include your JavaScript at the same time.
 
 Although several older ways to include JavaScript from PHP, it`s strongly
-recommended that all new JavaScript only use the `js_call_amd` function on the
+recommended that all new JavaScript only use the`js_call_amd` function on the
 `page_requirements_manager`.
 This has a similar format to the version used in Templates:
 
@@ -339,7 +339,7 @@ You can also pass arguments to your function by passing an array as the third ar
 
 ```php
 // Call the `init` function on `mod_forum/discussion`.
-$PAGE->requires->js_call_amd(‘mod_forum/discussion’, ‘init’, [$course->id]);
+$PAGE->requires->js_call_amd('mod_forum/discussion', 'init', [$course->id]);
 ```
 
 If you pass a multi-dimensional array as the third argument, then you can use Array destructuring within the JavaScript to get named values.
@@ -348,9 +348,9 @@ If you pass a multi-dimensional array as the third argument, then you can use Ar
 <TabItem value="php-js_call_admin-args" label="PHP">
 
 ```php
-$PAGE->requires->js_call_amd(‘mod_forum/discussion’, ‘init’, [[
-    ‘courseid’ => $course->id,
-    ‘categoryid’ => $course->category,
+$PAGE->requires->js_call_amd('mod_forum/discussion', 'init', [[
+    'courseid' => $course->id,
+    'categoryid' => $course->category,
 ]]);
 ```
 
@@ -367,7 +367,6 @@ export const init = ({courseid, category}) => {
 </TabItem>
 </Tabs>
 
-
 :::caution
 A limit applies to the length of the parameters passed in the third argument.
 If data is already available elsewhere in the DOM, you should avoid passing it as a parameter.
@@ -381,9 +380,9 @@ like full Objects.
 
 Moodle provides several ways to achieve this:
 
-* you can pass a small amount of data into the module initialisation, but this is no longer recommended
-* you can store this data in the DOM as a data attribute which is fetched in your code
-* a Moodle Web Service can be used to fetch more complex data structures dynamically
+- you can pass a small amount of data into the module initialisation, but this is no longer recommended
+- you can store this data in the DOM as a data attribute which is fetched in your code
+- a Moodle Web Service can be used to fetch more complex data structures dynamically
 
 ### Using data attributes
 
@@ -481,7 +480,6 @@ npm -g install grunt-cli
 </Tabs>
 
 #### Using grunt
-
 
 <Tabs>
 <TabItem value="npx_grunt" label="NPX">


### PR DESCRIPTION
In https://github.com/moodle/devdocs/pull/104 a markdown lint rule
has been added to convert directional quotes to their non-directional
variants.
This patch manually replaces the missing directional quotes.