### PR TITLE
[Docs] Migrate plagiarism docs page

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1324,6 +1324,9 @@ Overview:
 Peer_reviewing:
 - filePath: "/general/development/process/peer-review.md"
   slug: "/general/development/process/peer-review"
+Plagiarism_API:
+- filePath: "/docs/apis/subsystems/plagiarism.md"
+  slug: "/docs/apis/subsystems/plagiarism"
 Plugin_files:
 - filePath: "/docs/apis/plugintypes/commonfiles.md"
   slug: "/docs/apis/plugintypes/commonfiles"

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -241,7 +241,7 @@ The [Gradebook API](https://docs.moodle.org/dev/Gradebook_API) allows you to rea
 
 ### Plagiarism API (plagiarism)
 
-The [Plagiarism API](https://docs.moodle.org/dev/Plagiarism_API) allows your activity module to send files and data to external services to have them checked for plagiarism.
+The [Plagiarism API](./apis/subsystems/plagiarism) allows your activity module to send files and data to external services to have them checked for plagiarism.
 
 ### Question API (question)
 

--- a/docs/apis/subsystems/plagiarism.md
+++ b/docs/apis/subsystems/plagiarism.md
@@ -1,0 +1,34 @@
+---
+title: Plagiarism API
+documentationDraft: true
+tags:
+  - API
+  - Plagiarism
+---
+
+## Overview
+
+The Plagiarism API is a core set of functions that all Moodle code can use to send user submitted content to Plagiarism Prevention systems
+
+A typical user story:
+
+1. When Plagiarism tools are enabled, every module that allows it will have a group of settings added to allow management of sending the user content to a plagiarism service.
+1. A user enters some content/submits a file inside a module that a teacher/Admin has configured the tool to be used.
+1. An Event is triggered which contains details about the user, module and submission they have made
+1. Event handlers in the Plagiarism plugin are triggered and process anything required.
+1. Hooks for displaying information returned from the Plagiarism tools to both the user and teacher (controlled by the plugin)
+
+## Supported Modules
+
+- Assignment 2.2 -
+  - Single Upload Assignment
+  - Advanced Assignment
+  - Online Text Assignment
+- Assignment
+- Forum
+- Workshop
+
+## More information
+
+- [How to Develop a new Plagiarism Plugin](https://docs.moodle.org/dev/Developing_a_Plagiarism_Plugin)
+- [How to add support for a Plagiarism Plugin to my activity module](https://docs.moodle.org/dev/How_to_add_support_for_a_Plagiarism_Plugin_to_my_activity_module)


### PR DESCRIPTION
Trying migration for the first time.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/206"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

