### PR TITLE
fix small typo in the Docusaurus link

### DIFF
--- a/general/documentation/installation.md
+++ b/general/documentation/installation.md
@@ -11,7 +11,7 @@ tags:
 sidebar_position: 3
 ---
 
-Our documentation is built using [Docusaurus](https://docusarus.io), a powerful open source documentation project written in JavaScript.
+Our documentation is built using [Docusaurus](https://docusaurus.io), a powerful open source documentation project written in JavaScript.
 
 It's easy to get your development environment set up and if you plan to contribute regularly to our documentation, then we recommend you setup a [local development environment](#local-development) for the best results. If you're only planning to contribute as a once-off then you may want to consider trying [Gitpod](#quick-start-with-gitpod).
 


### PR DESCRIPTION
When digging through the docs, I found a small typo in the link to Docusaurus. Should be a fast merge. :)

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/410"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

