### PR TITLE
[repo] Fix link from old docs to new docs for File API

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -57,7 +57,7 @@ Documentation_credits:
   slug: "/general/community/credits/documentation"
 File_API:
 - filePath: "/docs/apis/subsystems/files/index.md"
-  slug: "/docs/subsystems/apis/files"
+  slug: "/docs/apis/subsystems/files"
 File_API_internals:
 - filePath: "/docs/apis/subsystems/files/internals.md"
   slug: "/docs/apis/subsystems/files/internals"


### PR DESCRIPTION
The link to the migrated Moodle Developer Resources on this page https://docs.moodle.org/dev/File_API in MediaWiki is broken. It's currently pointing to https://moodle.github.io/devdocs/docs/subsystems/apis/files but the correct link would be https://moodle.github.io/devdocs/docs/apis/subsystems/files.

See: https://github.com/moodle/devdocs/issues/58#issuecomment-1135016043

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/146"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

