### PR TITLE
[docs] Add additional redirect for Repository API docs

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1425,6 +1425,9 @@ Release_process:
 Releases:
 - filePath: "/general/releases.md"
   slug: "/general/releases"
+Repository_API:
+- filePath: "/docs/apis/plugintypes/repository/index"
+  slug: "/docs/apis/plugintypes/repository"
 Repository_plugins:
 - filePath: "/docs/apis/plugintypes/repository/index"
   slug: "/docs/apis/plugintypes/repository"

--- a/docs/apis/subsystems/files/index.md
+++ b/docs/apis/subsystems/files/index.md
@@ -11,7 +11,7 @@ The File API is used to control, manage, and serve all files uploaded and stored
 
 The following documentation is also related:
 
-- The [Repository API](https://docs.moodle.org/dev/Repository_API) is responsible for the code paths associated with uploading files to Moodle. This includes Repository plugins.
+- The [Repository API](../../plugintypes/repository/index.md) is responsible for the code paths associated with uploading files to Moodle. This includes Repository plugins.
 - [Using the File API in Moodle forms](https://docs.moodle.org/dev/Using_the_File_API_in_Moodle_forms)
 - Additional detail of how this API works is discussed in the [File API internals](./internals.md)
 
@@ -435,4 +435,4 @@ if ($file) {
 - [Core APIs](../../../apis.md)
 - [File API internals](./internals.md) how the File API works internally.
 - [Using the File API in Moodle forms](https://docs.moodle.org/dev/Using_the_File_API_in_Moodle_forms)
-- [Repository API](https://docs.moodle.org/dev/Repository_API)
+- [Repository API](../../plugintypes/repository/index.md)

--- a/docs/apis/subsystems/files/internals.md
+++ b/docs/apis/subsystems/files/internals.md
@@ -142,7 +142,7 @@ Each plugin should only ever use the File Storage API to access its __own files_
 Files are typically selected by users and uploaded to Moodle using the File manager, and the file picker.
 
 - The **file manager** is an interface used to view, and delete existing files, and to add new files.
-- The **file picker** is an interface, often accessed using the _file manager_, to select files for upload to Moodle. The file picker makes use of [file repositories](https://docs.moodle.org/dev/Repository_API).
+- The **file picker** is an interface, often accessed using the _file manager_, to select files for upload to Moodle. The file picker makes use of [file repositories](../../plugintypes/repository/index.md).
 
 ### Form fields
 
@@ -201,7 +201,7 @@ The packer is currently limited to ASCII filenames and individual files are limi
 
 ## See also
 
-- [Repository API](https://docs.moodle.org/dev/Repository_API)
+- [Repository API](../../plugintypes/repository/index.md)
 - [Portfolio API](https://docs.moodle.org/dev/Portfolio_API)
 - [Resource module file API migration](https://docs.moodle.org/dev/Resource_module_file_API_migration)
 - [MDL-14589](https://tracker.moodle.org/browse/MDL-14589) - File API Meta issue


### PR DESCRIPTION
Just discovered this missing link.

I need to work out a way to fetch all redirects from the WikiMedia API so that we can update any of those too, but that's a little more challenging as the nodemw API does not currently support it. I'll have to give it some thought.