### PR TITLE
MDL-75466 upgrade PHPMailer to 6.6.5

### DIFF
--- a/general/community/credits/thirdpartylibs.md
+++ b/general/community/credits/thirdpartylibs.md
@@ -989,15 +989,14 @@ Library to read, write and create spreadsheet documents in PHP.
 
 Class for sending email using either sendmail, PHP mail(), or SMTP. Methods are based upon the standard AspEmail(tm) classes.
 
-**Version**: 6.2.0<br/>
+**Version**: 6.6.5<br/>
 **License**: LGPL
 
 Copyright © 2003 Brent R. Matzelle (bmatzelle AT yahoo DOT com)
 
 :::
 
-<http://phpmailer.sourceforge.net><br/>
-<https://github.com/PHPMailer/PHPMailer/releases>
+<https://github.com/PHPMailer/PHPMailer>
 
 ## PHP Markdown
 


### PR DESCRIPTION
See: https://tracker.moodle.org/browse/MDL-75466

This also harmonizes the links to https://github.com/PHPMailer/PHPMailer.

http://phpmailer.sourceforge.net redirects to https://phpmailer2.com/, which seems to be a different project (see: https://phpmailer2.com/index.php?pg=history)

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/421"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

