### PR TITLE
[docs] Migrate Coding page as Policies index

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -25,6 +25,9 @@ Bug_triage:
 CodeSniffer:
 - filePath: "/general/development/tools/phpcs.md"
   slug: "/general/development/tools/phpcs"
+Coding:
+- filePath: "/general/development/policies.md"
+  slug: "/general/development/policies"
 Coding_style:
 - filePath: "/general/development/policies/codingstyle/index.md"
   slug: "/general/development/policies/codingstyle"
@@ -1193,8 +1196,8 @@ Roadmap:
 - filePath: "/general/community/roadmap.md"
   slug: "/general/community/roadmap"
 Security:
-- filePath: "/general/development/policies/codingstyle/security.md"
-  slug: "/general/development/policies/codingstyle/security"
+- filePath: "/general/development/policies/security.md"
+  slug: "/general/development/policies/security"
 Security:Brute-forcing_login:
 - filePath: "/general/development/policies/security/bruteforcing-login.md"
   slug: "/general/development/policies/security/bruteforcing-login"

--- a/general/community/intro.md
+++ b/general/community/intro.md
@@ -59,7 +59,7 @@ See our [Process](./development/process.md) document for full information on our
 
 ## Coding Standards
 
-Over time we have distilled our best practice in writing code down into our [Coding Guide](https://docs.moodle.org/dev/Coding).  These rules cover the formatting and layout of all our code to make it consistent across the code base. If you plan to write Moodle code, you need to read it thoroughly.
+Over time we have distilled our best practice in writing code down into our [Coding Guide](/general/development/policies).  These rules cover the formatting and layout of all our code to make it consistent across the code base. If you plan to write Moodle code, you need to read it thoroughly.
 
 ## Plugins and APIs
 

--- a/general/development/policies.md
+++ b/general/development/policies.md
@@ -1,0 +1,220 @@
+---
+title: Policies
+tags:
+  - Policies
+  - Coding guidelines
+  - Developer processes
+---
+
+:::note
+
+This is the top-level page describing Moodle's coding standards and guidelines.  It's the place to start if you want to know how to write code for Moodle.
+
+:::
+
+## Moodle architecture
+
+Moodle tries to run on the widest possible range of platforms, for the widest possible number of people, while remaining easy to install, use, upgrade and integrate with other systems.
+
+:::info
+
+For more about this, see [Moodle architecture](https://docs.moodle.org/dev/Moodle_architecture).
+
+:::
+
+## Plugins
+
+Moodle has a general philosophy of modularity.  There are nearly 30 different standard types of plugins and even more sub-plugin types, however all of these plugin types work the same way. Blocks and activities are the only small exceptions.
+
+:::info
+
+For more about this, see [Moodle plugins](https://docs.moodle.org/dev/Plugins) and [Moodle sub-plugins](https://docs.moodle.org/dev/Subplugins).
+
+:::
+
+## Coding style
+
+Consistent [coding style](/general/development/policies/codingstyle) is important in any development project, and particularly so when many developers are involved. A standard style helps to ensure that the code is easier to read and understand, which helps overall quality.
+
+Writing your code in this way is an important step to having your code accepted by the Moodle community.
+
+:::info
+
+For more about this, see the [Moodle coding style](/general/development/policies/codingstyle).
+
+:::
+
+## Security
+
+Security is about protecting the interests and data of all our users.  Moodle may not be banking software, but it is still protecting a lot of sensitive and important data such as private discussions and grades from outside eyes (or student hackers!) as well as protecting our users from spammers and other internet predators.
+
+It's also a script running on people's servers, so Moodle needs to be a responsible Internet citizen and not introduce vulnerabilities that could allow crackers to gain unlawful access to the server it runs on.
+
+:::info
+
+Any single script (in Moodle core or a third party module) can introduce a vulnerability to thousands of sites, so it's important that all developers strictly follow our [Moodle security guidelines](/general/development/policies/security).
+
+:::
+
+## Standards
+
+It's important that Moodle produces strict, well-formed [HTML 5](http://en.wikipedia.org/wiki/HTML5) code (preferably backwards compatible with XHTML 1.1 if possible), compliant with all common accessibility guidelines (such as [W3C WCAG 2.0](http://www.w3.org/TR/WCAG20/), [ARIA](http://www.w3.org/TR/wai-aria-practices/)).
+
+CSS should be used for layout. Moodle comes with several themes installed. Beginning with version 2.7, only the 'Boost, and 'Classic' themes are included with the base Moodle code.
+
+:::note Writing your own theme
+
+We recommend that if you are writing your own theme that it should extend the Moodle 'Boost' theme.
+
+:::
+
+This helps consistency across browsers in a nicely-degrading way (especially those using non-visual or mobile browsers), as well as improving life for theme designers.
+
+## JavaScript
+
+New Javascript in Moodle should be written as Vanilla javascript in the ES6 style. The use of jQuery, YUI, and other frameworks is strongly discouraged and will not be accepted into core except when dealing with legacy interfaces which require the use of those objects.
+
+In general code should be written to avoid displaying interfaces which are removed, or adding new interfaces as the page loads.
+
+All Javascript must be accessible.
+
+:::info
+
+For more about this, see the [Javascript guide](/docs/guides/javascript).
+
+:::
+
+## Internationalisation
+
+Moodle works in over 84 languages because we pay great attention to keeping the language strings and locale information separate from the code, in language packs.
+
+The default language for all code, comments and documentation, however, is English (AU).
+
+:::info
+
+For more about this, see [String API](https://docs.moodle.org/dev/String_API)
+
+:::
+
+## Accessibility
+
+Moodle should work well for the widest possible range of people.
+
+:::info
+
+For more about this, see [Moodle Accessibility](/general/development/policies/accessibility).
+
+:::
+
+## Component library
+
+The Component library is a developer tool provided to help identify frequently-used user interface components, and encourage their re-use.
+
+It includes components from both Twitter Bootstrap, and from Moodle, and it displays these features using your current Moodle theme.
+
+:::info
+
+For more about this, see [Component library](https://docs.moodle.org/dev/Component_library).
+
+:::
+
+## Performance
+
+The load any Moodle site can cope with will, of course, depend on the server and network hardware that it is running on. However there are some features (intended especially for developers) that are discouraged on production sites for performance reasons.
+
+The most important property is scalability, so a small increase in the number of users, courses, activities in a course, and so on, only causes a correspondingly small increase in server load.
+
+:::info
+
+For more information and advice, see [Performance and scalability](https://docs.moodle.org/dev/Performance_and_scalability).
+
+:::
+
+## Database
+
+Moodle has a powerful database abstraction layer that we wrote ourselves, called [XMLDB](https://docs.moodle.org/dev/XMLDB_Documentation).  This lets the same Moodle code work on MySQL/MariaDB, PostgreSQL, MS SQL Server and Oracle. There are known issues when using Oracle, it is not fully supported and is not recommended for production sites.
+``
+
+Is this Oracle statement true?
+
+We have tools and APIs for [defining and modifying tables](https://docs.moodle.org/dev/DDL_functions), and [retrieving and storing data](https://docs.moodle.org/dev/Data_manipulation_API) in the database.
+
+:::info
+
+For more about this, see the [Moodle Database](https://docs.moodle.org/dev/Database) guidelines.
+
+:::
+
+## Events
+
+In Moodle it is possible to register observers for events. An observer is notified when an event happens and receives the data related to that event. An observer can only act on the information in the event. It cannot modify the data for the event or prevent the action from occurring. The component containing the observer is communicating with the component that declared the event class. The normal rules for [inter-component communication](/general/development/policies/component-communication#event-observers) apply.
+
+:::info
+
+For more about this, see [Events API](https://docs.moodle.org/dev/Events_API). In particular, note the [Events naming convention](https://docs.moodle.org/dev/Events_API#Events_naming_convention).
+
+:::
+
+## Web services
+
+Web services enable other systems to login to Moodle and perform operations. They should be implemented according to [Web service API functions](https://docs.moodle.org/dev/Web_service_API_functions) and [How to contribute a web service function to core](https://docs.moodle.org/dev/How_to_contribute_a_web_service_function_to_core), including the [Naming convention](https://docs.moodle.org/dev/Web_service_API_functions#Naming_convention).
+
+:::info
+
+For more about this, see [Web services](https://docs.moodle.org/dev/Web_services).
+
+:::
+
+## Manual testing
+
+All issues integrated into the core codebase are tested both during Integration, and subsequently by our testing team. While much of this testing is automated, there are many parts which cannot be automated, and manual testing is required.
+
+:::info
+
+Moodle has guidelines on [how to write clear testing instructions](/general/development/process/testing/guide) which we recommend you read and follow.
+
+:::
+
+## Unit testing
+
+[Unit testing](http://en.wikipedia.org/wiki/Unit_testing) is not simply a technique but a philosophy of software development.
+
+The idea is to create automated tests for each bit of functionality that you are developing (at the same time you are developing it).  This not only helps everyone later test that the software works, but helps the development itself, because it forces you to work in a modular way with very clearly defined structures and goals.
+
+Moodle uses a framework called [PHPUnit](https://github.com/sebastianbergmann/phpunit/) that makes writing unit tests fairly simple.
+
+:::info
+
+For more about this, see [PHPUnit](https://docs.moodle.org/dev/PHPUnit).
+
+:::
+
+## Acceptance testing
+
+PHPUnit covers mostly the internal implementation of functions and classes, the user interaction testing can be automated using the [Behat framework](http://behat.org).
+
+:::info
+
+For more about this, see [Acceptance testing](https://docs.moodle.org/dev/Acceptance_testing).
+
+:::
+
+## Third Party Libraries
+
+Moodle has a standard way to include third party libraries in your code.
+
+:::info
+
+For more about this, see [Third-party libraries](https://docs.moodle.org/dev/Third_Party_Libraries).
+
+:::
+
+## Other standards
+
+Please note that Moodle coding style and design is pretty unique, it is not compatible with [PEAR coding standards](http://pear.php.net/manual/en/standards.php) or any other common PHP standards.
+
+<!-- cspell:ignore 開発 -->
+
+## Translations
+
+- [開発](https://docs.moodle.org/ja/開発:コーディング)

--- a/general/development/policies/codingstyle/index.md
+++ b/general/development/policies/codingstyle/index.md
@@ -39,7 +39,7 @@ When considering the goals above, each situation requires an examination of the 
 Much of the existing Moodle code may not follow all of these guidelines - we continue to upgrade this code when we see it.
 :::
 
-For details about using the Moodle API to get things done, see the [coding guidelines](https://docs.moodle.org/dev/Coding).
+For details about using the Moodle API to get things done, see the [coding guidelines](/general/development/policies).
 
 ### Useful tools
 
@@ -1878,7 +1878,7 @@ This document was drawn from the following sources:
 - [Javascript Coding Style](https://docs.moodle.org/dev/Javascript/Coding_Style)
 - [CSS Coding Style](https://docs.moodle.org/dev/CSS_Coding_Style)
 - [SQL coding style](https://docs.moodle.org/dev/SQL_coding_style)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)
 - [CodeSniffer](../../policies/codingstyle/index.md)
 - [Code Checker plugin](https://moodle.org/plugins/local_codechecker)
 - [Accessibility coding guidelines](./accessibility#Moodle-related-accessibility-coding-guidelines)

--- a/general/development/policies/security/bruteforcing-login.md
+++ b/general/development/policies/security/bruteforcing-login.md
@@ -41,5 +41,5 @@ There are admin settings to enforce a minimum level of complexity for passwords,
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)
 - [Brute force attack in OWASP](https://owasp.org/www-community/attacks/Brute_force_attack)

--- a/general/development/policies/security/bufferoverruns.md
+++ b/general/development/policies/security/bufferoverruns.md
@@ -36,4 +36,4 @@ There is very little that Moodle can do about this.
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/commandline-injection.md
+++ b/general/development/policies/security/commandline-injection.md
@@ -37,4 +37,4 @@ However, when there is no other option, it is the standard approach of cleaning 
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/configinfo-leakage.md
+++ b/general/development/policies/security/configinfo-leakage.md
@@ -55,4 +55,4 @@ Moodle is naughty. With the standard theme, it is easy to find out exactly which
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/crosssite-request-forgery.md
+++ b/general/development/policies/security/crosssite-request-forgery.md
@@ -114,5 +114,5 @@ Some examples to help guide how to fix these issues:
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)
 - [OWASP Cheat Sheet Series: Cross-Site Request Forgery Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)

--- a/general/development/policies/security/crosssite-scripting.md
+++ b/general/development/policies/security/crosssite-scripting.md
@@ -112,4 +112,4 @@ Follow the [Output functions](https://docs.moodle.org/dev/Output_functions) link
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/dataloss.md
+++ b/general/development/policies/security/dataloss.md
@@ -44,4 +44,4 @@ However, it is also possible for users to accidentally destroy lots of data if t
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/dos.md
+++ b/general/development/policies/security/dos.md
@@ -40,5 +40,5 @@ However, most of the really expensive operations in Moodle (for example completi
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)
 - [Denial of service in OWASP](https://owasp.org/www-community/attacks/Denial_of_Service)

--- a/general/development/policies/security/index.md
+++ b/general/development/policies/security/index.md
@@ -216,7 +216,7 @@ We recommend that you follow the [Output functions](https://docs.moodle.org/dev/
 ## See also
 
 - [Security issue process](../process#security-issues)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)
 - The [2010 CWE/SANS Top 25 Most Dangerous Programming Errors](http://cwe.mitre.org/top25/) - this is a generic list of common security mistakes, produced by a group of security experts. The above Moodle-specific guidelines cover most of these general points.
 - [PHP Security Cheat Sheet](https://www.owasp.org/index.php/PHP_Security_Cheat_Sheet)
 <!--cspell:ignore OWASP -->

--- a/general/development/policies/security/info-leakage.md
+++ b/general/development/policies/security/info-leakage.md
@@ -35,4 +35,4 @@ Moodle now has enough capabilities that it can be configures to comply with vari
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/insecure-config.md
+++ b/general/development/policies/security/insecure-config.md
@@ -41,4 +41,4 @@ This is not really a problem that can be solved from within Moodle code. However
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/session-fixation.md
+++ b/general/development/policies/security/session-fixation.md
@@ -31,5 +31,5 @@ This page forms part of the [Moodle security guidelines](../security).
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)
 - [Session fixation in OWASP](https://owasp.org/www-community/attacks/Session_fixation)

--- a/general/development/policies/security/socialengineering.md
+++ b/general/development/policies/security/socialengineering.md
@@ -47,4 +47,4 @@ This is not a problem that can be solved with technology.
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/sql-injection.md
+++ b/general/development/policies/security/sql-injection.md
@@ -68,5 +68,5 @@ In Moodle 1.9 or earlier:
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)
 - <https://sqlmap.org> - A tool for automatically finding SQL injection vulnerabilities.

--- a/general/development/policies/security/unauthenticated-access.md
+++ b/general/development/policies/security/unauthenticated-access.md
@@ -44,4 +44,4 @@ Yet another example is a **captcha**. This is some task that humans are able to 
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/policies/security/unauthorised-access.md
+++ b/general/development/policies/security/unauthorised-access.md
@@ -57,4 +57,4 @@ Moodle also allows users to be put in groups. Different groups may have access t
 ## See also
 
 - [Security](../security)
-- [Coding](https://docs.moodle.org/dev/Coding)
+- [Coding](/general/development/policies)

--- a/general/development/process.md
+++ b/general/development/process.md
@@ -181,7 +181,7 @@ Develop your code on an open Git repository, like github.com. That enables peopl
 
 Coverage with automated tests ([PHPUnit](https://docs.moodle.org/dev/PHPUnit) or [Behat integration](https://docs.moodle.org/dev/Behat)) is mandatory for new features.
 
-It is essential that your code follows the [Moodle Coding Guide](https://docs.moodle.org/dev/Coding).
+It is essential that your code follows the [Moodle Coding Guide](/general/development/policies).
 
 ### Submit your code for peer review
 
@@ -223,7 +223,7 @@ Bugs should normally be fixed on all the supported stable branches that are affe
 
 Develop your fix and push the change to an open git repository, for example on github.com. See also [Git for developers](https://docs.moodle.org/dev/Git_for_developers)
 
-It is essential that your code follows the [Moodle Coding Guide](https://docs.moodle.org/dev/Coding).
+It is essential that your code follows the [Moodle Coding Guide](/general/development/policies).
 
 You will need to push one commit for each branch the fix needs to be applied to. Often people use branch names like `MDL-12345-31_brief_name` so it is clear what each branch is. [git cherry-pick](http://kernel.org/pub/software/scm/git/docs/git-cherry-pick.html) can help with replicating the fix onto different branches.
 

--- a/general/development/tools/phpcs.md
+++ b/general/development/tools/phpcs.md
@@ -175,5 +175,5 @@ CodeSniffer can export its reports in the following formats:
 
 ## See also
 
-1. [Coding](https://docs.moodle.org/dev/Coding)
+1. [Coding](/general/development/policies)
 1. [Coding style](/general/development/policies/codingstyle)

--- a/sidebars/general.js
+++ b/sidebars/general.js
@@ -199,6 +199,10 @@ const sidebars = {
                     dirName: 'development/policies',
                 },
             ],
+            link: {
+                type: 'doc',
+                id: 'development/policies',
+            },
         },
         {
             label: 'Tools',


### PR DESCRIPTION
Migrated pages:
- https://docs.moodle.org/dev/Coding

Apart from that, several pages have been marked as "WillNotMigrate". For instance:
- https://docs.moodle.org/dev/Accessibility (and several pages linked from there).
- https://docs.moodle.org/dev/XHTML

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/157"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

