### PR TITLE
Add remove state update to reactive

### DIFF
--- a/docs/guides/javascript/reactive/index.md
+++ b/docs/guides/javascript/reactive/index.md
@@ -1144,7 +1144,8 @@ By default, the state manager can process the following actions:
 - `override`: like `put`, this action will create or update a state element but it will remove any other attribute that is not present in the fields.
 - `update`: will update an element with the fields but it will raise an exception if the element is not in the state.
 - `create`: will create a new state element but it will raise an exception if the element is already created.
-- `delete`: it will delete a state element.
+- `remove`: it will delete a state element.
+- `delete`: it will delete a state element but it will raise an exception if the element is not in the state.
 
 ### Implementing custom update types
 


### PR DESCRIPTION
The available update types section is missing the "remove" state update.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/290"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

