### PR TITLE
[repo] Fix mdlint-all and add migrate

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "mdlint-all": "markdownlint-cli2 '{docs,general}/**/*.md' '*.md'",
     "mdfix": "markdownlint-cli2-fix",
     "mdfix-all": "markdownlint-cli2-fix '{docs,general}/**/*.md' '*.md'",
-    "lint": "mdlint-all",
+    "migrate": "scripts/wikimedia-fetch.js migrate",
+    "lint": "yarn mdlint-all",
     "prepare": "husky install",
     "spell": "cspell '*.md' '**/*.md' 'docs/*.md' 'docs/**/*.md' 'general/*.md' 'general/**/*.md'"
   },


### PR DESCRIPTION
This patch fixes the mdlint-all (so `yarn mdlint-all` should work) and also add migrate to the scripts list, to run it easily:
`yarn migrate WIKIMEDIAPAGE docusaurusfolder/file.md -i`

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/137"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

