### PR TITLE
[repo] Make yarn fix to call to common fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "wikimedia-sync": "scripts/wikimedia-sync.js",
     "component-spellings": "scripts/component-helper.js spelling",
     "test": "jest",
+    "fix": "yarn mdfix-all; yarn mdxfix-all; yarn spell",
     "mdlint": "markdownlint-cli2",
     "mdlint-all": "markdownlint-cli2 '{docs,general}/**/*.md' '*.md'",
     "mdfix": "markdownlint-cli2-fix",
@@ -24,7 +25,7 @@
     "mdxfix": "markdownlint-cli2-config .markdownlint/mdx/fix/.markdownlint-cli2.cjs",
     "mdxfix-all": "markdownlint-cli2-config .markdownlint/mdx/fix/.markdownlint-cli2.cjs '{docs,general}/**/*.mdx' '*.mdx'",
     "migrate": "scripts/wikimedia-fetch.js migrate",
-    "lint": "yarn mdlint-all",
+    "lint": "yarn mdlint-all; yarn mdxlint-all; yarn spell",
     "prepare": "husky install",
     "spell": "cspell '*.md' '*.mdx' '**/*.md' '**/*.mdx' 'docs/*.md' 'docs/*.mdx' 'docs/**/*.md' 'docs/**/*.mdx' 'general/*.md' 'general/*.mdx' 'general/**/*.md' 'general/**/*.mdx'"
   },

--- a/project-words.txt
+++ b/project-words.txt
@@ -47,6 +47,7 @@ Notas
 OCI8
 OIDC
 OWASP
+Oudtshoorn
 Packagist
 PHPDoc
 PHPDocumentor

--- a/scripts/wikimedia-fetch.js
+++ b/scripts/wikimedia-fetch.js
@@ -373,33 +373,22 @@ const fetchOneDoc = async (title, newPath, options) => {
         }
     }
 
-    await new Promise((resolve) => {
-        exec('yarn mdfix-all', async (error, stdout, stderr) => {
-            if (error) {
-                logger.warn('mdlint-all reported warnings that you will need to resolve manually');
-                logger.warn(stderr);
-                logger.warn('----');
-            }
-            logger.debug(stdout);
-            resolve();
-        });
-    });
-
-    await new Promise((resolve) => {
-        exec('yarn mdxfix-all', async (error, stdout, stderr) => {
-            if (error) {
-                logger.warn('mdlint-all reported warnings that you will need to resolve manually');
-                logger.warn(stderr);
-                logger.warn('----');
-            }
-            logger.debug(stdout);
-            resolve();
-        });
-    });
-
     // Update the migratedPages file.
     logger.info('=> Adding to migrated page list');
     addMigratedPage(title.replaceAll(/ /g, '_'), newFile, guessSlug(newFile));
+
+    logger.info('=> Running automated fixes and checks');
+    await new Promise((resolve) => {
+        exec('yarn fix', async (error, stdout, stderr) => {
+            if (error) {
+                logger.warn('fix reported warnings that you will need to resolve manually');
+                logger.warn(stderr);
+                logger.warn('----');
+            }
+            logger.debug(stdout);
+            resolve();
+        });
+    });
 };
 
 program


### PR DESCRIPTION
This pair of commit adds `yarn fix` as a shortcut to `yarn mdfix-all; yarn mdxfix-all; yarn spell` to perform standard checks for all files.
It then also updates the `yarn migrate` command to use the new command, and makes it run _after_  we add to `migratedPages.yml` which makes it actually useful in that instance.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/280"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

