### PR TITLE
[docs] Migrate new features and ideas

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1491,6 +1491,9 @@ Navigation_API:
 New_docs_version_process:
 - filePath: "/general/development/process/release/newuserdocs.md"
   slug: "/general/development/process/release/newuserdocs"
+New_features_ideas:
+- filePath: "/general/community/contribute.md"
+  slug: "/general/community/contribute"
 Output_API:
 - filePath: "/docs/apis/subsystems/output/index.md"
   slug: "/docs/apis/subsystems/output"

--- a/general/community/contribute.md
+++ b/general/community/contribute.md
@@ -4,6 +4,8 @@ tags:
   - Core development
   - Processes
   - Community
+  - Ideas
+  - Suggesting features
 sidebar_position: 3
 ---
 
@@ -20,6 +22,30 @@ If you want to contribute to Moodle, you can start looking at the following:
 :::tip Searching for other ways to contribute?
 
 You'll find them in the [How do I contribute to Moodle?](https://moodle.com/faq/how-do-i-contribute-to-moodle/) page.
+
+## Where to begin
+
+- Start by [searching moodle.org](http://moodle.org/public/search/) to check whether someone else has had the same idea. The Moodle community is very large, so it's quite likely you'll find someone else with the same idea as you ;-)
+- Join an existing discussion about your idea, or start a new discussion in an [appropriate forum on moodle.org](http://moodle.org/course/view.php?id=5).
+- Assuming others agree with your idea, [create a new issue in the Moodle tracker](http://tracker.moodle.org/secure/CreateIssue!default.jspa), selecting 'New feature' or 'Improvement' as the issue type. (You'll need to create a tracker account to be able to create a new issue.) Include a link to the discussion thread in the tracker issue.
+- Post the tracker issue number in the discussion thread, to encourage others to watch, vote, comment and/or come up with a patch for it.
+
+## What happens next?
+
+- The [list of most voted-for new features](http://tracker.moodle.org/secure/IssueNavigator.jspa?mode=hide&requestId=10512) is regularly reviewed by Moodle HQ and other core developers.
+- Promising ideas are added to the [Roadmap](roadmap.md) (depending on funding availability).
+- Small feature ideas and improvements may be added to core by the component maintainer.
+
+## How to maximize the chance of your idea being implemented
+
+Ideas with lots of votes are more likely to be implemented, however votes are not the only deciding factor.
+
+- If you're able to provide funding for your idea to be implemented, please contact a [Moodle Partner specializing in custom development](http://moodle.com/partners/).
+- Alternatively, you could join the [Moodle Users Association (MUA)](https://moodleassociation.org/) and propose your idea there. Note that the MUA will transition to
+  the [Moodle LMS Community Product Advisory Group](https://moodleassociation.org/mod/page/view.php?id=1320).
+- If you're a developer and can create a patch for your feature idea or improvement,
+  please attach it to the tracker issue for review by the component maintainer. When you add a patch, add a "patch" label so your patch will be found in searches.
+- Moodle is very modular, so the easiest way for new developers to implement are [new modules and plugins](https://moodle.org/plugins/)
 
 :::
 


### PR DESCRIPTION
Migrated pages :

* https://docs.moodle.org/dev/New_feature_ideas

Closes #173 

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/200"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

