### PR TITLE
[repo] Add lighthouse report

### DIFF
--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -1,0 +1,56 @@
+name: Lighthouse Report
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  lighthouse-report:
+    name: Lighthouse Report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+      - name: Wait for the Netlify Preview
+        uses: jakepartusch/wait-for-netlify-action@7ccf91c9ba3d64aa4389c0d3adcba0a6e77e5421 # v1
+        id: netlify
+        with:
+          site_name: moodledevdocs
+          max_timeout: 600
+      - name: Audit URLs using Lighthouse
+        id: lighthouse_audit
+        uses: treosh/lighthouse-ci-action@b4dfae3eb959c5226e2c5c6afd563d493188bfaf # 9.3.0
+        with:
+          urls: |
+            https://deploy-preview-$PR_NUMBER--docusaurus-2.netlify.app/
+            https://deploy-preview-$PR_NUMBER--docusaurus-2.netlify.app/docs/installation
+          configPath: ./.github/workflows/lighthouserc.json
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number}}
+      - name: Format lighthouse score
+        id: format_lighthouse_score
+        uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e # v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const results = ${{ steps.lighthouse_audit.outputs.manifest }}
+            const links = ${{ steps.lighthouse_audit.outputs.links }}
+            const createLighthouseReport = (await import(`${process.env.GITHUB_WORKSPACE}/admin/scripts/format-lighthouse-score.mjs`)).default;
+            const comment = createLighthouseReport({ results, links });
+            core.setOutput("comment", comment);
+
+      - name: Add Lighthouse stats as comment
+        id: comment_to_pr
+        uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # v2.2.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ github.event.pull_request.number }}
+          header: lighthouse
+          message: ${{ steps.format_lighthouse_score.outputs.comment }}

--- a/.github/workflows/lighthouserc.json
+++ b/.github/workflows/lighthouserc.json
@@ -1,0 +1,16 @@
+{
+  "ci": {
+    "collect": {
+      "settings": {
+        "skipAudits": [
+          "robots-txt",
+          "canonical",
+          "tap-targets",
+          "is-crawlable",
+          "works-offline",
+          "offline-start-url"
+        ]
+      }
+    }
+  }
+}

--- a/scripts/format-lighthouse-score.mjs
+++ b/scripts/format-lighthouse-score.mjs
@@ -1,0 +1,76 @@
+/* eslint-disable header/header */
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// @ts-check
+
+/** @typedef {Record<'performance' | 'accessibility' | 'best-practices' | 'seo' | 'pwa', number>} LighthouseSummary */
+
+/** @type {Record<keyof LighthouseSummary, string>} */
+const summaryKeys = {
+    performance: 'Performance',
+    accessibility: 'Accessibility',
+    'best-practices': 'Best Practices',
+    seo: 'SEO',
+    pwa: 'PWA',
+};
+
+/** @param {number} rawScore */
+const scoreEntry = (rawScore) => {
+    const score = Math.round(rawScore * 100);
+    // eslint-disable-next-line no-nested-ternary
+    const scoreIcon = score >= 90 ? '🟢' : score >= 50 ? '🟠' : '🔴';
+    return `${scoreIcon} ${score}`;
+};
+
+/**
+ * @param {Object} param0
+ * @param {string} param0.url
+ * @param {LighthouseSummary} param0.summary
+ * @param {string} param0.reportUrl
+ */
+const createMarkdownTableRow = ({ url, summary, reportUrl }) => [
+    `| [${new URL(url).pathname}](${url})`,
+    ...Object.keys(summaryKeys).map((k) => scoreEntry(summary[k])),
+    `[Report](${reportUrl}) |`,
+].join(' | ');
+
+const createMarkdownTableHeader = () => [
+    ['| URL', ...Object.values(summaryKeys), 'Report |'].join(' | '),
+    ['|---', ...Array(Object.keys(summaryKeys).length).fill('---'), '---|'].join(
+        '|',
+    ),
+];
+
+/**
+ * @param {Object} param0
+ * @param {Record<string, string>} param0.links
+ * @param {{url: string, summary: LighthouseSummary}[]} param0.results
+ */
+const createLighthouseReport = ({ results, links }) => {
+    const tableHeader = createMarkdownTableHeader();
+    const tableBody = results.map((result) => {
+        const testUrl = Object.keys(links).find((key) => key === result.url);
+        const reportPublicUrl = links[testUrl];
+
+        return createMarkdownTableRow({
+            url: testUrl,
+            summary: result.summary,
+            reportUrl: reportPublicUrl,
+        });
+    });
+    const comment = [
+        '### ⚡️ Lighthouse report for the deploy preview of this PR',
+        '',
+        ...tableHeader,
+        ...tableBody,
+        '',
+    ];
+    return comment.join('\n');
+};
+
+export default createLighthouseReport;


### PR DESCRIPTION
This is borrowed from Docusaurus upstream and retains their copyright.

This change adds a lighthouse report for several key pages to pull requests to help us keep an eye out for possible issues.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/169"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

