### PR TITLE
MDL-55580 Document capabilities deprecation

### DIFF
--- a/docs/apis/subsystems/access.md
+++ b/docs/apis/subsystems/access.md
@@ -76,6 +76,38 @@ The capability names are defined in plugin language files, the name of the strin
 $string['folder:managefiles'] = 'Manage files in folder module';
 ```
 
+### Deprecating a capability
+
+When a capability is no longer needed or is replaced by another, it should be deprecated. The timeline for deprecation should follow the normal [Deprecation](/general/development/policies/deprecation) process.
+
+To mark a capability as deprecated, edit the access.php containing the capability, remove it from the `$capabilities` array, and add it to the `$deprecatedcapabilities` array in this file.
+
+Entries in `$deprecatedcapabilities` can have a `replacement` key indicating a new or existing capability that replaces the deprecated one. If this is specified, any checks to the deprecated capability will check the replacement capability instead. A debugging message will always be output at `DEBUG_DEVELOPER` level if a deprecated capability is checked.
+
+`$deprecatedcapaibilities` can also define an optional `message` explaining the deprecation.
+
+The following example demonstates an access.php file where a capability has been deprecated and replaced with another.
+
+```php title="mod/folder/db/access.php"
+$capabilities = [
+    'mod/folder:newmanagefiles' => [
+        'riskbitmask' => RISK_SPAM,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes' => [
+            'editingteacher' => CAP_ALLOW,
+        ],
+    ],
+];
+
+$deprecatedcapabilities = [
+    'mod/folder:managefiles' => [
+        'replacement' => 'mod/folder:newmanagefiles',
+        'message' => 'This was replaced with another capability'
+    ],
+];
+```
+
 ## Useful functions and classes
 
 ### Context fetching

--- a/general/development/policies/deprecation.md
+++ b/general/development/policies/deprecation.md
@@ -121,5 +121,6 @@ Remember the phpDoc parameter type should also be updated to `null`.
 
 - [String deprecation](../../projects/api/string-deprecation.md)
 - [External functions deprecation](https://docs.moodle.org/dev/Adding_a_web_service_to_a_plugin#Deprecation)
+- [Capabilities deprecation](/docs/apis/subsystems/access#deprecating-a-capability)
 - [Process](../process.md)
 - [Release process](../process/release/index.md)


### PR DESCRIPTION
This branch documents the technical process for deprecating a capability, as implemented by MDL-55580.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/367"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

