### PR TITLE
[docs] Typo: BugBlueButton instead of BigBlueButton

### DIFF
--- a/general/releases/4.0/4.0.5.md
+++ b/general/releases/4.0/4.0.5.md
@@ -29,7 +29,7 @@ import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
 - [MDL-75010](https://tracker.moodle.org/browse/MDL-75010) - Viewing images in email should not update last access
 - [MDL-74201](https://tracker.moodle.org/browse/MDL-74201) - Content bank files used by reference not restored on other site
 - [MDL-75766](https://tracker.moodle.org/browse/MDL-75766) - Adding indexes in h5p database table (backport of MDL-71129)
-- [MDL-74965](https://tracker.moodle.org/browse/MDL-74965) - BugBlueButton students access error
+- [MDL-74965](https://tracker.moodle.org/browse/MDL-74965) - BigBlueButton students access error
 - [MDL-75784](https://tracker.moodle.org/browse/MDL-75784) - Expand all/Collapse all button is not working when we have two more button in a page
 - [MDL-76169](https://tracker.moodle.org/browse/MDL-76169) - Various behat fixes for Question
 - [MDL-74468](https://tracker.moodle.org/browse/MDL-74468) - BigBlueButton Custom Completion Fixes


### PR DESCRIPTION
We don't want additional bugs (amended in tracker, too).

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/429"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

