### PR TITLE
Added note regarding variable naming

### DIFF
--- a/docs/guides/templates/index.md
+++ b/docs/guides/templates/index.md
@@ -413,7 +413,7 @@ public function export_for_template(renderer_base $output) {
 }
 ```
 
-:::Tip
+:::tip
 
 When naming variables in your export data, be careful not to reuse names of helpers such as `str` or `js` - these will silently fail. Try to keep your variable names short but descriptive.
 

--- a/docs/guides/templates/index.md
+++ b/docs/guides/templates/index.md
@@ -419,7 +419,6 @@ When naming variables in your export data, be careful not to reuse names of help
 
 :::
 
-
 The rendering method can now use templates to render the object:
 
 ```php

--- a/docs/guides/templates/index.md
+++ b/docs/guides/templates/index.md
@@ -413,6 +413,13 @@ public function export_for_template(renderer_base $output) {
 }
 ```
 
+:::Tip
+
+When naming variables in your export data, be careful not to reuse names of helpers such as `str` or `js` - these will silently fail. Try to keep your variable names short but descriptive.
+
+:::
+
+
 The rendering method can now use templates to render the object:
 
 ```php


### PR DESCRIPTION
I spent a good while trying to debug why my variables weren't able to be rendered until I realised I had variables name clashes with core template helper methods.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/443"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

