### PR TITLE
[repo] Generate a list of pages left to migrate

### DIFF
--- a/scripts/wikimedia-sync.js
+++ b/scripts/wikimedia-sync.js
@@ -101,4 +101,36 @@ program
         logger.info('Run completed');
     });
 
+program
+    .command('fetch-todo')
+    .description('Fetch a list of pages which are not marked as obsolete or migrated')
+    .action(async () => {
+        const getAllPages = () => new Promise((resolve, reject) => {
+            logger.info('Fetching all pages');
+            client.getAllPages((err, data) => {
+                if (err) {
+                    reject(new Error(err));
+                }
+                resolve(data.map((pageData) => pageData.title));
+            });
+        });
+
+        const allPages = await getAllPages();
+        const migratedPages = await getPagesTranscluding('Template:Migrated');
+        const obsoletePages = await getPagesTranscluding('Template:obsolete');
+        const todo = allPages.filter((pageName) => {
+            if (migratedPages.includes(pageName)) {
+                return false;
+            }
+
+            if (obsoletePages.includes(pageName)) {
+                return false;
+            }
+
+            return true;
+        });
+        todo.every((pageName) => logger.info(`=> ${pageName}`));
+        logger.info(`== ${todo.length} pages to migrate ==`);
+    });
+
 program.parse();


### PR DESCRIPTION
Just useful to be able to help us identify which pages to migrate.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/135"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

