### PR TITLE
Fix incorrect slug

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1394,7 +1394,7 @@ Moodle_Penetration_Testing:
   slug: "/general/development/process/security/penetration-testing"
 Moodle_and_PHP:
 - filePath: "/general/development/policies/php.md"
-  slug: "/general/development/php"
+  slug: "/general/development/policies/php"
 Moodle_libraries_credits:
 - filePath: "/general/community/credits/thirdpartylibs.md"
   slug: "/general/community/credits/thirdpartylibs"


### PR DESCRIPTION
I imagine this is the cause for the old docs pointing to incorrect URL in the new docs. AKA:

https://docs.moodle.org/dev/Moodle_and_PHP

is pointing to:

https://moodledev.io/general/development/php

and it should point to:

https://moodledev.io/general/development/policies/php

It seems that in the last move of that page, the information was modified only partially.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/354"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

