### PR TITLE
[repo] Fix editUrl for general

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -117,7 +117,7 @@ const config = {
                 path: 'general',
                 routeBasePath: 'general',
                 sidebarPath: require.resolve('./sidebars/general.js'),
-                editUrl: 'https://github.com/andrewnicols/devdocs/edit/main/',
+                editUrl: 'https://github.com/moodle/devdocs/edit/main/',
                 showLastUpdateAuthor: true,
                 showLastUpdateTime: true,
                 remarkPlugins,


### PR DESCRIPTION
When we moved the repo, I missed one of the editUrls

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/130"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

