### PR TITLE
Bump the priority of non-bugs related with the release

### DIFF
--- a/general/development/process/release/index.md
+++ b/general/development/process/release/index.md
@@ -61,6 +61,7 @@ sidebar_position: 7
 | 12. | &#10003; |  | Monitor QA fails. Check each fail is real and if so ensure an MDL issue has been created and correctly linked and labelled. | Testing Maintainer |
 | 13. | &#10003; |  | Monitor MDL issues created for QA fails. Add them to the "Must fix for X.Y" list and get a developer to work on the issue immediately. | Development Manager |
 | 14. | &#10003; |  | Review the [list of features and improvements submitted before code freeze](https://tracker.moodle.org/issues/?filter=17705&jql=filter%20%3D%2011701%20AND%20type%20!%3D%20Bug) which are awaiting integration review and decide on related QA tests to be put on hold. | Development Manager |
+| 15. | &#10003; |  | Bump the priority of all the minor new features and improvements being must-fix or already under IR/CLR with X.Y as only affected version. Use [this search to find them](https://tracker.moodle.org/issues/?jql=project%20%3D%20MDL%20AND%20resolution%20%3D%20Unresolved%20%20AND%20type%20!%3D%20%22Bug%22%20AND%20priority%20%3C%20%22Major%22%20%20AND%20(fixversion%20in%20(versionMatches(%22Must%20fix%20for%20.*%22))%20OR%20(%22Component%20Lead%20Review%22%20IS%20NOT%20EMPTY%20AND%20affectedversion%20%3D%204.1))) (note that it will need to be adjusted for current X.Y version | Integration Team |
 
 ## 3 weeks prior
 


### PR DESCRIPTION
Add a point to -4w before release (1w after freeze) about to bump the priority of all the minor/trivial non-bug issues to major.

This includes both must-fix issues and issues already under IR/CLR which unique affected version is the one to be released. (the query needs to be amended on every release, it's noted in the new step description).

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/398"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

