### PR TITLE
Output API - Fix typos and grammar

### DIFF
--- a/docs/apis/subsystems/output.md
+++ b/docs/apis/subsystems/output.md
@@ -7,15 +7,11 @@ tags:
 
 <!-- cspell:ignore renderables, sometext, courseid, enabletrusttext -->
 
-The Output API is responsible for visual aspects of Moodle content. This page explain how renderers, renderables, themes and templates all work together.
-
-The following documentation is also related:
-
-- The [Templates](../../guides/templates/index.md) used for rendering the output such as HTML or email messages bodies
+The Output API is responsible for visual aspects of Moodle content. This page explains how renderers, renderables, themes and templates all work together.
 
 ## Page Output Journey
 
-Lets start with building a page that is part of an admin tool.
+Let's start with building a page that is part of an admin tool.
 
 ```php title="/admin/tool/demo/index.php"
 <?php
@@ -46,7 +42,7 @@ echo $output->footer();
 
 :::info Setup of an admin page
 
-On admin pages the `admin_externalpage_setup($sectionname);` function should be used to setup and perform permission checks, for example:
+On admin pages, the `admin_externalpage_setup($sectionname);` function should be called to set up and perform permission checks, for example:
 
 ```php title="admin/tool/demo/mypage.php"
 require_once(__DIR__ . '/../../config.php');
@@ -56,7 +52,7 @@ admin_externalpage_setup('example');
 
 :::
 
