### PR TITLE
[repo] Remove unused navbar items

### DIFF
--- a/config/navbar.js
+++ b/config/navbar.js
@@ -16,6 +16,7 @@
  */
 const VersionsArchived = require('../versionsArchived.json');
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ArchivedVersionsDropdownItems = Object.entries(VersionsArchived).splice(
     0,
     5,
@@ -53,27 +54,27 @@ const navbar = {
         },
 
         // Right.
-        {
-            type: 'docsVersionDropdown',
-            position: 'right',
-            dropdownActiveClassDisabled: true,
-            dropdownItemsAfter: [
-                ...ArchivedVersionsDropdownItems.map(
-                    ([versionName, versionUrl]) => ({
-                        label: versionName,
-                        href: versionUrl,
-                    }),
-                ),
-                {
-                    href: 'https://docs.moodle.org/dev/',
-                    label: 'Legacy documentation',
-                },
-                {
-                    to: '/versions',
-                    label: 'All versions',
-                },
-            ],
-        },
+        // {
+        //     type: 'docsVersionDropdown',
+        //     position: 'right',
+        //     dropdownActiveClassDisabled: true,
+        //     dropdownItemsAfter: [
+        //         ...ArchivedVersionsDropdownItems.map(
+        //             ([versionName, versionUrl]) => ({
+        //                 label: versionName,
+        //                 href: versionUrl,
+        //             }),
+        //         ),
+        //         {
+        //             href: 'https://docs.moodle.org/dev/',
+        //             label: 'Legacy documentation',
+        //         },
+        //         {
+        //             to: '/versions',
+        //             label: 'All versions',
+        //         },
+        //     ],
+        // },
     ],
 };
 

--- a/config/navbar.js
+++ b/config/navbar.js
@@ -74,11 +74,6 @@ const navbar = {
                 },
             ],
         },
-        {
-            href: 'https://github.com/moodle',
-            label: 'GitHub',
-            position: 'right',
-        },
     ],
 };
 


### PR DESCRIPTION
The Versions dropdown is not in use at the moment until we fork the docs for 4.1 (when we hit enough items), and the Github links is not helpful right now.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/199"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

