### PR TITLE
[repo] Switch to commit-specific wait-for-netlify alternative

### DIFF
--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -16,26 +16,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
+
       - name: Wait for the Netlify Preview
-        uses: jakepartusch/wait-for-netlify-action@7ccf91c9ba3d64aa4389c0d3adcba0a6e77e5421 # v1
+        uses: andrewnicols/wait-for-netlify-preview@v1.0.6
         id: netlify
         with:
-          site_name: moodledevdocs
+          site_id: "3c056055-e1bd-4cfd-8a02-ed35ab7aedfa"
           max_timeout: 600
+          netlify_secret: ${{ secrets.NETLIFY_SECRET }}
+
       - name: Audit URLs using Lighthouse
         id: lighthouse_audit
         uses: treosh/lighthouse-ci-action@b4dfae3eb959c5226e2c5c6afd563d493188bfaf # 9.3.0
         with:
           urls: |
-            https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/
-            https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/docs/apis/commonfiles
-            https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/general/development/gettingstarted
-            https://deploy-preview-$PR_NUMBER--moodledevdocs.netlify.app/general/releases
+            ${{ steps.netlify.deployUrl }}/
+            ${{ steps.netlify.deployUrl }}/docs/apis/commonfiles
+            ${{ steps.netlify.deployUrl }}/general/development/gettingstarted
+            ${{ steps.netlify.deployUrl }}/general/releases
           configPath: ./.github/workflows/lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: true
         env:
           PR_NUMBER: ${{ github.event.pull_request.number}}
+
       - name: Format lighthouse score
         id: format_lighthouse_score
         uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e # v6


### PR DESCRIPTION
The previous copy of wait-for-netlify is only looking for any build, not for a specific build. That meant that subsequent pushes to the branch on the same pull request immediately return the previous Netlify build, and the lighthouse report related to that build.

This change also updates the Lighthouse report to run against the permalink for the build rather than the Deploy preview. The difference is that the permalink is the pure build as it would be against on the live site, whilst the deploy preview includes a bottom banner for Netlify with some useful tools. This negatively affects the performance scores for Lighthouse and brings up some false issues.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/182"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