-First, we set some general `$PAGE` properties. We load the title of the page from a lang string (see [String API](https://docs.moodle.org/dev/String_API)).
+Firstly, we set some general `$PAGE` properties. We load the title of the page from a language string (see [String API](https://docs.moodle.org/dev/String_API)).
 
 ```php
 // Set up the page.
@@ -74,7 +70,7 @@ $PAGE->set_heading($title);
 
 :::
 
-The most important properties stored in `$PAGE` are the page context, the url, the layout, title and headings. `$PAGE` also gives access to some other important classes such as `$PAGE->requires`, which is an instance of the `page_requirements_manager` (`lib/outputrequirementslib.php`). The `page_requirements_manager` class lets us set dependencies on e.g. JavaScript and css to be inserted in the correct place in the page (The order things are inserted in the page is hugely important for performance).
+The most important properties stored in `$PAGE` are the page context, URL, layout, title and headings. `$PAGE` also gives access to some other important classes such as `$PAGE->requires`, which is an instance of the `page_requirements_manager` (`lib/outputrequirementslib.php`). The `page_requirements_manager` class lets us set dependencies on e.g. JavaScript and CSS to be inserted in the correct place in the page (The order in which things are inserted into the page is hugely important for performance).
 
 `$PAGE` also lets us load specific renderers for a plugin, or plugin and subtype. We will cover renderers in more detail next.
 
@@ -86,7 +82,7 @@ This gets an instance of the `plugin_renderer_base` class that we use to create 
 
 :::important
 
-Some pages use the global variable `$OUTPUT to generate their output. This is a generic renderer used for core pages etc, but plugins should always use a more specific plugin renderer.
+Some pages use the global variable `$OUTPUT` to generate their output. This is a generic renderer used for core pages etc, but plugins should always use a more specific plugin renderer.
 
 :::
 
@@ -95,20 +91,20 @@ echo $output->header();
 echo $output->heading($pagetitle);
 ```
 
-This code prints the header of the page and adds one heading to the page at the top of the content region. Page headings are very important in Moodle and should be applied consistently. See [HTML Guidelines](https://docs.moodle.org/dev/HTML_Guidelines) for more information on how and where to use  headings.
+This code prints the header of the page and adds one heading to the page at the top of the content region. Page headings are very important in Moodle and should be applied consistently. See [HTML Guidelines](https://docs.moodle.org/dev/HTML_Guidelines) for more information on how and where to use headings.
 
 ```php
 $renderable = new \tool_demo\output\index_page('Some text');
 echo $output->render($renderable);
 ```
 
-This is the most interesting part of our page. We are creating a renderable and telling our renderer to render it. The renderable is usually more complex than this, it should hold all the data required for the renderer to display the page. This means we should perform all our logic such as database queries, page parameters and access checks in advance and the results should be passed as data to the renderable. The renderable then just takes that data and returns a HTML representation of it.
+This is the most interesting part of our page. We are creating an instance of a renderable and telling our renderer to render it. The renderable is usually more complex than this. It should hold all the data required for the renderer to display the page. This means we should perform all our logic such as database queries, page parameters and access checks in advance then pass the results as data to the renderable. The renderable then just takes that data and returns an HTML representation of it.
 
 ```php
 echo $output->footer();
 ```
 
-This prints the HTML for the bottom of the page. It is very important because it also prints out things that were added to the page_requirements_manager and need to be printed in the footer. Things like JavaScript includes, navigation tree setup, closing open containers tags etc. The reason all JavaScripts are added to the footer of the page is for performance. If you add JavaScript includes to the top of the page, or inline with the content the browser must stop and execute the JavaScript before it can render the page. See https://developers.google.com/speed/docs/insights/BlockingJS for more information.
+This prints the HTML for the bottom of the page. It is very important because it also prints out things that were added to the `page_requirements_manager` and that need to be printed in the footer; things like JavaScript includes, navigation tree setup, closing open containers tags etc. The reason all JavaScripts are added to the footer of the page is for performance. If you add JavaScript includes to the top of the page, or inline with the content the browser, must stop and execute the JavaScript before it can render the page. See https://developers.google.com/speed/docs/insights/BlockingJS for more information.
 
 ### Renderable
 
@@ -148,7 +144,7 @@ class index_page implements renderable, templatable {
 
 This class implements the renderable interface, which has no methods, and the templatable interface, which means that this class could be rendered with a template, so it must implement the `export_for_template` method. So in this example, the class accepts data via it's constructor, and stores that data in class variables. It does nothing else fancy with the data in this example (but it could). Note that the `export_for_template` function should only return simple types (arrays, stdClass, bool, int, float, string).
 
-Now lets look at the renderer for this plugin.
+Now let's look at the renderer for this plugin.
 
 ```php title="admin/tool/demo/classes/output/renderer.php"
 <?php
@@ -173,9 +169,9 @@ class renderer extends plugin_renderer_base {
 }
 ```
 
-The renderer exists to provide `render_<page>` methods for all renderables used in the plugin. A theme designer can provide a custom version of this renderer that changes the behaviour of any of the render methods and so to customize their theme. In this example, the render method for the index page (`render_index_page`) does 2 things. It asks the renderable to export it's data so that it is suitable for passing as the context to a template, and then renders a specific template with this context. A themer could either manipulate the data in the render method (e.g. removing menu entries), or change the template (change the generated html) to customize the output.
+The renderer exists to provide `render_<page>` methods for all renderables used in the plugin. A theme designer can provide a custom version of this renderer that changes the behaviour of any of the render methods and so to customize their theme. In this example, the render method for the index page (`render_index_page`) does 2 things. It asks the renderable to export it's data so that it is suitable for passing as the context to a template, and then renders a specific template with this context. A themer could either manipulate the data in the render method (e.g. removing menu entries), or change the template (change the generated HTML) to customize the output.
 
-The template used in this plugin is located in the plugins templates folder. The template can also be overridden by a themer.
+The template used in this plugin is located in the plugin's templates folder. The template can also be overridden by a themer.
 
 ```xml title="admin/tool/demo/templates/index_page.mustache"
 <div class="hero-unit">
@@ -207,20 +203,19 @@ function s($var, $strip=false)
 function p($var, $strip=false)
 ```
 
-These functions share the same code so they will be explained together. The only difference is that `s()` returns the string while `p()` prints it directly.
+These functions share the same code, so they will be explained together. The only difference is that `s()` returns the string, while `p()` prints it directly.
 
 These functions should be used to:
 
 - print all the **values of form fields** like `<input>` or `<textarea>` tags.
-- to **show plain (non html) text** that has been introduced by the user (search string, quiz responses...).
-- in general, all the **dynamic data, not being html**, that doesn't need to be cleaned nor processed by filters
-It is important not to use these functions for strings that contain html markup.
+- **show plain (non-HTML) text** that has been introduced by the user (search string, quiz responses, ...).
+- print, in general, all the **dynamic data, not being HTML**, that doesn't need to be cleaned nor processed by filters. It is important not to use these functions for strings that contain HTML markup.
 
-The functions replace certain characters that would have special meaning in html (`<, >, ", ', and &`) by html entities so that they are displayed as intended. Note that even though the value of form fields printed with `p()` will have these characters converted to html entities, the submitted values will contain the original characters again.
+The functions replace certain characters that would have special meaning in HTML (`<, >, ", ', and &`) by HTML entities, so that they are displayed as intended. Note that even though the value of form fields printed with `p()` will have these characters converted to HTML entities, the submitted values will still contain the original characters.
 
 The key parameter for this function is:
 
-- **strip**: it decides if we want to strip slashes from the string or no. By default it's `false` so no strip will be performed. We should set such parameter to 'true' only when data to be processed isn't coming from database but from http requests (forms, links...).
+- **strip**: it decides if we want to strip slashes from the string or not. By default, it's `false`, so no strip will be performed. We should set such parameter to 'true' only when data to be processed isn't coming from database, but from HTTP requests (forms, links, ...).
 
 ### format_text()
 
@@ -230,7 +225,7 @@ function format_text($text, $format = FORMAT_MOODLE, $options = null, $courseid_
 
 This function should be used to:
 
-- print **any html/plain/markdown/moodle text**, needing any of the features below. Mainly used for long strings like posts, answers, glossary items...
+- print **any html/plain/markdown/moodle text**, needing any of the features below. It is mainly used for long strings like posts, answers, glossary items, etc.
 - filter content through Moodle or 3rd party language filters for multi-language support. Not to be confused with [get_string](https://docs.moodle.org/dev/String_API#get_string.28.29) which is used to access localized strings in Moodle and its language packs. Together, these functions enable Moodle multi-language support .
 Note that this function is really **heavy** because it supports **cleaning** of dangerous contents, delegates processing to enabled **content filter**s, supports different **formats** of text (HTML, PLAIN, MARKDOWN, MOODLE) and performs a lot of **automatic conversions** like adding smilies, build links. Also, it includes a strong **cache mechanism** (DB based) that will alleviate the server from a lot of work processing the same texts time and again.
 
@@ -273,9 +268,12 @@ Some interesting parameters for this function are:
   - **options->filter**: To decide if you want to allow filters to process the text (defaults to true). This is ignored by `FORMAT_PLAIN` for which filters are never applied.
 
 :::note
-In earlier versions of Moodle the third argument was integer `$courseid`. It is still supported for legacy - if the third argument is an integer instead of array or object it is considered to be course id and is this course's context is passed to the filters being applied.
+In earlier versions of Moodle, the third argument was integer `$courseid`. It is still supported for legacy - if the third argument is an integer instead of an array or object, it is considered to be course id and is this course's context is passed to the filters being applied.
 :::
 
 ## See also
 
+- [HTML Guidelines](https://docs.moodle.org/dev/HTML_Guidelines)
+- [Output renderers](https://docs.moodle.org/dev/Output_renderers)
+- [Overriding a renderer](https://docs.moodle.org/dev/Overriding_a_renderer)
 - [Templates](../../guides/templates/index.md)

--- a/docs/apis/subsystems/output.md
+++ b/docs/apis/subsystems/output.md
@@ -104,7 +104,7 @@ This is the most interesting part of our page. We are creating an instance of a 
 echo $output->footer();
 ```
 
-This prints the HTML for the bottom of the page. It is very important because it also prints out things that were added to the `page_requirements_manager` and that need to be printed in the footer; things like JavaScript includes, navigation tree setup, closing open containers tags etc. The reason all JavaScripts are added to the footer of the page is for performance. If you add JavaScript includes to the top of the page, or inline with the content the browser, must stop and execute the JavaScript before it can render the page. See https://developers.google.com/speed/docs/insights/BlockingJS for more information.
+This prints the HTML for the bottom of the page. It is very important because it also prints out things that were added to the `page_requirements_manager` and that need to be printed in the footer; things like JavaScript includes, navigation tree setup, closing open containers tags etc. The reason all JavaScripts are added to the footer of the page is for performance. If you add JavaScript includes to the top of the page, or inline with the content, the browser must stop and execute the JavaScript before it can render the page. See https://developers.google.com/speed/docs/insights/BlockingJS for more information.
 
 ### Renderable
 


### PR DESCRIPTION
I removed "The following documentation is also related", because it is covered by the "See Also" section.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/339"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

