### PR TITLE
Use direct link to recording

### DIFF
--- a/general/community/meetings/202206.md
+++ b/general/community/meetings/202206.md
@@ -9,7 +9,7 @@ tags:
 
 Tuesday 14 June 2022 at 08:00 UTC
 
-Meeting recording: [Developer meetings BBB on moodle.org](https://moodle.org/mod/bigbluebuttonbn/view.php?id=8596) (Set rows to show all, click Go then order by date to have the June 2022 recording listed first.)
+Meeting recording: [Developer meeting - June 2022](https://moodle.org/mod/bigbluebuttonbn/bbb_view.php?action=play&bn=1&rid=19&rtype=video)
 
 ### Agenda
 


### PR DESCRIPTION
Thanks to Andrew for suggesting using a direct link to the recording.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/227"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

