### PR TITLE
[repo] Noting a page as migrated is a major edit

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -339,7 +339,9 @@ const getUpdateMigratedPages = (logger) => (client) => async () => {
                 legacyPage,
                 newContent,
                 'Update migration status and path',
-                true,
+
+                // This is a major edit. minor = false.
+                false,
                 (err, data) => {
                     if (err) {
                         throw err;


### PR DESCRIPTION
When we started marking pages as protected we should have also set the template addition as a major change and not a minor change.