### PR TITLE
[docs] 402 minors: Add security fixes and remove incorrect translations

### DIFF
--- a/general/releases/3.11/3.11.8.md
+++ b/general/releases/3.11/3.11.8.md
@@ -61,9 +61,11 @@ import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
 ## Security fixes
 
-A number of security related issues were resolved. Details of these issues will be released after a period of approximately one week to allow system administrators to safely update to the latest version.
-
-## Translations
-
-- [Notes de version de Moodle 3.11](https://docs.moodle.org/fr/Notes_de_version_de_Moodle_3.11)
-- [Notas de Moodle 3.11](https://docs.moodle.org/es/Notas_de_Moodle_3.11)
+<!-- cspell:disable -->
+- [MSA-22-0015](https://moodle.org/mod/forum/discuss.php?d=436456) - PostScript Code Injection / Remote code execution risk
+- [MSA-22-0016](https://moodle.org/mod/forum/discuss.php?d=436457) - Arbitrary file read when importing lesson questions
+- [MSA-22-0017](https://moodle.org/mod/forum/discuss.php?d=436458) - Stored XSS and blind SSRF possible via SCORM track details
+- [MSA-22-0018](https://moodle.org/mod/forum/discuss.php?d=436459) - Open redirect risk in mobile auto-login feature
+- [MSA-22-0019](https://moodle.org/mod/forum/discuss.php?d=436460) - LTI module reflected XSS risk - affecting unauthenticated users only
+- [MSA-22-0020](https://moodle.org/mod/forum/discuss.php?d=436461) - Upgrade moodle-mlbackend-python and update its reference in /lib/mlbackend/python/classes/processor.php (upstream)
+<!-- cspell:enable -->

--- a/general/releases/3.9/3.9.15.md
+++ b/general/releases/3.9/3.9.15.md
@@ -24,9 +24,11 @@ import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 <!-- cspell:enable -->
 ## Security fixes
 
-A number of security related issues were resolved. Details of these issues will be released after a period of approximately one week to allow system administrators to safely update to the latest version.
-
-## Translations
-
-- [Notes de version de Moodle 3.9](https://docs.moodle.org/fr/Notes_de_version_de_Moodle_3.9)
-- [Notas de Moodle 3.9](https://docs.moodle.org/es/Notas_de_Moodle_3.9)
+<!-- cspell:disable -->
+- [MSA-22-0015](https://moodle.org/mod/forum/discuss.php?d=436456) - PostScript Code Injection / Remote code execution risk
+- [MSA-22-0016](https://moodle.org/mod/forum/discuss.php?d=436457) - Arbitrary file read when importing lesson questions
+- [MSA-22-0017](https://moodle.org/mod/forum/discuss.php?d=436458) - Stored XSS and blind SSRF possible via SCORM track details
+- [MSA-22-0018](https://moodle.org/mod/forum/discuss.php?d=436459) - Open redirect risk in mobile auto-login feature
+- [MSA-22-0019](https://moodle.org/mod/forum/discuss.php?d=436460) - LTI module reflected XSS risk - affecting unauthenticated users only
+- [MSA-22-0020](https://moodle.org/mod/forum/discuss.php?d=436461) - Upgrade moodle-mlbackend-python and update its reference in /lib/mlbackend/python/classes/processor.php (upstream)
+<!-- cspell:enable -->

--- a/general/releases/4.0/4.0.2.md
+++ b/general/releases/4.0/4.0.2.md
@@ -72,4 +72,15 @@ import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
 ## Security fixes
 
-A number of security related issues were resolved. Details of these issues will be released after a period of approximately one week to allow system administrators to safely update to the latest version.
+<!-- cspell:disable -->
+- [MSA-22-0015](https://moodle.org/mod/forum/discuss.php?d=436456) - PostScript Code Injection / Remote code execution risk
+- [MSA-22-0016](https://moodle.org/mod/forum/discuss.php?d=436457) - Arbitrary file read when importing lesson questions
+- [MSA-22-0017](https://moodle.org/mod/forum/discuss.php?d=436458) - Stored XSS and blind SSRF possible via SCORM track details
+- [MSA-22-0018](https://moodle.org/mod/forum/discuss.php?d=436459) - Open redirect risk in mobile auto-login feature
+- [MSA-22-0019](https://moodle.org/mod/forum/discuss.php?d=436460) - LTI module reflected XSS risk - affecting unauthenticated users only
+- [MSA-22-0020](https://moodle.org/mod/forum/discuss.php?d=436461) - Upgrade moodle-mlbackend-python and update its reference in /lib/mlbackend/python/classes/processor.php (upstream)
+<!-- cspell:enable -->
+
+## Translations
+
+- [Notes de version de Moodle 4.0.2](https://docs.moodle.org/4x/fr/Notes_de_version_de_Moodle_4.0.2)


### PR DESCRIPTION
Added security fixes for latest minor release. Also removed links to translations that did not correspond to the relevant page (versions corresponding with these releases did not appear to exist to replaced them with), and added the one 4.0.2 translation page that did exist in the old docs (FR).

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/315"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

