### PR TITLE
[repo] Improve colour for Since and DeprecatedSince

### DIFF
--- a/src/components/Since.js
+++ b/src/components/Since.js
@@ -50,10 +50,13 @@ function getSinceLabel(type, versionNumber, issueNumber) {
         </span>
     );
 
+    const color = type === 'since' ? 'success' : 'warning';
+
     const chip = (
         <Chip
             key={`chip-${type}${normalisedVersionNumber}`}
             label={label}
+            color={color}
             clickable={!!issueNumber}
         />
     );


### PR DESCRIPTION
The chips were using their default colours, which do not play nicely
with Dark mode - the Soince tags become invisible.

I've chosen the "success" and "warning" colours which are green and
amber respectively.