### PR TITLE
[docs] 403 minors: Add security fixes and improvements

### DIFF
--- a/general/releases/3.11/3.11.9.md
+++ b/general/releases/3.11/3.11.9.md
@@ -31,6 +31,13 @@ import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 - [MDL-56923](https://tracker.moodle.org/browse/MDL-56923) - Assignment, Add new criterion icon should be aligned to the right, in RTL mode (theme:boost)
 <!-- cspell:enable -->
 
-## Security fixes
+## Security improvements
+<!-- cspell:disable -->
+- [MDL-75237](https://tracker.moodle.org/browse/MDL-75237) - Alternate implementation of [MSA-22-0016](https://moodle.org/mod/forum/discuss.php?d=436457) applied to fix a regression (Note: There was no new security risk addressed, however MDL-75237 still has access restricted to avoid revealing details of the original vulnerability)
+<!-- cspell:enable -->
 
-A number of security related issues were resolved. Details of these issues will be released after a period of approximately one week to allow system administrators to safely update to the latest version.
+## Security fixes
+<!-- cspell:disable -->
+- [MSA-22-0021](https://moodle.org/mod/forum/discuss.php?d=437684) - Upgrade Mustache to latest version (upstream)
+- [MSA-22-0022](https://moodle.org/mod/forum/discuss.php?d=437685) - CSRF risk in enabling/disabling installed H5P libraries
+<!-- cspell:enable -->

--- a/general/releases/3.9/3.9.16.md
+++ b/general/releases/3.9/3.9.16.md
@@ -13,6 +13,12 @@ import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 
 <ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
 
-## Security fixes
+## Security improvements
+<!-- cspell:disable -->
+- [MDL-75237](https://tracker.moodle.org/browse/MDL-75237) - Alternate implementation of [MSA-22-0016](https://moodle.org/mod/forum/discuss.php?d=436457) applied to fix a regression (Note: There was no new security risk addressed, however MDL-75237 still has access restricted to avoid revealing details of the original vulnerability)
+<!-- cspell:enable -->
 
-A number of security related issues were resolved. Details of these issues will be released after a period of approximately one week to allow system administrators to safely update to the latest version.
+## Security fixes
+<!-- cspell:disable -->
+- [MSA-22-0021](https://moodle.org/mod/forum/discuss.php?d=437684) - Upgrade Mustache to latest version (upstream)
+<!-- cspell:enable -->

--- a/general/releases/4.0/4.0.3.md
+++ b/general/releases/4.0/4.0.3.md
@@ -43,6 +43,13 @@ import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 - [MDL-74800](https://tracker.moodle.org/browse/MDL-74800) - HTML validator errors on course homepage
 <!-- cspell:enable -->
 
-## Security fixes
+## Security improvements
+<!-- cspell:disable -->
+- [MDL-75237](https://tracker.moodle.org/browse/MDL-75237) - Alternate implementation of [MSA-22-0016](https://moodle.org/mod/forum/discuss.php?d=436457) applied to fix a regression (Note: There was no new security risk addressed, however MDL-75237 still has access restricted to avoid revealing details of the original vulnerability)
+<!-- cspell:enable -->
 
-A number of security related issues were resolved. Details of these issues will be released after a period of approximately one week to allow system administrators to safely update to the latest version.
+## Security fixes
+<!-- cspell:disable -->
+- [MSA-22-0021](https://moodle.org/mod/forum/discuss.php?d=437684) - Upgrade Mustache to latest version (upstream)
+- [MSA-22-0022](https://moodle.org/mod/forum/discuss.php?d=437685) - CSRF risk in enabling/disabling installed H5P libraries
+<!-- cspell:enable -->


### PR DESCRIPTION
Pull request to publish security announcements as part of the minor release +1 week process.

Also added a security improvement item to document a previous security fix that was re-implemented this release to eliminate a regression from the original patch.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/343"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

