### PR TITLE
[docs] Remove reference to NEWMODULE Documentation

### DIFF
--- a/docs/apis/plugintypes/mod/index.mdx
+++ b/docs/apis/plugintypes/mod/index.mdx
@@ -250,8 +250,6 @@ also _required_:
   extraDescription={
 <div>
 
-See the [NEWMODULE Documentation#lib.php](https://docs.moodle.org/dev/NEWMODULE_Documentation#lib.php) for details on the list of the functions which can be specified in `lib.php`.
-
 For an Activity, you _must_ define the following three functions, which are described below:
 
 ```php title="mod/[modname]/lib.php"
@@ -295,4 +293,4 @@ The `lib.php` file is one of the older parts of Moodle and functionality is grad
 
 ## See also
 
-- [NEWMODULE Documentation](https://docs.moodle.org/dev/NEWMODULE_Documentation)
+- [Tutorial](https://docs.moodle.org/dev/Tutorial)


### PR DESCRIPTION
Should fix https://github.com/moodle/devdocs/issues/320 

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/322"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

