### PR TITLE
MDL-74912 New DML driver methods for regex word boundary markers

### DIFF
--- a/docs/apis/core/dml/index.md
+++ b/docs/apis/core/dml/index.md
@@ -1045,6 +1045,30 @@ if ($DB->sql_regex_supported()) {
 $pages = $DB->get_records_select('page', $select, $params, 'course', 'id, course, name');
 ```
 
+### sql_regex_get_word_beginning_boundary_marker
+
+<Since versions={["3.11.11", "4.0.5", "4.1"]} issueNumber="MDL-74912" />
+
+Return the word-beginning boundary marker if the current database driver supports regex syntax when searching.
+
+Defaults to `[[:<:]]`. On MySQL `v8.0.4+`, it returns `\\b`.
+
+```php
+public function sql_regex_get_word_beginning_boundary_marker()
+```
+
+### sql_regex_get_word_end_boundary_marker
+
+<Since versions={["3.11.11", "4.0.5", "4.1"]} issueNumber="MDL-74912" />
+
+Return the word-end boundary marker if the current database driver supports regex syntax when searching.
+
+Defaults to `[[:>:]]`. On MySQL `v8.0.4+`, it returns `\\b`.
+
+```php
+public function sql_regex_get_word_end_boundary_marker()
+```
+
 ### sql_intersect
 
 <Since version="2.8" />


### PR DESCRIPTION
This PR add the new DML driver methods `$DB->sql_regex_get_word_beginning_boundary_marker` and `$DB->sql_regex_get_word_end_boundary_marker` for managing word boundary markers in a database driver supporting regex syntax when searching.

Depends on [MDL-74912](https://tracker.moodle.org/browse/MDL-74912).

Please note that MDL-74912 is marked as _Bug_ so the two new methods could be back-ported, depending on what will be the decision there in order to add MySQL 8 support in the supported releases too.
If back-porting those methods will be the choice, I'll amend the PR to add the proper versions _since_ when they have been added.

HTH,
Matteo

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/417"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

