### PR TITLE
Fix 4.0.5 and friends release date

### DIFF
--- a/data/versions.json
+++ b/data/versions.json
@@ -44,7 +44,7 @@
                 },
                 {
                     "name": "4.0.5",
-                    "releaseDate": "14 October 2022",
+                    "releaseDate": "14 November 2022",
                     "version": 2022041905
                 }
             ]
@@ -115,7 +115,7 @@
                 },
                 {
                     "name": "3.11.11",
-                    "releaseDate": "14 October 2022",
+                    "releaseDate": "14 November 2022",
                     "version": 2021051711
                 }
             ]
@@ -293,7 +293,7 @@
                 },
                 {
                     "name": "3.9.18",
-                    "releaseDate": "14 October 2022",
+                    "releaseDate": "14 November 2022",
                     "version": 2020061518
                 }
             ]


### PR DESCRIPTION
Must be 14 November 2022 instead of 14 October 2022

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/430"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

