### PR TITLE
[docs] docs: Tidy up the Guides landing

### DIFF
--- a/config/navbar.js
+++ b/config/navbar.js
@@ -32,10 +32,9 @@ const navbar = {
     },
     items: [
         {
-            type: 'doc',
-            docId: 'apis',
-            position: 'left',
+            to: '/docs',
             label: 'Guides',
+            position: 'left',
         },
         {
             to: '/general/community/contribute',

--- a/docs/apis/_files/db-services-php.mdx
+++ b/docs/apis/_files/db-services-php.mdx
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable first-line-heading -->
 The `db/services.php` file is used to describe the external functions available for use in web services. This includes
-web service functions defined for javascript, and for the [Moodle Mobile App](https://docs.moodle.org/dev/Moodle_Mobile_App).
+web service functions defined for JavaScript, and for the [Moodle Mobile App](../../moodleapp.md).
 
 :::note
 

--- a/docs/apis/plugintypes/antivirus/index.mdx
+++ b/docs/apis/plugintypes/antivirus/index.mdx
@@ -23,8 +23,6 @@ import {
 } from '../../_files';
 import ScannerPHP from './_files/scanner-php';
 
-## Introduction
-
 Moodle supports automatic virus scanning of files as they are uploaded by users. To enable this developers can write an antivirus plugin, which acts as a bridge between Moodle and the antivirus tooling.
 
 A plugin to support the Open Source [ClamAV](https://www.clamav.net/) antivirus engine is included with Moodle core as standard.

--- a/docs/apis/plugintypes/blocks/index.md
+++ b/docs/apis/plugintypes/blocks/index.md
@@ -18,6 +18,8 @@ import {
     TabItem
 } from '@site/src/components';
 
+Block plugins allow you to show supplemental information, and features, within different parts of Moodle.
+
 ## File structure
 
 Blocks plugins are located in the `/blocks` directory.

--- a/docs/apis/plugintypes/format/migration.md
+++ b/docs/apis/plugintypes/format/migration.md
@@ -12,8 +12,6 @@ tags:
 
 import { getExample } from '@site/src/moodleBridge';
 
-## Introduction
-
 The new course editor introduced n Moodle 4.0 reimplements most of the previous webservices, AMD modules, and internal logic of the course rendering. However, all formats since 3.11 will use the previous libraries by default until its final deprecation in Moodle 4.3. This document collects the main adaptations any 3.11 course format will require to continue working when this happens.
 
 ## Changes summary

--- a/docs/apis/plugintypes/qbank/index.md
+++ b/docs/apis/plugintypes/qbank/index.md
@@ -6,6 +6,7 @@ tags:
   - qbank
   - Quiz
 description: Question type plugins allow you to extend the functionality of the Moodle Question bank.
+documentationDraft: true
 ---
 
 import { Since } from '@site/src/components';
@@ -14,8 +15,6 @@ import { Since } from '@site/src/components';
   version="4.0"
   issueNumber="MDL-70329"
 />
-
-## Introduction
 
 Question type plugins allow you to extend the functionality of the Moodle Question bank, and support features including:
 

--- a/docs/apis/subsystems/analytics/index.md
+++ b/docs/apis/subsystems/analytics/index.md
@@ -10,8 +10,6 @@ import { Since } from '@site/src/components';
 
 <!-- cspell:ignore analysables -->
 
-## Summary
-
 The Moodle Analytics API allows Moodle site managers to define _prediction models_ that combine _indicators_ and a _target_.
 
 The _target_ is the event we want to predict. The _indicators_ are what we think will lead to an accurate prediction of the target.
@@ -32,6 +30,8 @@ The _target_ would be whether the student is able to complete the course or not.
 Moodle uses these indicators and the target for each student in a finished course to predict which students are at risk of dropping out in ongoing courses.
 
 :::
+
+## Summary
 
 ### API components
 

--- a/docs/apis/subsystems/files/index.md
+++ b/docs/apis/subsystems/files/index.md
@@ -7,8 +7,6 @@ tags:
 
 <!-- cspell:ignore filestore -->
 
-## Overview
-
 The File API is used to control, manage, and serve all files uploaded and stored within Moodle. This page covers the core File API, which is responsible for storage, retrieval, and serving of files stored in Moodle.
 
 The following documentation is also related:

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1,0 +1,13 @@
+---
+title: Developer guides
+description: Getting started guides to Moodle features
+tags:
+  - Guide
+  - Feature
+  - Getting started
+---
+
+Learn about key Moodle features for developers through our Developer Guides. The following guides are currently available:
+
+- Introduction to [JavaScript](./guides/javascript/index.md) in Moodle
+- Learn about how Moodle uses [Templates](./guides/templates/index.md) to render content

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,8 +1,23 @@
 ---
 id: introduction
 title: Introduction
-description: Moodle developer documentation
+description: Developer documentation for Moodle 4.0.
 slug: /
+tags:
+  - Getting started
 ---
 
-This is the Developer Documentation for Moodle 4.0.
+Welcome to the Developer Documentation for **Moodle 4.0**.
+
+This documentation is version-specific and includes a range of useful guides and information.
+
+:::tip Where to start
+
+- If you're new to Moodle development, you should check out our [Getting started guide](/general/development/gettingstarted)
+- Look through our [guides to Moodle APIs](./apis.md)
+- Browse our [Moodle feature](./guides.md) deep dives
+- You may want to read the [Release notes](/general/releases/4.0) for Moodle 4.0
+- Have a plugin that you want to prepare for Moodle 4.0, check out the [Developer update notes](./devupdate.md)
+- Interested in supporting the Moodle App in your plugins? Read the [Moodle App documentation](./moodleapp.md)
+
+:::

--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -22,11 +22,6 @@ const sidebars = {
     docs: [
         'introduction',
         {
-            label: 'Getting started',
-            type: 'link',
-            href: '/general/development/gettingstarted',
-        },
-        {
             label: 'Developer guides',
             type: 'category',
             items: [
@@ -35,6 +30,10 @@ const sidebars = {
                     dirName: 'guides',
                 },
             ],
+            link: {
+                type: 'doc',
+                id: 'guides',
+            },
         },
         {
             label: 'API guides',
@@ -50,6 +49,13 @@ const sidebars = {
                 id: 'apis',
             },
         },
+
+        {
+            label: 'Developer update',
+            type: 'doc',
+            id: 'devupdate',
+        },
+
         {
             type: 'html',
             value: '<hr>',
@@ -78,11 +84,6 @@ const sidebars = {
             value: '<hr>',
         },
 
-        {
-            label: 'Developer update',
-            type: 'doc',
-            id: 'devupdate',
-        },
         {
             label: 'Release notes',
             type: 'link',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -88,6 +88,7 @@ html {
   margin-right: 2rem;
 }
 
+.navbar__link--active,
 .navbar__link:hover {
   border-bottom-color: var(--ifm-navbar-link-hover-color);
 }


### PR DESCRIPTION
This changes adds a new guides landing page for the non-API guides, and
updates the main landing page for the version-specific documentation.

I've also removed the link to the 'Getting started' from the sidebar
because it takes you away from the API information and changes the
sidebar navigation completely, which makes it harder to go back to the
previous area.

As part of this I've also restructured the sidebar to move the Developer
update notes to the top section above the break, so that all
documentation for the version is together, in one place.
