### PR TITLE
[docs] Add agreement for the class deprecation

### DIFF
--- a/general/development/policies/deprecation.md
+++ b/general/development/policies/deprecation.md
@@ -40,7 +40,11 @@ Deprecation affects only the current master version, in other words, the depreca
 
 - If the function is not a member of a class (in other words, it is an independent function), it should be moved, with its PHPDoc and all comments, to `lib/deprecatedlib.php`, which is included everywhere. If the function is a class member, it will need to be deprecated in its current location.
   - Deprecated behat step definitions should be moved to `lib/tests/behat/behat_deprecated.php`, including a call to `behat_deprecated::deprecated_message()` proposing an alternative to the deprecated method.
-- If an entire class is being moved (for example, moving multiple class definitions from a monolithic file in to individual files), follow the process for [renaming classes](/docs/apis/commonfiles#dbrenamedclassesphp).
+- If an entire class is being deprecated, the following actions should be done:
+  - Add @deprecated tag on class level PHPDoc block
+  - Add @deprecated tag on the PHPDoc block of all public methods
+  - Add debugging on all of the public methods
+- Besides, if the entire class is being moved (for example, moving multiple class definitions from a monolithic file in to individual files), follow the process for [renaming classes](/docs/apis/commonfiles#dbrenamedclassesphp).
 - A debugging message should be added to the function so that, when [developer debugging mode](https://docs.moodle.org/en/Debugging) is on, attention is drawn to the deprecation. The message should state that the function being called has been deprecated. The message should help a developer whose code currently calls the function that has gone. Tell them what they should do instead.
 
 ```
@@ -81,7 +85,8 @@ Longer deprecation periods can be considered for functions that are widely used.
  throw new coding_exception('check_potential_filename() can not be used any more, please use new file API');
  ```
 
-- All function parameters should be removed
+- All function parameters should be removed.
+- Deprecated classes must be completely removed.
 - The content of the PHPDoc should be removed, leaving only the `@deprecated` tag with the notice and, optionally, the replacement information. This includes all `@param`, `@return`, and other tags, as well as the description.
 - External functions deprecation process is different from the standard deprecation and functions should be completely removed.
 - Last but not least, every deprecation should be documented in the corresponding `upgrade.txt` files **at least** once but, **ideally**, both on the initial/immediate deprecation and also on this final deprecation/removal.


### PR DESCRIPTION
In MDLSITE-6729 (policy issue), an agreement was done to add more information for initial and final class deprecation.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/335"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

