### PR TITLE
Update release dates on the release notes

### DIFF
--- a/general/releases/3.11/3.11.8.md
+++ b/general/releases/3.11/3.11.8.md
@@ -9,7 +9,7 @@ moodleVersion: 3.11.8
 ---
 [Releases](/general/releases) > Moodle 3.11.8 release notes
 
-Release date: Not yet released
+Release date: 11 July 2022
 
 Here is [the full list of fixed issues in 3.11.8](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.8%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
 

--- a/general/releases/3.9/3.9.15.md
+++ b/general/releases/3.9/3.9.15.md
@@ -9,7 +9,7 @@ moodleVersion: 3.9.15
 ---
 [Releases](/general/releases) > Moodle 3.9.15 release notes
 
-Release date: Not yet released
+Release date: 11 July 2022
 
 Here is [the full list of fixed issues in 3.9.15](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.15%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
 

--- a/general/releases/4.0/4.0.2.md
+++ b/general/releases/4.0/4.0.2.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 moodleVersion: 4.0.2
 ---
 
-Release date: Not yet released
+Release date: 11 July 2022
 
 Here is [the full list of fixed issues in 4.0.2](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%224.0.2%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
 


### PR DESCRIPTION
In the future, perhaps it would be better to just note the planned release date when drafting the new release notes for the next minors. People should be able to determine the actual release status of the version from the indicated release date, right?

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/298"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

