### PR TITLE
[repo] And use the URIs that I selected

### DIFF
--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -28,7 +28,9 @@ jobs:
         with:
           urls: |
             https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/
-            https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/docs/installation
+            https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/docs/apis/commonfiles
+            https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/general/development/gettingstarted
+            https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/general/releases
           configPath: ./.github/workflows/lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: true


### PR DESCRIPTION
I had these URIs in my editor and had not saved them. These replace the
ones 'borrowed' from Docusaurus.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/171"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

