### PR TITLE
[docs] Migrate the "Moodle and PHP" page and related changes

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1197,6 +1197,9 @@ Moodle_4.0_developer_update:
 Moodle_4.0_release_notes:
 - filePath: "/general/releases/4.0.md"
   slug: "/general/releases/4.0"
+Moodle_and_PHP:
+- filePath: "/general/development/policies/php.md"
+  slug: "/general/development/php"
 Moodle_App:
 - filePath: "/docs/moodleapp.md"
   slug: "/docs/moodleapp"

--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -1,0 +1,94 @@
+---
+title: PHP
+sidebar_label: PHP versions
+description: Information about how PHP supported versions correlate with Moodle releases and the policy controlling it.
+tags:
+  - Requirements
+  - Support
+  - Releases
+  - PHP
+---
+
+import { Since } from '@site/src/components';
+
+New PHP versions are [released every year](https://www.php.net/supported-versions.php) and come with important improvements and changes compared with previous versions. Moodle tries to support them as soon as possible, always matching them with our own [scheduled release plans](/general/releases).
+
+## Policy statement
+
+<Since versions={["3.5"]} issueNumber="MDL-59159" />
+
+We always follow this agreed policy regarding PHP and Moodle supported versions:
+
+1. A LTS will always **require the previous LTS** (or later) for upgrading.
+2. The **maximum PHP version** supported for a branch will be the max one achieved along the life of the branch. Usually with .0 releases but may happen later (we added support for php74 with 3.8.3, or support for php80 with 3.11.8, for example).
+3. The **minimum PHP** version supported for a branch will be **the lower of**:
+    - The [minimum version supported in any way by php](https://www.php.net/supported-versions.php) the day of the Moodle release (so we provide slow, progressive increments).
+    - The maximum PHP version supported by the previous LTS branch (so we guarantee jumping between LTS is possible without upgrading PHP at the same time).
+
+<details><summary>PHP and Moodle policy in Jira wiki markup format.</summary>
+
+```txt
+{panel:title=Policy: PHP & Moodle supported versions|borderStyle=dashed|borderColor=#cccccc|titleBGColor=#f7d6c1|bgColor=#ffffce}
+Since Moodle 3.5 (MDL-59159), these rules apply to decide Minimum PHP and Moodle versions supported:
+ # A LTS will always require the previous LTS (or later) for upgrading.
+ # The maximum PHP version supported for a branch will be the max one achieved along the life of the branch. Usually with .0 releases but may happen later (we added support for php70 with 3.0.1, or support for php73 with 3.6.4, for example).
+ # The minimum PHP version supported for a branch will be *the lower of*:
+ -- The [minimum version supported in any way by php|http://php.net/supported-versions.php] the day of the Moodle release (so we provide slow, progressive increments).
+ -- The maximum PHP version supported by the previous LTS branch (so we guarantee jumping between LTS is possible without upgrading PHP at the same time).{panel}
+```
+
+</details>
+
+This page contains the current status of support for every PHP version and Moodle versions. For details, follow also the epic links below that combine all the changes that were made in Moodle to ensure PHP compatibility.
+
+:::note
+
+You must be logged in to tracker to see issues in Epics.
+
+:::
+
+## PHP supported versions
+
+### PHP 8.1
+
+PHP 8.1 support **is being implemented** for Moodle 4.1 and later releases. Hence it's still **incomplete and only for development purposes**.  See [MDL-73016](https://tracker.moodle.org/browse/MDL-73016) for details.
+
+### PHP 8.0
+
+<Since versions={["3.11.8", "4.0.2"]} issueNumber="MDL-70745" />
+
+PHP 8.0 **can be used with** Moodle 3.11.8, Moodle 4.0.2 and later releases. See [MDL-70745](https://tracker.moodle.org/browse/MDL-70745) for details.
+
+### PHP 7.4
+
+<Since versions={["3.8.3", "3.9"]} issueNumber="MDL-66260" />
+
+PHP 7.4 **can be used with** Moodle 3.8.3, Moodle 3.9 and later releases. It is also the **minimum** supported version for Moodle 4.1. See [MDL-66260](https://tracker.moodle.org/browse/MDL-66260) for details.
+
+### PHP 7.3
+
+<Since versions={["3.6.4", "3.7"]} issueNumber="MDL-63420" />
+
+PHP 7.3 **can be used with** Moodle 3.6.4, Moodle 3.7 and later releases. It is also the **minimum** supported version for Moodle 3.11. See [MDL-63420](https://tracker.moodle.org/browse/MDL-63420) for details.
+
+### PHP 7.2
+
+<Since versions={["3.4"]} issueNumber="MDL-60279" />
+
+PHP 7.2 **can be used with** Moodle 3.4 and later releases. It is also the **minimum** supported version for Moodle 3.9. See [MDL-60279](https://tracker.moodle.org/browse/MDL-60279) for details.
+
+### PHP 7.1
+
+<Since versions={["3.2"]} issueNumber="MDL-55120" />
+
+PHP 7.1 **can be used with** Moodle 3.2 and later releases. It is also the **minimum** supported version for Moodle 3.7. See [MDL-55120](https://tracker.moodle.org/browse/MDL-55120) for details.
+
+### PHP 7.0
+
+<Since versions={["3.0.1", "3.1"]} issueNumber="MDL-50565" />
+
+PHP 7.0 **can be used with** Moodle 3.0.1, Moodle 3.1 and later releases. It is also the **minimum** supported version for Moodle 3.4. See [Moodle and PHP 7.0 details](https://docs.moodle.org/dev/Moodle_and_PHP_7.0_details) and [MDL-50565](https://tracker.moodle.org/browse/MDL-50565) for details.
+
+## See also
+
+- [Releases](/general/releases) - For details about all the Moodle releases.

--- a/general/releases/3.10.md
+++ b/general/releases/3.10.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade:  Moodle 3.5 or later
-- PHP version: minimum PHP 7.2.0 *Note: minimum PHP version has increased since Moodle 3.8*. PHP 7.3.x and 7.4.x are supported too. See [Moodle and PHP](https://docs.moodle.org/dev/Moodle_and_PHP) for details.
+- PHP version: minimum PHP 7.2.0 *Note: minimum PHP version has increased since Moodle 3.8*. PHP 7.3.x and 7.4.x are supported too. See [Moodle and PHP](/general/development/policies/php) for details.
 - PHP extension **mbstring** is required (it was previously only recommended)
 
 ### Database requirements

--- a/general/releases/3.11.md
+++ b/general/releases/3.11.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 3.6 or later
-- PHP version: minimum PHP 7.3.0 *Note: minimum PHP version has increased since Moodle 3.10*. PHP 7.4.x is supported too. [PHP 8.0 support](https://docs.moodle.org/dev/Moodle_and_PHP) is being implemented (see [MDL-70745](https://tracker.moodle.org/browse/MDL-70745)) and **not ready for production** yet.
+- PHP version: minimum PHP 7.3.0 *Note: minimum PHP version has increased since Moodle 3.10*. PHP 7.4.x and 8.0.x are supported too. See [PHP](/general/development/php) for details.
 - PHP extension **sodium** is recommended. It will be required in Moodle 4.2. For further details, see [Environment - PHP extension sodium](https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** is recommended to be >= 5000 for PHP 7.x installations. It's a requirement for PHP 8.x installations. For further details, see [Environment - max input vars](https://docs.moodle.org/311/en/Environment_-_max_input_vars).
 

--- a/general/releases/3.11.md
+++ b/general/releases/3.11.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 3.6 or later
-- PHP version: minimum PHP 7.3.0 *Note: minimum PHP version has increased since Moodle 3.10*. PHP 7.4.x and 8.0.x are supported too. See [PHP](/general/development/php) for details.
+- PHP version: minimum PHP 7.3.0 *Note: minimum PHP version has increased since Moodle 3.10*. PHP 7.4.x and 8.0.x are supported too. See [PHP](/general/development/policies/php) for details.
 - PHP extension **sodium** is recommended. It will be required in Moodle 4.2. For further details, see [Environment - PHP extension sodium](https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** is recommended to be >= 5000 for PHP 7.x installations. It's a requirement for PHP 8.x installations. For further details, see [Environment - max input vars](https://docs.moodle.org/311/en/Environment_-_max_input_vars).
 

--- a/general/releases/3.5.md
+++ b/general/releases/3.5.md
@@ -19,7 +19,7 @@ If you are upgrading from previous version, make sure you read the [Upgrading](h
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade:  Moodle 3.1 or later
-- PHP version: minimum PHP 7.0.0 *Note: minimum PHP version has increased since Moodle 3.3*. PHP 7.1.x and 7.2.x are supported too. See [Moodle and PHP](https://docs.moodle.org/dev/Moodle_and_PHP) for details.
+- PHP version: minimum PHP 7.0.0 *Note: minimum PHP version has increased since Moodle 3.3*. PHP 7.1.x and 7.2.x are supported too. See [Moodle and PHP](/general/development/policies/php) for details.
 - PHP extension **intl** is required since Moodle 3.4 (it was recommended in 2.0 onwards)
 - (Recommendation only) If you use MySQL or MariaDB, make sure your database supports full UTF-8 (utf8mb4) if you install a new instance of Moodle. CLI script may be used to convert to utf8mb4 if you're upgrading. You may choose to keep using 'utf8_*', but then a warning will show that the database isn't using full UTF-8 support and suggest moving to 'utf8mb4_unicode_ci'. See [MySQL full unicode support](https://docs.moodle.org/en/MySQL_full_unicode_support) for details. If you do enable utf8mb4 you *must* use the Barracuda file format.
 

--- a/general/releases/3.6.md
+++ b/general/releases/3.6.md
@@ -25,7 +25,7 @@ You are recommended to use [Moodle 3.6.1](/general/releases/3.6/3.6.1), as it in
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade:  Moodle 3.1 or later
-- PHP version: minimum PHP 7.0.0 *Note: minimum PHP version has increased since Moodle 3.3*. PHP 7.1.x, 7.2.x and 7.3.x (since Moodle 3.6.4) are supported too. See [Moodle and PHP](https://docs.moodle.org/dev/Moodle_and_PHP) for details.
+- PHP version: minimum PHP 7.0.0 *Note: minimum PHP version has increased since Moodle 3.3*. PHP 7.1.x, 7.2.x and 7.3.x (since Moodle 3.6.4) are supported too. See [Moodle and PHP](/general/development/policies/php) for details.
 - PHP extension **intl** is required since Moodle 3.4 (it was recommended in 2.0 onwards)
 
 ### Database requirements

--- a/general/releases/3.7.md
+++ b/general/releases/3.7.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade:  Moodle 3.2 or later
-- PHP version: minimum PHP 7.1.0 *Note: minimum PHP version has increased since Moodle 3.6*. PHP 7.2.x and 7.3.x are supported too. See [Moodle and PHP](https://docs.moodle.org/dev/Moodle_and_PHP) for details.
+- PHP version: minimum PHP 7.1.0 *Note: minimum PHP version has increased since Moodle 3.6*. PHP 7.2.x and 7.3.x are supported too. See [Moodle and PHP](/general/development/policies/php) for details.
 - PHP extension **intl** is required since Moodle 3.4 (it was recommended in 2.0 onwards)
 
 ### Database requirements

--- a/general/releases/3.8.md
+++ b/general/releases/3.8.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade:  Moodle 3.2 or later
-- PHP version: minimum PHP 7.1.0 *Note: minimum PHP version has increased since Moodle 3.6*. PHP 7.2.x, 7.3.x and 7.4.x (since Moodle 3.8.3) are supported too. See [Moodle and PHP](https://docs.moodle.org/dev/Moodle_and_PHP) for details.
+- PHP version: minimum PHP 7.1.0 *Note: minimum PHP version has increased since Moodle 3.6*. PHP 7.2.x, 7.3.x and 7.4.x (since Moodle 3.8.3) are supported too. See [Moodle and PHP](/general/development/policies/php) for details.
 - PHP extension **intl** is required since Moodle 3.4 (it was recommended in 2.0 onwards)
 
 ### Database requirements

--- a/general/releases/3.9.md
+++ b/general/releases/3.9.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade:  Moodle 3.5 or later
-- PHP version: minimum PHP 7.2.0 *Note: minimum PHP version has increased since Moodle 3.8*. PHP 7.3.x and 7.4.x are supported too. See [Moodle and PHP](https://docs.moodle.org/dev/Moodle_and_PHP) for details.
+- PHP version: minimum PHP 7.2.0 *Note: minimum PHP version has increased since Moodle 3.8*. PHP 7.3.x and 7.4.x are supported too. See [Moodle and PHP](/general/development/policies/php) for details.
 - PHP extension **mbstring** is required (it was previously only recommended)
 
 ### Database requirements

--- a/general/releases/4.0.md
+++ b/general/releases/4.0.md
@@ -23,7 +23,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 3.6 or later
-- PHP version: minimum PHP 7.3.0 *Note: minimum PHP version has increased since Moodle 3.10*. PHP 7.4.x and 8.0.x are supported too. See [PHP](/general/development/php) for details.
+- PHP version: minimum PHP 7.3.0 *Note: minimum PHP version has increased since Moodle 3.10*. PHP 7.4.x and 8.0.x are supported too. See [PHP](/general/development/policies/php) for details.
 - PHP extension **sodium** is recommended. It will be required in Moodle 4.2. For further details, see [Environment - PHP extension sodium](https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium).
 - PHP extension **exif** is recommended.
 - PHP setting **max_input_vars** is recommended to be >= 5000 for PHP 7.x installations. It's a requirement for PHP 8.x installations. For further details, see [Environment - max input vars](https://docs.moodle.org/311/en/Environment_-_max_input_vars).

--- a/general/releases/4.0.md
+++ b/general/releases/4.0.md
@@ -23,7 +23,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 3.6 or later
-- PHP version: minimum PHP 7.3.0 *Note: minimum PHP version has increased since Moodle 3.10*. PHP 7.4.x is supported too. [PHP 8.0 support](https://docs.moodle.org/dev/Moodle_and_PHP) is being implemented (see [MDL-70745](https://tracker.moodle.org/browse/MDL-70745)) and **not ready for production** yet.
+- PHP version: minimum PHP 7.3.0 *Note: minimum PHP version has increased since Moodle 3.10*. PHP 7.4.x and 8.0.x are supported too. See [PHP](/general/development/php) for details.
 - PHP extension **sodium** is recommended. It will be required in Moodle 4.2. For further details, see [Environment - PHP extension sodium](https://docs.moodle.org/311/en/Environment_-_PHP_extension_sodium).
 - PHP extension **exif** is recommended.
 - PHP setting **max_input_vars** is recommended to be >= 5000 for PHP 7.x installations. It's a requirement for PHP 8.x installations. For further details, see [Environment - max input vars](https://docs.moodle.org/311/en/Environment_-_max_input_vars).


### PR DESCRIPTION
This migrates the https://docs.moodle.org/dev/Moodle_and_PHP
page to devdocs/general/development/php and, given php80
support has been officially announced for 3.11 and 4.0,
amend the release notes of those versions to tell so.

Then, register it as migrated page.

And finally, fix all the links to the old page (`yarn mdfix-all`).

Let's see if everything is in place (`yarn build` said ok), yay!

Ciao :-)



<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/279"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

