### PR TITLE
[docs] Migrate form features

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1626,6 +1626,9 @@ lib/formslib.php_Testing:
 lib/formslib.php_Usage:
 - filePath: "/docs/apis/subsystems/form/usage.md"
   slug: "/docs/apis/subsystems/form/usage"
+lib/formslib.php_add_checkbox_controller:
+- filePath: "/docs/apis/subsystems/form/advanced/checkbox-controller.md"
+  slug: "/docs/apis/subsystems/form/advanced/checkbox-controller"
 lib/formslib.php_repeat_elements:
 - filePath: "/docs/apis/subsystems/form/advanced/repeat-elements.md"
   slug: "/docs/apis/subsystems/form/advanced/repeat-elements"

--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1629,6 +1629,9 @@ lib/formslib.php_Usage:
 lib/formslib.php_add_checkbox_controller:
 - filePath: "/docs/apis/subsystems/form/advanced/checkbox-controller.md"
   slug: "/docs/apis/subsystems/form/advanced/checkbox-controller"
+lib/formslib.php_no_submit_button_pressed:
+- filePath: "/docs/apis/subsystems/form/advanced/no-submit-button.md"
+  slug: "/docs/apis/subsystems/form/advanced/no-submit-button"
 lib/formslib.php_repeat_elements:
 - filePath: "/docs/apis/subsystems/form/advanced/repeat-elements.md"
   slug: "/docs/apis/subsystems/form/advanced/repeat-elements"

--- a/docs/apis/subsystems/form/advanced/checkbox-controller.md
+++ b/docs/apis/subsystems/form/advanced/checkbox-controller.md
@@ -1,0 +1,74 @@
+---
+title: Checkbox controller
+tags:
+  - core_form
+  - core
+  - Forms API
+  - Advanced
+---
+
+The checkbox controller allows developers to group checkboxes together and add a link or button to check, or uncheck, all of the checkboxes at once.
+
+You can add as many groups of checkboxes as you like, as long as they are uniquely named, where the name is an integer.
+
+## Checkbox groups
+
+When adding checkboxes, you can add them in _groups_. Each group of checkboxes must have a unique integer name, for example:
+
+```php title="classes/form/example_form.php"
+public function definition(): void {
+    // These two elements are part of group 1.
+    $mform->addElement('advcheckbox', 'test1', 'Test 1', null, ['group' => 1]);
+    $mform->addElement('advcheckbox', 'test2', 'Test 2', null, ['group' => 1]);
+
+    // Add a checkbox controller for all checkboxes in `group => 1`:
+    $this->add_checkbox_controller(1);
+
+    // These two elements are part of group 3.
+    $mform->addElement('advcheckbox', 'test3', 'Test 3', null, ['group' => 3]);
+    $mform->addElement('advcheckbox', 'test4', 'Test 4', null, ['group' => 3]);
+
+    // Add a checkbox controller for all checkboxes in `group => 3`.
+    // This example uses a different wording isntead of Select all/none by passing the second parameter:
+    $this->add_checkbox_controller(
+        3,
+        get_string("checkall", "plugintype_pluginname")
+    );
+}
+```
+
+## API
+
+The checkbox controller is described by the following mform function:
+
+```php
+moodleform::add_checkbox_controller(
+    $groupid = null,
+    string $text = null,
+    mixed $attributes = null,
+    int $originalvalue
+): void;
+```
+
+- int *$groupid* This also serves as the checkbox group name. It must be a unique integer per collection of checkboxes.
+- string *$text* (optional) Link display text. Defaults to `get_string('selectallornone', 'form')`.
+- mixed  *$attributes* (optional) Either a typical HTML attribute string or an associative array.
+- int *$originalValue* (optional) Defaults to 0; The general original value of the checkboxes being controlled by this element.
+
+:::info An explanation of `$originalvalue`
+
+Imagine that you have 50 checkboxes in your form, which are all unchecked when the form first loads, except 5 or 6 of them.
+
+The logical choice here would be for the standard behaviour to check all of the checkboxes upon first click, then to uncheck them all upon the next click and so on.
+
+If the situation was reversed, with most of the checkboxes already checked by default, then it would make more sense to have the first action uncheck all the checkboxes.
+
+The `$originalvalue` parameter allows you to configure the initial value and therefore the initial behaviour.
+
+:::
+
+### Description of functionality
+
+The first role of the `add_checkbox_controller` method is to add a form element. Depending on whether JavaScript is supported by the browser or not, it will either output a link with onclick behaviour for instant action, or a `nosubmit` button which will reload the page and change the state of the checkboxes, but retain the rest of the data already filled in the form by the user.
+
+The second role is to change the state of the checkboxes. The JavaScript version simply switches all checkboxes to checked or unchecked. The state applied when the link is first clicked depends on the `$originalvalue` parameter as noted above. The non-JavaScript version behaves in exactly the same way, although a page reload is necessary.

--- a/docs/apis/subsystems/form/advanced/no-submit-button.md
+++ b/docs/apis/subsystems/form/advanced/no-submit-button.md
@@ -1,0 +1,54 @@
+---
+title: No submit button
+tags:
+  - core_form
+  - core
+  - Forms API
+  - Advanced
+---
+
+The moodleform 'no_submit_button_pressed()' method allows you to detect if a button on your form has been pressed that is a submit button but that has been defined as a button that doesn't result in a processing of all the form data but will result in some form 'sub action' and then having the form redisplayed. This is useful for example to have an 'Add' button to add some option to a select box in the form etc. You define a button as a no submit button as in the example below (in `definition()`). This example adds a text box and a submit button in a group.
+
+## Form definition
+
+When defining your form, you will need to call the `registerNoSubmitButton()` function with the name of the submit button mark as a non-submission button, for example:
+
+```php
+$mform->registerNoSubmitButton('addtags');
+$tags = [
+    $mform->createElement('text', 'tagsadd', get_string('addtags', 'blog')),
+    $mform->createElement('submit', 'addtags', get_string('add')),
+];
+$mform->addGroup($tags, 'tagsgroup', get_string('addtags','blog'), [' '], false);
+$mform->setType('tagsadd', PARAM_NOTAGS);
+```
+
+## Form handling
+
+When handling a no-submit button press you will need to check whether any no-submit button as pressed _before_ checking for submitted data. For example:
+
+```php
+$mform = new \plugintype_pluginname\form\my_form();
+$mform->set_data($toform);
+
+if ($mform->is_cancelled()){
+    // If you have a cancel button on your form then you will need
+    // to handle the cancel action here according to the
+    // requirements of your plugin
+} else if ($mform->no_submit_button_pressed()) {
+    // If you have a no-submit button on your form, then you can handle that action here.
+    $data = $mform->get_submitted_data();
+} else if ($fromform = $mform->data_submitted()){
+    // This branch is where you process validated data.
+} else {
+    // The form has not been submitted, or was unsuccessfully submitted.
+}
+```
+
+:::important Modifying your form in a no-submit action
+
+Because the check for a no-submit button press takes place on the defined form, the form is already defined at the point that it is checked.
+
+If you wish to add or modify elements or options in your form, then may need to use methods on MoodleQuickForm to redefine your form elements.
+
+:::


### PR DESCRIPTION
This small patch just migrates two more of the advanced form features.

There are still a couple of form-related pages to migrate but these are non-trivial and I'll do them as separate PRs due to their size.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/310"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

