### PR TITLE
Developer Meeting Jan 23

### DIFF
--- a/general/community/meetings/202301.md
+++ b/general/community/meetings/202301.md
@@ -1,13 +1,13 @@
 ---
-title: Developer meeting - December 2022
-sidebar_label: December 2022
+title: Developer meeting - January 2023
+sidebar_label: January 2023
 tags:
   - Developer meetings
 ---
 
 ### Details
 
-Tuesday 13 December 2022 at 08:00 UTC.
+Tuesday 31st January 2023 at 08:00 UTC.
 
 [BBB Meeting link](https://moodle.org/mod/bigbluebuttonbn/view.php?id=8596)
 
@@ -19,4 +19,4 @@ We have two presentations from Moodle community developers and one discussion wi
 
 1. An approach to Moodle builds automated testing for frequent prod-release - by [Alistair Spark](https://moodle.org/user/profile.php?id=1434260).
 2. Getting started with PHP Unit Tests - by [Sarah Cotton](https://moodle.org/user/profile.php?id=1595379).
-3. Integration discussion, with Marie Achour and Matt Porritt (Moodle HQ).
+3. Integrations listening session / discussion, with Marie Achour and Matt Porritt (Moodle HQ).

--- a/general/community/meetings/index.md
+++ b/general/community/meetings/index.md
@@ -12,8 +12,8 @@ sidebar_label: Meetings
 Developer meetings are open to anyone interested in Moodle development.
 
 :::important
-Our next Developer meeting is on 13th December 2022.
-The agenda and meeting link are in the [Developer meeting December 2022 notes](./202212.md)
+Our next Developer meeting is now on 31st January 2023.
+The agenda and meeting link are in the [Developer meeting January 2023 notes](./202301.md)
 
 If there are any topics that you would like to present or discuss at a developer meeting, please contact [Aurelie Soulier](https://moodle.org/user/profile.php?id=5177207).
 
@@ -21,9 +21,10 @@ If there are any topics that you would like to present or discuss at a developer
 
 ## Past meeting notes
 
-### 2022
+### 2023
+- [Developer meeting January 2023](./202301.md)
 
-- [Developer meeting December 2022](./202212.md)
+### 2022
 - [Developer meeting October 2022](./202210.md)
 - [Developer meeting June 2022](./202206.md)
 - [Developer meeting April 2022](./202204.md)


### PR DESCRIPTION
the December meeting has been postponed to January 2023 so I'm making the necessary changes here.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/457"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

