### PR TITLE
[docs] Point to the latest release

### DIFF
--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -69,7 +69,7 @@ const sidebars = {
         {
             label: 'Release notes',
             type: 'link',
-            href: '/general/releases/4.0',
+            href: '/general/releases/4.1',
         },
         {
             label: 'Projects',


### PR DESCRIPTION
The current "Release notes" link in the sidebar menu in Guides is still pointing to 4.0. This patch updates the link to 4.1.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/464"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

