### PR TITLE
Add lib/phpxmlrpc to the thirdpartylibs

### DIFF
--- a/general/community/credits/thirdpartylibs.md
+++ b/general/community/credits/thirdpartylibs.md
@@ -1335,6 +1335,21 @@ Copyright © 2009 Phacility
 
 <https://github.com/phacility/xhprof>
 
+## XMLRPC for PHP
+
+:::note lib/phpxmlrpc
+
+A php library for building xml-rpc clients and servers
+
+**Version**: 4.8.0<br/>
+**License**: BSD
+
+Copyright © 1999,2000,2001 Edd Dumbill, Useful Information Company
+
+:::
+
+<https://github.com/gggeek/phpxmlrpc>
+
 ## Yahoo User Interface
 
 :::note lib/yui


### PR DESCRIPTION
**IMPORTANT NOTE**: This only should be merged if/when [MDL-76055](https://tracker.moodle.org/browse/MDL-76055), that introduces it, is successfully integrated.

This adds the new phpxmlrpc library from MDL-76055 to the documentation. A php-only replacement for the xmlrpc extension (deprecated since php80).

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/400"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

