### PR TITLE
[docs] Migrade Upgrade notes page

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1309,6 +1309,9 @@ Translation_priority:
 Unit_testing_for_the_Moodle_App:
 - filePath: "/docs/moodleapp/development/testing/unit-testing.md"
   slug: "/docs/moodleapp/development/testing/unit-testing"
+Upgrade_notes:
+- filePath: "docs/apis/_files/upgrade-txt.mdx"
+  slug: "docs/apis/commonfiles#upgradetxt"
 Using_the_Moodle_App_in_a_browser:
 - filePath: "/docs/moodleapp/development/setup/app-in-browser.md"
   slug: "/docs/moodleapp/development/setup/app-in-browser"

--- a/docs/apis/_files/index.tsx
+++ b/docs/apis/_files/index.tsx
@@ -40,6 +40,7 @@ import ReadmeMoodleTXT from './readme_moodle-txt';
 import SettingsPHP from './settings-php';
 import StylesCSS from './styles-css';
 import ThirdpartylibsXML from './thirdpartylibs-xml';
+import UpgradeTXT from './upgrade-txt';
 import VersionPHP from './version-php';
 import YUIDir from './yui-dir';
 
@@ -69,6 +70,7 @@ export {
     StylesCSS,
     ThirdpartylibsXML,
     DbUpgradePHP,
+    UpgradeTXT,
     VersionPHP,
     YUIDir,
 };

--- a/docs/apis/_files/upgrade-txt.mdx
+++ b/docs/apis/_files/upgrade-txt.mdx
@@ -1,0 +1,17 @@
+<!-- markdownlint-disable first-line-heading -->
+Each component and subsystem may make use of an `upgrade.txt` file in the top level folder. A title is used to identify the Moodle version where the change was introduced, and significant changes for that version relating to that component or subsystem are displayed.
+
+When changes are integrated to multiple branches, for example a stable version and the master branch, then the relevant versions used to describe the change in the `upgrade.txt` file should be the next version to be released _for each branch_. The `master` branch should always use the next major version.
+
+For example if a change is applied to the **MOODLE_400_STABLE** during the development of Moodle 4.0.2, and the **master** branch during the development of Moodle 4.1, then the relevant versions will be **4.0.2** and **4.1**.
+
+If a change is only applied to the master branch then only the **4.1** version will be listed.
+
+:::note Exception during parallel development
+
+When Moodle is developing two major versions in parallel, for example Moodle 3.11.0, and Moodle 4.0.0, then the
+version in the earliest of the major version development branches will be used for both branches.
+
+For example, during the development of Moodle 3.11, and Moodle 4.0, which took place in parallel, if a change was integrated to 3.11 and 4.0, then the version specified in both branches would be 3.11.
+
+:::

--- a/docs/apis/_files/upgrade-txt.tsx
+++ b/docs/apis/_files/upgrade-txt.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Moodle Pty Ltd.
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import { ComponentFileSummary } from '../../_utils';
+import type { Props } from '../../_utils';
+import DefaultDescription from './upgrade-txt.mdx';
+
+export default (initialProps: Props): ComponentFileSummary => (
+    <ComponentFileSummary
+        recommended
+        filepath="/*/upgrade.txt"
+        defaultDescription={DefaultDescription}
+        summary="Significant changes for each version of your plugin"
+        {...initialProps}
+    />
+);

--- a/docs/apis/commonfiles/index.mdx
+++ b/docs/apis/commonfiles/index.mdx
@@ -31,6 +31,7 @@ import {
     SettingsPHP,
     StylesCSS,
     ThirdpartylibsXML,
+    UpgradeTXT,
     VersionPHP,
     YUIDir,
 } from '../_files';
@@ -132,6 +133,10 @@ import extraLangDescription from '../_files/lang-extra.md';
 ### readme_moodle.txt
 
 <ReadmeMoodleTXT />
+
+### upgrade.txt
+
+<UpgradeTXT />
 
 ### environment.xml
 


### PR DESCRIPTION
Migrated page:
- https://docs.moodle.org/dev/Upgrade_notes

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/166"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

