### PR TITLE
Fetch release note dates from metadata

### DIFF
--- a/.markdownlint-cli2.cjs
+++ b/.markdownlint-cli2.cjs
@@ -164,6 +164,9 @@ config.MD033 = {
         "InvalidExample",
         "ReactPlayer",
         "Link",
+        "ReleaseNoteIntro",
+        "ReleaseDate",
+        "ReleaseVersion",
     ]
 };
 

--- a/general/releases/3.11.md
+++ b/general/releases/3.11.md
@@ -4,11 +4,13 @@ tags:
   - Release notes
   - Moodle 3.11
 sidebar_position: -311
-moodleVersion: '3.11'
+moodleVersion: 3.11.0
+description: The release notes for Moodle version 3.11.0.
 ---
-Release date: 17 May 2021
 
-Here is [the full list of fixed issues in 3.11](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 See our [New features page](https://docs.moodle.org/311/en/New_features) in the user documentation for an introduction to Moodle 3.11 with screenshots.
 

--- a/general/releases/3.11/3.11.1.md
+++ b/general/releases/3.11/3.11.1.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.11
 sidebar_position: 1
 moodleVersion: 3.11.1
+description: The release notes for Moodle version 3.11.1.
 ---
-Release date: 12 July 2021
 
-Here is [the full list of fixed issues in 3.11.1](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.1%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.11/3.11.2.md
+++ b/general/releases/3.11/3.11.2.md
@@ -5,8 +5,12 @@ tags:
   - Moodle 3.11
 sidebar_position: 2
 moodleVersion: 3.11.2
+description: The release notes for Moodle version 3.11.2.
 ---
-Here is [the full list of fixed issues in 3.11.2](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.2%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Regression fix
 

--- a/general/releases/3.11/3.11.3.md
+++ b/general/releases/3.11/3.11.3.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.11
 sidebar_position: 3
 moodleVersion: 3.11.3
+description: The release notes for Moodle version 3.11.3.
 ---
-Release date: 13 September 2021
 
-Here is [the full list of fixed issues in 3.11.3](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.3%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.11/3.11.4.md
+++ b/general/releases/3.11/3.11.4.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.11
 sidebar_position: 4
 moodleVersion: 3.11.4
+description: The release notes for Moodle version 3.11.4.
 ---
-Release date: 8 November 2021
 
-Here is [the full list of fixed issues in 3.11.4](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.4%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.11/3.11.5.md
+++ b/general/releases/3.11/3.11.5.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.11
 sidebar_position: 5
 moodleVersion: 3.11.5
+description: The release notes for Moodle version 3.11.5.
 ---
-Release date: 17 January 2022
 
-Here is [the full list of fixed issues in 3.11.5](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.5%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.11/3.11.6.md
+++ b/general/releases/3.11/3.11.6.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.11
 sidebar_position: 6
 moodleVersion: 3.11.6
+description: The release notes for Moodle version 3.11.6.
 ---
-Release date: 14 March 2022
 
-Here is [the full list of fixed issues in 3.11.6](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.6%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.11/3.11.7.md
+++ b/general/releases/3.11/3.11.7.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.11
 sidebar_position: 7
 moodleVersion: 3.11.7
+description: The release notes for Moodle version 3.11.7.
 ---
-Release date: 9 May 2022
 
-Here is [the full list of fixed issues in 3.11.7](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.7%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.11/3.11.8.md
+++ b/general/releases/3.11/3.11.8.md
@@ -6,12 +6,12 @@ tags:
   - Moodle 3.11
 sidebar_position: 8
 moodleVersion: 3.11.8
+description: The release notes for Moodle version 3.11.8.
 ---
-[Releases](../../releases.md) > Moodle 3.11.8 release notes
 
-Release date: 11 July 2022
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Here is [the full list of fixed issues in 3.11.8](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.11.8%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.9.md
+++ b/general/releases/3.9.md
@@ -4,11 +4,13 @@ tags:
   - Release notes
   - Moodle 3.9
 sidebar_position: -309
-moodleVersion: '3.9'
+moodleVersion: 3.9.0
+description: The release notes for Moodle version 3.9.0.
 ---
-Release date: 15 June 2020
 
-Here is [the full list of fixed issues in 3.9](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 See our [New features page](https://docs.moodle.org/39/en/New_features) in the user documentation for an introduction to Moodle 3.9 with screenshots.
 

--- a/general/releases/3.9/3.9.1.md
+++ b/general/releases/3.9/3.9.1.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 1
 moodleVersion: 3.9.1
+description: The release notes for Moodle version 3.9.1.
 ---
-Release date: 13 July 2020
 
-Here is [the full list of fixed issues in 3.9.1](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.1%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.9/3.9.10.md
+++ b/general/releases/3.9/3.9.10.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 10
 moodleVersion: 3.9.10
+description: The release notes for Moodle version 3.9.10.
 ---
-Release date: 13 September 2021
 
-Here is [the full list of fixed issues in 3.9.10](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.10%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Backported bug fixes
 

--- a/general/releases/3.9/3.9.11.md
+++ b/general/releases/3.9/3.9.11.md
@@ -5,11 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 11
 moodleVersion: 3.9.11
+description: The release notes for Moodle version 3.9.11.
 ---
 
-Release date: 8 November 2021
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Here is [the full list of fixed issues in 3.9.11](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.11%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Backported bug fixes
 

--- a/general/releases/3.9/3.9.12.md
+++ b/general/releases/3.9/3.9.12.md
@@ -5,11 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 12
 moodleVersion: 3.9.12
+description: The release notes for Moodle version 3.9.12.
 ---
 
-Release date: 17 January 2022
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Here is [the full list of fixed issues in 3.9.12](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.12%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Backported bug fixes
 

--- a/general/releases/3.9/3.9.13.md
+++ b/general/releases/3.9/3.9.13.md
@@ -5,11 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 13
 moodleVersion: 3.9.13
+description: The release notes for Moodle version 3.9.13.
 ---
 
-Release date: 14 March 2022
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Here is [the full list of fixed issues in 3.9.13](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.13%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Backported bug fixes
 

--- a/general/releases/3.9/3.9.14.md
+++ b/general/releases/3.9/3.9.14.md
@@ -5,11 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 14
 moodleVersion: 3.9.14
+description: The release notes for Moodle version 3.9.14.
 ---
 
-Release date: 9 May 2022
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Here is [the full list of fixed issues in 3.9.14](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.14%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Security fixes
 

--- a/general/releases/3.9/3.9.15.md
+++ b/general/releases/3.9/3.9.15.md
@@ -6,12 +6,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 15
 moodleVersion: 3.9.15
+description: The release notes for Moodle version 3.9.15.
 ---
-[Releases](../../releases.md) > Moodle 3.9.15 release notes
 
-Release date: 11 July 2022
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Here is [the full list of fixed issues in 3.9.15](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.15%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## For developers
 

--- a/general/releases/3.9/3.9.2.md
+++ b/general/releases/3.9/3.9.2.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 2
 moodleVersion: 3.9.2
+description: The release notes for Moodle version 3.9.2.
 ---
-Release date: 14 September 2020
 
-Here is [the full list of fixed issues in 3.9.2](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.2%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.9/3.9.3.md
+++ b/general/releases/3.9/3.9.3.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 3
 moodleVersion: 3.9.3
+description: The release notes for Moodle version 3.9.3.
 ---
-Release date: 9 November 2020
 
-Here is [the full list of fixed issues in 3.9.3](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.3%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Warning
 

--- a/general/releases/3.9/3.9.4.md
+++ b/general/releases/3.9/3.9.4.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 4
 moodleVersion: 3.9.4
+description: The release notes for Moodle version 3.9.4.
 ---
-Release date: 18 January 2021
 
-Here is [the full list of fixed issues in 3.9.4](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.4%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Warning - courses with many sections
 

--- a/general/releases/3.9/3.9.5.md
+++ b/general/releases/3.9/3.9.5.md
@@ -5,11 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 5
 moodleVersion: 3.9.5
+description: The release notes for Moodle version 3.9.5.
 ---
 
-Release date: 8 March 2021
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Here is [the full list of fixed issues in 3.9.5](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.5%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.9/3.9.6.md
+++ b/general/releases/3.9/3.9.6.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 6
 moodleVersion: 3.9.6
+description: The release notes for Moodle version 3.9.6.
 ---
-Release date: 25 March 2021
 
-Here is [the full list of fixed issues in 3.9.6](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.6%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Regression fix
 

--- a/general/releases/3.9/3.9.7.md
+++ b/general/releases/3.9/3.9.7.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 7
 moodleVersion: 3.9.7
+description: The release notes for Moodle version 3.9.7.
 ---
-Release date: 10 May 2021
 
-Here is [the full list of fixed issues in 3.9.7](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.7%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/3.9/3.9.8.md
+++ b/general/releases/3.9/3.9.8.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 8
 moodleVersion: 3.9.8
+description: The release notes for Moodle version 3.9.8.
 ---
-Release date: 12 July 2021
 
-Here is [the full list of fixed issues in 3.9.8](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.8%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Backported bug fixes
 

--- a/general/releases/3.9/3.9.9.md
+++ b/general/releases/3.9/3.9.9.md
@@ -5,8 +5,12 @@ tags:
   - Moodle 3.9
 sidebar_position: 9
 moodleVersion: 3.9.9
+description: The release notes for Moodle version 3.9.9.
 ---
-Here is [the full list of fixed issues in 3.9.9](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%223.9.9%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## Regression fix
 

--- a/general/releases/4.0.md
+++ b/general/releases/4.0.md
@@ -4,14 +4,13 @@ tags:
   - Release notes
   - Moodle 4.0
 sidebar_position: -400
-moodleVersion: '4.0'
+moodleVersion: 4.0.0
+description: The release notes for Moodle version 4.0.0.
 ---
 
-import ReactPlayer from 'react-player/lazy';
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Release date: 19 April 2022
-
-Here is [the full list of fixed issues in 4.0](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%224.0%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 See our [New features](https://docs.moodle.org/400/en/New_features) page in the user documentation for an introduction to Moodle 4.0 with screenshots.
 <ReactPlayer url="https://www.youtube.com/watch?v=sZxZ_YzsD_w&list=PLxcO_MFWQBDcI0BezfCOW8QRfJw6FblRn&ab_channel=Moodle" />

--- a/general/releases/4.0/4.0.1.md
+++ b/general/releases/4.0/4.0.1.md
@@ -5,10 +5,12 @@ tags:
   - Moodle 4.0
 sidebar_position: 1
 moodleVersion: 4.0.1
+description: The release notes for Moodle version 4.0.1.
 ---
-Release date: 9 May 2022
 
-Here is [the full list of fixed issues in 4.0.1](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%224.0.1%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/general/releases/4.0/4.0.2.md
+++ b/general/releases/4.0/4.0.2.md
@@ -6,11 +6,12 @@ tags:
   - Moodle 4.0
 sidebar_position: 2
 moodleVersion: 4.0.2
+description: The release notes for Moodle 4.0.2.
 ---
 
-Release date: 11 July 2022
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
-Here is [the full list of fixed issues in 4.0.2](https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%224.0.2%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true).
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
 ## General fixes and improvements
 

--- a/src/components/ReleaseInformation/index.tsx
+++ b/src/components/ReleaseInformation/index.tsx
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Moodle Pty Ltd.
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import { getRelease } from '@site/src/utils/SupportedReleases';
+import Link from '@docusaurus/Link';
+
+export interface ReleaseInfoProps {
+    releaseName: string,
+}
+
+function ReleaseInfo(releaseName: string, key: string): JSX.Element {
+    const versionInfo = getRelease(releaseName);
+
+    if (versionInfo && typeof versionInfo[key] !== 'undefined') {
+        return (
+            <>
+                {versionInfo[key]}
+            </>
+        );
+    }
+
+    return null;
+}
+
+export function ReleaseDate({ releaseName }: ReleaseInfoProps): JSX.Element {
+    return ReleaseInfo(releaseName, 'releaseDate');
+}
+
+export function ReleaseVersion({ releaseName }: ReleaseInfoProps): JSX.Element {
+    return ReleaseInfo(releaseName, 'version');
+}
+
+export function ReleaseNoteIntro({ releaseName }: ReleaseInfoProps): JSX.Element {
+    const versionInfo = getRelease(releaseName);
+    if (!versionInfo) {
+        return null;
+    }
+
+    const trackerReleaseNumber = versionInfo.name.endsWith('.0') ? versionInfo.name.slice(0, -2) : versionInfo.name;
+
+    return (
+        <>
+            <p>
+
+                Release date:
+                {' '}
+                <ReleaseDate releaseName={releaseName} />
+                <br />
+            </p>
+            <p>
+                Here is
+                {' '}
+                <Link
+                    href={`https://tracker.moodle.org/secure/IssueNavigator!executeAdvanced.jspa?jqlQuery=project+%3D+mdl+AND+resolution+%3D+fixed+AND+fixVersion+in+%28%22${trackerReleaseNumber}%22%29+ORDER+BY+priority+DESC&runQuery=true&clear=true`}
+                >
+                    the full list of fixed issues in
+                    {' '}
+                    {releaseName}
+                </Link>
+                .
+            </p>
+        </>
+    );
+}

--- a/src/components/ReleaseInformation/index.tsx
+++ b/src/components/ReleaseInformation/index.tsx
@@ -34,7 +34,13 @@ function ReleaseInfo(releaseName: string, key: string): JSX.Element {
         );
     }
 
-    return null;
+    // No release information found.
+    // Assume that it's in the future rather than ignoring it completely.
+    return (
+        <>
+            not yet released
+        </>
+    );
 }
 
 export function ReleaseDate({ releaseName }: ReleaseInfoProps): JSX.Element {
@@ -46,12 +52,7 @@ export function ReleaseVersion({ releaseName }: ReleaseInfoProps): JSX.Element {
 }
 
 export function ReleaseNoteIntro({ releaseName }: ReleaseInfoProps): JSX.Element {
-    const versionInfo = getRelease(releaseName);
-    if (!versionInfo) {
-        return null;
-    }
-
-    const trackerReleaseNumber = versionInfo.name.endsWith('.0') ? versionInfo.name.slice(0, -2) : versionInfo.name;
+    const trackerReleaseNumber = releaseName.endsWith('.0') ? releaseName.slice(0, -2) : releaseName;
 
     return (
         <>

--- a/src/utils/SupportedReleases.ts
+++ b/src/utils/SupportedReleases.ts
@@ -139,3 +139,15 @@ export const getVersion = (versionName: string): majorVersionData => {
     const majorVersion = `${major}.${release}`;
     return getAllVersions().find((version) => version.name === majorVersion);
 };
+
+export const getRelease = (versionName: string): versionInfo | null => {
+    const [major, release] = versionName.split('.');
+    const majorVersionName = `${major}.${release}`;
+    const majorVersion = getAllVersions().find((version) => version.name === majorVersionName);
+
+    if (!majorVersion) {
+        return null;
+    }
+
+    return majorVersion.releases.find((versionInfo) => versionInfo.name === versionName);
+};


### PR DESCRIPTION
As requested in #298.

This issue introduces a new React component:

```
<ReleaseNoteIntro releaseName="4.0.2" />
```

This will display the:

- release date
- link to the tracker

I've also updated the page description for the meta tag because the import statement and React tags mess with it.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/300"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

