### PR TITLE
[docs] Fixing an error on deprecating a parameter doc

### DIFF
--- a/general/development/policies/deprecation.md
+++ b/general/development/policies/deprecation.md
@@ -110,7 +110,7 @@ Remember the phpDoc parameter type should also be updated to `null`.
 ```
 
 - Update all calls to the affected function removing the deprecated parameter.
-- Add a mention to corresponding `upgrade.txt` documenting the deprecated method should not be used any more.
+- Add a mention to corresponding `upgrade.txt` documenting the deprecated parameter should not be used any more.
 
 ## See also...
 


### PR DESCRIPTION
Add a mention to corresponding upgrade.txt documenting the deprecated PARAMETER should not be used any more.

instead of

Add a mention to corresponding upgrade.txt documenting the deprecated method should not be used any more.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/334"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

