### PR TITLE
Migrate various YUI docs

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1560,12 +1560,12 @@ String_deprecation:
 Subject_Access_Request_FAQ:
 - filePath: "/docs/apis/subsystems/privacy/faq.md"
   slug: "/docs/apis/subsystems/privacy/faq"
+Tag_API:
+- filePath: "/docs/apis/subsystems/tag/index.md"
+  slug: "/docs/apis/subsystems/tag/"
 Task_API:
 - filePath: "/docs/apis/subsystems/task/index.md"
   slug: "/docs/apis/subsystems/task/"
-Tag_API:
-    - filePath: "/docs/apis/subsystems/tag/index.md"
-      slug: "/docs/apis/subsystems/tag/"
 Templates:
 - filePath: "/docs/guides/templates/index.md"
   slug: "/docs/guides/templates/"
@@ -1614,6 +1614,9 @@ Using_the_Moodle_App_in_a_browser:
 Writing_acceptance_tests:
 - filePath: "/general/development/tools/behat/writing.md"
   slug: "/general/development/tools/behat/writing"
+YUI:
+- filePath: "/docs/guides/javascript/yui/index.md"
+  slug: "/docs/guides/javascript/yui/"
 html_writer:
 - filePath: "/docs/apis/core/htmlwriter/index.md"
   slug: "/docs/apis/core/htmlwriter/"

--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1617,6 +1617,9 @@ Writing_acceptance_tests:
 YUI:
 - filePath: "/docs/guides/javascript/yui/index.md"
   slug: "/docs/guides/javascript/yui/"
+YUI/Modules:
+- filePath: "/docs/guides/javascript/yui/modules.md"
+  slug: "/docs/guides/javascript/yui/modules"
 html_writer:
 - filePath: "/docs/apis/core/htmlwriter/index.md"
   slug: "/docs/apis/core/htmlwriter/"

--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1620,6 +1620,9 @@ YUI:
 YUI/Modules:
 - filePath: "/docs/guides/javascript/yui/modules.md"
   slug: "/docs/guides/javascript/yui/modules"
+YUI/Namespacing:
+- filePath: "/docs/guides/javascript/yui/namespacing.md"
+  slug: "/docs/guides/javascript/yui/namespacing"
 html_writer:
 - filePath: "/docs/apis/core/htmlwriter/index.md"
   slug: "/docs/apis/core/htmlwriter/"

--- a/docs/apis/_files/yui-dir.mdx
+++ b/docs/apis/_files/yui-dir.mdx
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable first-line-heading -->
 In older versions of Moodle, JavaScript was written in the YUI format. This is being phased out in favour of [JavaScript Modules](https://docs.moodle.org/dev/Javascript_Modules), although some older uses still remain in Moodle core.
 
-- [YUI/Modules](https://docs.moodle.org/dev/YUI/Modules)
+- [YUI/Modules](../../guides/javascript/yui/modules.md)
 - [YUI](../../guides/javascript/yui/index.md)
 
 :::caution

--- a/docs/apis/_files/yui-dir.mdx
+++ b/docs/apis/_files/yui-dir.mdx
@@ -2,7 +2,7 @@
 In older versions of Moodle, JavaScript was written in the YUI format. This is being phased out in favour of [JavaScript Modules](https://docs.moodle.org/dev/Javascript_Modules), although some older uses still remain in Moodle core.
 
 - [YUI/Modules](https://docs.moodle.org/dev/YUI/Modules)
-- [YUI](https://docs.moodle.org/dev/YUI)
+- [YUI](../../guides/javascript/yui/index.md)
 
 :::caution
 

--- a/docs/guides/javascript/yui/index.md
+++ b/docs/guides/javascript/yui/index.md
@@ -22,8 +22,6 @@ Originally this transition suggested the use of jQuery, but since Moodle 3.8 the
 
 The [Yahoo! User Interface (YUI)](http://yuilibrary.com) framework is a fast, powerful, modular, and [well-documented](http://yuilibrary.com/yui/docs/api/) framework with a powerful loading system.
 
-<!-- cspell:ignore yuidoc -->
-
 ## The Basics
 
 YUI is an extremely extensible, fast, modular, and powerful JavaScript framework with a very capable loading system.
@@ -103,59 +101,31 @@ Some good books:
 
 JavaScript authoring have moved along considerably in recent years, and we highly recommend that you look at using some of the available tools to help you in your development. Most of these tools are available through [Node.js](http://nodejs.org) which is relatively trivial to install on most operating systems:
 
-### Shifter
+### Grunt
 
-[Shifter](https://docs.moodle.org/dev/Javascript/Shifter) is a tool to help manage your YUI modules. It takes away some of the confusion associated with creating a YUI module (like the YUI.add line) and moves the metadata out of your module, and into a separate json file. This means that it can be picked up by Moodle to reduce the number of HTTP transactions through use of the YUI combo loader. Shifter also lints your code with jshint, and minifies your code too.
-
-The upstream YUI project use a tool called [Shifter](http://yuilibrary.com/shifter) to wrap up meta-data, rollup files, minify, and strip out debugging information from files.
-We will shortly be shifting to use of Shifter for core Moodle as it offers us many potential benefits.
-
-**Note: More information on the use of Shifter within Moodle is discussed at [JavaScript/Shifter](https://docs.moodle.org/dev/Javascript/Shifter).**
-
-#### Installation
-
-Installation is relatively simple from the node.js Packaging Manager:
-
-```bash
-    npm install shifter@SUPPORTEDVERSION -g
-```
-
-For information on the current support version see [JavaScript/Shifter#Supported version of Shifter](https://docs.moodle.org/dev/Javascript/Shifter#Supported_version_of_Shifter)
+Moodle uses [Grunt](../index.md#grunt) for most JavaScript management. We recommend reading our Grunt documentation for further information on the available commands.
 
 #### Use
 
-There are two ways to run shifter depending on your intended use.
+There are several ways to use `grunt`.
 
-During development, we recommend you run shifter in --watch mode. To do so, enter the src directory of the module you are working on and run:
-
-```bash
-cd lib/yui/src
-shifter --watch
-```
-
-For more general use, you can run shifter across the whole of Moodle using --walk:
+During development, we recommend you run grunt in _watch_ mode:
 
 ```bash
-shifter --walk --recursive
+npx grunt watch
 ```
 
-...from your Moodle wwwroot.
+To build all YUI modules across Moodle you can call `grunt` by running the following command from the root directory:
 
-Read more about shifter: https://moodle.org/mod/forum/discuss.php?d=217450
+```bash
+npx grunt yui
+```
 
 ### JSHint
 
 [JSHint](http://jshint.com) is a JSLint derivative for checking your code. This includes checking for errors and recommended stylistic approaches to writing JavaScript.
 
 Since Moodle 2.5, a JSHint configuration is also included in the Moodle codebase to inform the tester of our preferences and recommendations.
-
-#### Installation
-
-Installation is relatively simple:
-
-```bash
-    npm install jshint -g
-```
 
 #### Use
 
@@ -164,7 +134,7 @@ Many IDEs and editors will automatically detect if you have JSHint installed and
 To run jshint on the command line, simply pass it the file that you wish to check:
 
 ```bash
-    jshint blocks/fruit/yui/fruitbowl/fruitbowl.js
+npx jshint blocks/fruit/yui/fruitbowl/fruitbowl.js
 ```
 
 #### Documentation
@@ -173,36 +143,6 @@ There's a variety of documentation on JSHint and the error messages it returns. 
 
 - [JSHint](http://jshint.com)
 - [JSLint Error Explanations](http://jslinterrors.com)
-
-### YUIDoc
-
-[YUIDoc](http://yui.github.com/yuidoc/) is a documentation system. It can work with any type of code, but is designed with JavaScript in mind.
-It's the documentation system used to create the YUI core API documentation, and will soon be used to create API documentation for Moodle-specific YUI modules in core.
-
-#### Installation
-
-Installation is relatively simple:
-
-```bash
-    npm install yuidocjs -g
-```
-
-#### Use
-
-To run yuidoc across the entirety of Moodle JavaScript, from the root directory run:
-
-```bash
-    yuidoc
-```
-
-Whilst writing your documentation, you may also like to run yuidoc in server mode. See the --server option for help on how to do this.
-
-#### Documentation
-
-There's a variety of documentation on JSHint and the error messages it returns. Start off with the jshint website:
-
-- [YUIDoc Project Documentation](http://yui.github.com/yuidoc/)
-- [YUIDoc Syntax Reference](http://yui.github.com/yuidoc/syntax/index.html)
 
 ## Moodle Settings for JavaScript Development
 

--- a/docs/guides/javascript/yui/index.md
+++ b/docs/guides/javascript/yui/index.md
@@ -1,0 +1,233 @@
+---
+title: YUI
+tags:
+  - AJAX
+  - Javascript
+  - YUI
+---
+
+import DeprecatedSince from '../../../../src/components/DeprecatedSince';
+
+<DeprecatedSince versions={["2.9"]} />
+
+:::caution
+
+As of Moodle 2.9 we are transitioning away from YUI to AMD modules. This transition will take a long time, but it is important because the YUI team have [stopped all new development on the YUI library](http://yahooeng.tumblr.com/post/96098168666/important-announcement-regarding-yui). See [JavaScript Modules](https://docs.moodle.org/dev/_Javascript_Modules_) for more information.
+
+:::
+
+This document provides an brief overview of Moodle's use of YUI.
+
+Originally this transition suggested the use of jQuery, but since Moodle 3.8 the recommendation is to write Native Vanilla code in the ES2015 module style.
+
+The [Yahoo! User Interface (YUI)](http://yuilibrary.com) framework is a fast, powerful, modular, and [well-documented](http://yuilibrary.com/yui/docs/api/) framework with a powerful loading system.
+
+<!-- cspell:ignore yuidoc -->
+
+## The Basics
+
+YUI is an extremely extensible, fast, modular, and powerful JavaScript framework with a very capable loading system.
+A number of modules are available for YUI providing a wide range of functionality to suit most situations.
+All of the core YUI modules are documented on their [API](http://yuilibrary.com/yui/docs/api/). We are working to put together documentation for moodle's YUI modules too.
+
+Since version 2.4, Moodle has included SimpleYUI to expose several features natively without requiring you to specify which features you wish to use. Prior to this a basic YUI was included. SimpleYUI loads a number of standard modules and makes them available on the global Y namespace. These include:
+
+- [`YUI`](http://yuilibrary.com/yui/docs/api/classes/YUI.html)
+- [`oop`](http://yuilibrary.com/yui/docs/api/modules/oop.html)
+- [`dom`](http://yuilibrary.com/yui/docs/api/classes/DOM.html)
+- [`event-custom-base`](http://yuilibrary.com/yui/docs/api/modules/event-custom-base.html)
+- [`event-base`](http://yuilibrary.com/yui/docs/api/modules/event-base.html)
+- [`node`](http://yuilibrary.com/yui/docs/api/classes/Node.html)
+- [`event-delegate`](http://yuilibrary.com/yui/docs/api/modules/event-delegate.html)
+- [`io-base`](http://yuilibrary.com/yui/docs/api/modules/io-base.html)
+- [`json-parse`](http://yuilibrary.com/yui/docs/api/modules/json-parse.html)
+- [`transition`](http://yuilibrary.com/yui/docs/api/modules/transition.html)
+- [`selector-css3`](http://yuilibrary.com/yui/docs/api/modules/selector-css3.html)
+- [`dom-style-ie`](http://yuilibrary.com/yui/docs/api/modules/dom-style-ie.html)
+- [`querystring-stringify-simple`](http://yuilibrary.com/yui/docs/api/modules/querystring-stringify-simple.html)
+
+Whilst accessing the global Y variable will suffice for many uses, we highly recommend that you look at writing your code within a [YUI module](https://docs.moodle.org/dev/How_to_create_a_YUI_3_module). It is also possible to use one of the other methods to include your JavaScript. These include:
+
+- inclusion of a JavaScript file (e.g. a file included by a theme); and
+- inclusion of a module.js file.
+
+It is also possible to use JavaScript within a Database module - see the JavaScript template setting for further information.
+
+## Modularity
+
+YUI is extremely modular with different components, features, plugins, and tasks broken down into YUI Modules. When using YUI, you can choose which modules you wish to use and the YUI loader will go away and retrieve those modules, determining their dependencies automatically. This has the effect of separating out the load and execution phases of JavaScript component loading and also allows for asynchronous loading of the code. For a deeper dive on the benefits of this separation, it's well worth watching this video entitled [YUI3 Below the Surface](http://www.youtube.com/watch?v=XdM0GJEnlNU).
+
+In order to benefit from these features, it is necessary to wrap your code in a registration function. This wrapper defines the name of the module, wraps the code in a closure to offer module sandboxing, and defines meta-data to inform the loader of any specific dependencies. A complete wrapper is shown below:
+
+```javascript
+YUI.add('moodle-block_fruit-fruitbowl', function(Y) {
+  // Your module code goes here.
+}, '@VERSION@', {
+  requires: ['panel']
+});
+```
+
+Note: From Moodle 2.5, it is possible to write your modules in such a way that you do not have to explicitly specify write the YUI.add() wrapper.
+
+To then make use of this code, you then have to use it. For example:
+
+```javascript
+YUI().use('moodle-block_fruit-fruitbowl', function(Y) {
+  // Use the class you defined earlier.
+});
+```
+
+## Documentation and further information
+
+Other YUI documentation you may find useful:
+
+- [How to create a YUI 3 module](https://docs.moodle.org/dev/How_to_create_a_YUI_3_module)
+- [API Documentation for the main YUI library](http://yuilibrary.com/yui/docs/api/)
+- [YUI User Guides](http://yuilibrary.com/yui/docs/guides/)
+- [YUI Tutorials](http://yuilibrary.com/yui/docs/tutorials/)
+- [YUI Examples](http://yuilibrary.com/yui/docs/examples/)
+- [YUI Forums](http://yuilibrary.com/forum/)
+
+We will soon be adding API Documentation for Moodle-specific YUI modules in addition to the core YUI library.
+
+## Books:
+
+<!-- cspell:ignore Zakas -->
+
+Some good books:
+
+- [YUI 3 Cookbook](http://shop.oreilly.com/product/0636920013303.do) by Evan Goer
+- [Maintainable JavaScript](http://shop.oreilly.com/product/0636920025245.do) by Nicholas C. Zakas
+
+## Useful tools
+
+JavaScript authoring have moved along considerably in recent years, and we highly recommend that you look at using some of the available tools to help you in your development. Most of these tools are available through [Node.js](http://nodejs.org) which is relatively trivial to install on most operating systems:
+
+### Shifter
+
+[Shifter](https://docs.moodle.org/dev/Javascript/Shifter) is a tool to help manage your YUI modules. It takes away some of the confusion associated with creating a YUI module (like the YUI.add line) and moves the metadata out of your module, and into a separate json file. This means that it can be picked up by Moodle to reduce the number of HTTP transactions through use of the YUI combo loader. Shifter also lints your code with jshint, and minifies your code too.
+
+The upstream YUI project use a tool called [Shifter](http://yuilibrary.com/shifter) to wrap up meta-data, rollup files, minify, and strip out debugging information from files.
+We will shortly be shifting to use of Shifter for core Moodle as it offers us many potential benefits.
+
+**Note: More information on the use of Shifter within Moodle is discussed at [JavaScript/Shifter](https://docs.moodle.org/dev/Javascript/Shifter).**
+
+#### Installation
+
+Installation is relatively simple from the node.js Packaging Manager:
+
+```bash
+    npm install shifter@SUPPORTEDVERSION -g
+```
+
+For information on the current support version see [JavaScript/Shifter#Supported version of Shifter](https://docs.moodle.org/dev/Javascript/Shifter#Supported_version_of_Shifter)
+
+#### Use
+
+There are two ways to run shifter depending on your intended use.
+
+During development, we recommend you run shifter in --watch mode. To do so, enter the src directory of the module you are working on and run:
+
+```bash
+cd lib/yui/src
+shifter --watch
+```
+
+For more general use, you can run shifter across the whole of Moodle using --walk:
+
+```bash
+shifter --walk --recursive
+```
+
+...from your Moodle wwwroot.
+
+Read more about shifter: https://moodle.org/mod/forum/discuss.php?d=217450
+
+### JSHint
+
+[JSHint](http://jshint.com) is a JSLint derivative for checking your code. This includes checking for errors and recommended stylistic approaches to writing JavaScript.
+
+Since Moodle 2.5, a JSHint configuration is also included in the Moodle codebase to inform the tester of our preferences and recommendations.
+
+#### Installation
+
+Installation is relatively simple:
+
+```bash
+    npm install jshint -g
+```
+
+#### Use
+
+Many IDEs and editors will automatically detect if you have JSHint installed and pass your code through it for you, reporting any errors as you go.
+
+To run jshint on the command line, simply pass it the file that you wish to check:
+
+```bash
+    jshint blocks/fruit/yui/fruitbowl/fruitbowl.js
+```
+
+#### Documentation
+
+There's a variety of documentation on JSHint and the error messages it returns. Start off with the jshint website:
+
+- [JSHint](http://jshint.com)
+- [JSLint Error Explanations](http://jslinterrors.com)
+
+### YUIDoc
+
+[YUIDoc](http://yui.github.com/yuidoc/) is a documentation system. It can work with any type of code, but is designed with JavaScript in mind.
+It's the documentation system used to create the YUI core API documentation, and will soon be used to create API documentation for Moodle-specific YUI modules in core.
+
+#### Installation
+
+Installation is relatively simple:
+
+```bash
+    npm install yuidocjs -g
+```
+
+#### Use
+
+To run yuidoc across the entirety of Moodle JavaScript, from the root directory run:
+
+```bash
+    yuidoc
+```
+
+Whilst writing your documentation, you may also like to run yuidoc in server mode. See the --server option for help on how to do this.
+
+#### Documentation
+
+There's a variety of documentation on JSHint and the error messages it returns. Start off with the jshint website:
+
+- [YUIDoc Project Documentation](http://yui.github.com/yuidoc/)
+- [YUIDoc Syntax Reference](http://yui.github.com/yuidoc/syntax/index.html)
+
+## Moodle Settings for JavaScript Development
+
+The following settings will ensure that the js loaded by your browser is relatively readable.
+
+Make sure that :
+
+- your  Development / Debugging / Debug messages is set to "Developer : Extra Debug Moodle Messages ...." - Moodle will then use the debug non-minified and thus more readable YUI 2 and YUI 3 library files.
+- You will probably want to change some of the settings at "Home / Site administration / Appearance / AJAX and JavaScript" :
+  - YUI combo loading - you probably want to turn this off so that files are not combined.
+  - JavaScript caching and compressing - turn this off so that your custom JS code is not minified.
+  - Check the other settings on this page to see that they are as you would expect them to be.
+
+You might want to add the following code to your config.php file when developing or debugging JavaScript code:
+
+```php
+// For javascript development or debugging.
+$CFG->cachejs = false;
+$CFG->yuicomboloading = false;
+$CFG->yuiloglevel = 'debug';
+$CFG->debug = 32767;
+```
+
+## See Also
+
+- [JavaScript Modules](https://docs.moodle.org/dev/Javascript_Modules)
+- [jQuery](../jquery/index.md)
+- [JavaScript FAQ](https://docs.moodle.org/dev/JavaScript_FAQ)

--- a/docs/guides/javascript/yui/modules.md
+++ b/docs/guides/javascript/yui/modules.md
@@ -1,27 +1,29 @@
 ---
-title: YUI/Modules
+title: YUI Modules
 tags:
   - Javascript
+  - YUI
 ---
-{{Deprecated|version=2.9}}
 
-Note: As of Moodle 2.9 we are transitioning away from YUI to AMD modules. This transition will take a long time, but it is important because the YUI team have stopped all new development on the YUI library ( http://yahooeng.tumblr.com/post/96098168666/important-announcement-regarding-yui ). See [JavaScript Modules](https://docs.moodle.org/dev/_Javascript_Modules_) for more information.
+import DeprecatedSince from '../../../../src/components/DeprecatedSince';
 
-{{Moodle 2.5}}
-{{Moodle 2.6}}
-{{Moodle 2.7}}
+<DeprecatedSince versions={["2.9"]} />
+
+:::caution
+
+As of Moodle 2.9 we are transitioning away from YUI to AMD modules. This transition will take a long time, but it is important because the YUI team have [stopped all new development on the YUI library](http://yahooeng.tumblr.com/post/96098168666/important-announcement-regarding-yui). See [JavaScript Modules](https://docs.moodle.org/dev/_Javascript_Modules_) for more information.
+
+:::
+
+<!-- cspell:ignore fruitbowl -->
 
 ## YUI modules
 
-You may want to [Jump straight to the complete example](https://docs.moodle.org/dev/#Additional_functions_instead_of_anonymous_functions).
+You may want to [Jump straight to the complete example](#additional-functions-instead-of-anonymous-functions).
 
 ### What is a module and why would I want to use one?
 
-Many people are used to writing their JavaScript code either inline, or in a
-separate file included using <script> tags in their HTML. Although both of
-these are supported within Moodle, we highly recommend investing a little
-time in looking into the [YUI](./index.md) module system as it offers some really great
-features which will benefit you in the long run.
+Many people are used to writing their JavaScript code either inline, or in a separate file included using `<script>` tags in their HTML. Although both of these are supported within Moodle, we highly recommend investing a little time in looking into the [YUI](./index.md) module system as it offers some really great features which will benefit you in the long run.
 
 These features and benefits include:
 
@@ -38,10 +40,7 @@ By using existing modules in your code, you can benefit in other ways too, such 
 - a consistent look and feel across Moodle; and
 - most of the edge cases already catered for.
 
-The Moodle community is in the process of improving much of its JavaScript
-in areas such as code, documentation, and processes. This includes updating
-older code, adding documentation, seeding dependency information for
-modules to improve load efficiency for browsers, and much more.
+The Moodle community is in the process of improving much of its JavaScript in areas such as code, documentation, and processes. This includes updating older code, adding documentation, seeding dependency information for modules to improve load efficiency for browsers, and much more.
 
 You may find the following resources particularly helpful:
 
@@ -50,9 +49,7 @@ You may find the following resources particularly helpful:
 
 ### Structure and naming
 
-A YUI module is structured in a particular way, both on file, and in the
-file itself. Before you start writing your module, you need to know a few
-bits of information:
+A YUI module is structured in a particular way, both on file, and in the file itself. Before you start writing your module, you need to know a few pieces of information:
 
 - what is the [Frankenstyle](/general/development/policies/codingstyle/frankenstyle) name of your Moodle plugin;
 - what does your YUI module do in a single word.
@@ -60,17 +57,20 @@ bits of information:
 You can use these pieces of information to work out the namespace for your
 plugin. This namespace fits into the template:
 
-  moodle-FRANKENSTYLE-MODULENAME
+```javascript
+moodle-FRANKENSTYLE-MODULENAME
+```
 
-As an example, writing a plugin for the fictional **'fruit**' **block** which
-offers fruit to users:
+As an example, writing a plugin for the fictional `fruit` **block** which offers fruit to users:
 
-- you may decide to call this module the **'fruitbowl**' as the module offers fruit to users, and presents it in an appealing way so that they can see it.
+- you may decide to call this module the `fruitbowl` as the module offers fruit to users, and presents it in an appealing way so that they can see it.
 - The block is fruit, therefore the frankenstyle name is block_fruit.
 
 Therefor the name for this module will be:
 
-    moodle-block_fruit-fruitbowl
+```javascript
+moodle-block_fruit-fruitbowl
+```
 
 The other thing that you need to know in order to create your first module
 is where in your plugin the code needs to be.
@@ -92,8 +92,11 @@ yui/
 
 *Note: Moodle 2.5 onwards is backwards compatibly with the previous structure.*
 
-So in the case of moodle-block_fruit-fruitbowl, the JavaScript code will need to go into:
-    /block/fruit/yui/src/fruitbowl/js/fruitbowl.js
+So in the case of `moodle-block_fruit-fruitbowl`, the JavaScript code will need to go into:
+
+```bash
+/block/fruit/yui/src/fruitbowl/js/fruitbowl.js
+```
 
 (Sorry, it does look a little more complicated than it really is)
 
@@ -103,19 +106,14 @@ Now that you know where your code needs to be on disk, you can actually include 
 
 ### Including your module from your PHP code
 
-Rather than using <script> tags to include JavaScript code, Moodle makes
+Rather than using `<script>` tags to include JavaScript code, Moodle makes
 use of the YUI loader and a single inline script tag in the page footer.
 
 Moving JavaScript to a page footer is important to the perceived performance of a page, and the YUI loader helps further.
 
-The YUI loader also intelligiently loads page dependencies, in as few
-requests as possible by making use of a combo-loader system.
-It will also attempt to use the appropriate version of your JavaScript
-depending on your $CFG->jsrev settings. In normal operation, a minified
-version of your code is used; and with $CFG->cachejs false, then a debugging version is used.
+The YUI loader also intelligently loads page dependencies, in as few requests as possible by making use of a combo-loader system. It will also attempt to use the appropriate version of your JavaScript depending on your `$CFG->jsrev` settings. In normal operation, a minified version of your code is used; and with `$CFG->cachejs` false, then a debugging version is used.
 
-To ensure that your module is loaded, there is a **yui_module()**
-function on the page requirements class. This can be accessed using:
+To ensure that your module is loaded, there is a `yui_module()` function on the page requirements class. This can be accessed using:
 
 ```php
 $PAGE->requires->yui_module();
@@ -123,13 +121,13 @@ $PAGE->requires->yui_module();
 $this->page->requires->yui_module();
 ```
 
-The yui_module function takes the module name, and the init function to
-call as it's first two arguments, and an optional list of arguments as a
-third argument:
+The `yui_module` function takes the module name, and the init function to call as it's first two arguments, and an optional list of arguments as a third argument:
 
 ```php
-$PAGE->requires->yui_module('moodle-block_fruit-fruitbowl',
-        'M.block_fruit.fruitbowl.init');
+$PAGE->requires->yui_module(
+    'moodle-block_fruit-fruitbowl',
+    'M.block_fruit.fruitbowl.init'
+);
 ```
 
 #### Passing arguments from your PHP to your module
@@ -139,12 +137,10 @@ using the optional third argument to yui_module which accepts an array of
 arguments.
 
 ```php
-$PAGE->requires->yui_module('moodle-block_fruit-fruitbowl',
-        'M.block_fruit.fruitbowl.init',
-        array(
-            'value1',
-            'value2',
-        ));
+$PAGE->requires->yui_module('moodle-block_fruit-fruitbowl', 'M.block_fruit.fruitbowl.init',[
+    'value1',
+    'value2',
+]);
 ```
 
 These will be presented to the JavaScript function you name:
@@ -158,12 +154,11 @@ init = function(argument1, argument2) {
 Often it makes more sense to pass a single argument with an associative array:
 
 ```php
-$PAGE->requires->yui_module('moodle-block_fruit-fruitbowl',
-        'M.block_fruit.fruitbowl.init',
-        array(array(
-            'key1' => 'value1',
-            'key2' => 'value2',
-        )));
+$PAGE->requires->yui_module('moodle-block_fruit-fruitbowl', 'M.block_fruit.fruitbowl.init',
+[[
+    'key1' => 'value1',
+    'key2' => 'value2',
+]]);
 ```
 
 These will be presented to the JavaScript function you name:
@@ -176,26 +171,21 @@ init = function(params) {
 
 ### A basic module
 
-The most common use-case for JavaScript in Moodle is to utilise existing
-modules to do something. Your module isn't intended to be reused, or
-extended by some other piece of code. In these cases, you want to keep
-things simple.
+The most common use-case for JavaScript in Moodle is to utilise existing modules to do something. Your module isn't intended to be reused, or extended by some other piece of code. In these cases, you want to keep things simple.
 
 This section will build up the YUI module gradually, but you can cheat and skip to the [completed example](https://docs.moodle.org/dev/#Additional_functions_instead_of_anonymous_functions).
 
 #### Namespacing
 
-One of the great benefits of using YUI is the ability to sandbox code in
-such a way that you can be sure that it won't interfere with other JS code
-in Moodle, this is done by placing your object in a JavaScript object.
-Using our fictitious example, this namespace is very similar to the module
-name namespace:
+One of the great benefits of using YUI is the ability to sandbox code in such a way that you can be sure that it won't interfere with other JS code in Moodle, this is done by placing your object in a JavaScript object. Using our fictitious example, this namespace is very similar to the module name namespace:
 
-  M.FRANKENSTYLE.MODNAME
+```javascript
+M.FRANKENSTYLE.MODNAME
+```
 
 As a JavaScript object this would look like:
 
-```bash
+```json
 M: {
   FRANKENSTYLE: {
     MODNAME: {
@@ -213,21 +203,13 @@ M.block_fruit.fruitbowl = {};
 var NS = M.block_fruit.fruitbowl;
 ```
 
-This ensures that any existing code on the M.block_fruit object is not
-inadvertently overwritten, but also ensures that the definition for the
-fruitbowl code is clean.
+This ensures that any existing code on the M.block_fruit object is not inadvertently overwritten, but also ensures that the definition for the fruitbowl code is clean.
 
-That's to say that, if you have already used your fruitbowl code once on
-the page, and have modified it in some way (for example to override a
-function), then the next time it is used, it will be in it's original state
-with the original function.
+That's to say that, if you have already used your fruitbowl code once on the page, and have modified it in some way (for example to override a function), then the next time it is used, it will be in it's original state with the original function.
 
 #### Initialisation
 
-Once you have your namespace, you'll want to create one or more functions on this namespace in which to put your code. Typically, we use an 'init' function to perform the initial setup.
-The amount that this code does should be kept to a minimum because every
-piece of JavaScript which has to be executed at page load is a piece of
-code slowing the page down. As a best practice:
+Once you have your namespace, you'll want to create one or more functions on this namespace in which to put your code. Typically, we use an 'init' function to perform the initial setup. The amount that this code does should be kept to a minimum because every piece of JavaScript which has to be executed at page load is a piece of code slowing the page down. As a best practice:
 
 - don't modify the DOM unless you need to do so;
 - don't create anything you aren't using immediately (for example a JS dialogue hidden until first used); and
@@ -241,7 +223,7 @@ NS.init = function() {
     Y.delegate('click', function(e) {
         // Alert users when they've clicked on some fruit to tell them the obvious.
         alert("You clicked on some fruit");
-        
+
         // Add a border to the fruit so we can see that it was selected.
         e.setStyle('border', '1px solid black');
     }, Y.config.doc, '.fruit');
@@ -250,24 +232,19 @@ NS.init = function() {
 
 #### Separation of code from configuration and style (loose coupling)
 
-As another best practice, we encourage you to separate out the code from
-configuration, and not to apply any CSS styles directly. Instead, use
-techniques to move the configuration out of the code itself and into
-variables or attributes, and use CSS classes which the theme can modify.
+As another best practice, we encourage you to separate out the code from configuration, and not to apply any CSS styles directly. Instead, use techniques to move the configuration out of the code itself and into variables or attributes, and use CSS classes which the theme can modify.
 
-Typically to make it easier to read your code, and to modify it later, we
-recommend creating two static objects at the top of your code: one for CSS
-selectors, and one for CSS class names.
+Typically to make it easier to read your code, and to modify it later, we recommend creating two static objects at the top of your code: one for CSS selectors, and one for CSS class names.
 
 ```javascript
 var CSS = {
-        FRUIT: 'fruit',
-        SELECTED: 'selected'
-    },
-    SELECTORS = {
-        FRUIT: '.' + CSS.FRUIT
-    },
-    NS;
+    FRUIT: 'fruit',
+    SELECTED: 'selected'
+};
+var SELECTORS = {
+    FRUIT: '.' + CSS.FRUIT
+};
+var NS;
 
 M.block_fruit = M.block_fruit || {};
 NS = M.block_fruit.fruitbowl = {};
@@ -276,27 +253,20 @@ NS.init = function() {
     Y.delegate('click', function() {
         // Alert users when they've clicked on some fruit to tell them the obvious.
         alert("You clicked on some fruit");
-        
+
         // Apply the relevant class which contains indications that this fruit was selected.
         e.target.addClass(CSS.SELECTED);
     }, Y.config.doc, SELECTORS.FRUIT, this);
 };
 ```
 
-With this change, if at a later date you need to change the styling on a
-selected fruit, this can be done in the theme. An alternative theme can
-also choose to theme the same item in a completely different way.
+With this change, if at a later date you need to change the styling on a selected fruit, this can be done in the theme. An alternative theme can also choose to theme the same item in a completely different way.
 
-It also means that if you need to change the class names, you can do so
-once in the JavaScript without making it difficult to work out the purpose
-of a particular line of code from git.
+It also means that if you need to change the class names, you can do so once in the JavaScript without making it difficult to work out the purpose of a particular line of code from git.
 
 #### Additional functions instead of anonymous functions
 
-Although it's often quicker to write an inline anonymous function when
-you write your event handlers, loops, and at other times, it's often much
-easier to read the code if you move it to a function on your namespace and
-call it accordingly.
+Although it's often quicker to write an inline anonymous function when you write your event handlers, loops, and at other times, it's often much easier to read the code if you move it to a function on your namespace and call it accordingly.
 
 ```javascript
 var CSS = {
@@ -318,18 +288,10 @@ NS.init = function() {
 NS.handle_selection = function(e) {
     // Alert users when they've clicked on some fruit to tell them the obvious.
     alert("You clicked on some fruit");
-    
+
     // Apply the relevant class which contains indications that this fruit was selected.
     e.target.addClass(CSS.SELECTED);
 };
 ```
 
-Now you can clearly see your what your initialiser does, and you can call handle_selection for other events too without duplicating code.
-
-### A re-usable module
-
-{{Work in progress}} This section of documentation has yet to be written.
-
-### Notes
-
-There is a proposal to [alter the namespace](https://docs.moodle.org/dev/YUI/Namespacing) for YUI modules. This is likely to be implemented from Moodle 2.7 onwards.
+Now you can clearly see your what your initialiser does, and you can call `handle_selection` for other events too without duplicating code.

--- a/docs/guides/javascript/yui/modules.md
+++ b/docs/guides/javascript/yui/modules.md
@@ -45,7 +45,6 @@ The Moodle community is in the process of improving much of its JavaScript in ar
 You may find the following resources particularly helpful:
 
 - [YUI](./index.md); and
-- [YUI/Shifter](https://docs.moodle.org/dev/YUI/Shifter).
 
 ### Structure and naming
 

--- a/docs/guides/javascript/yui/modules.md
+++ b/docs/guides/javascript/yui/modules.md
@@ -71,12 +71,9 @@ Therefor the name for this module will be:
 moodle-block_fruit-fruitbowl
 ```
 
-The other thing that you need to know in order to create your first module
-is where in your plugin the code needs to be.
+The other thing that you need to know in order to create your first module is where in your plugin the code needs to be.
 
-As described in the [JavaScript/Shifter#How do I write a YUI module which uses Shifter.3F](https://docs.moodle.org/dev/Javascript/Shifter#How_do_I_write_a_YUI_module_which_uses_Shifter.3F) documentation, the code will need to go in your plugin directory inside a yui directory.
-
-Since Moodle 2.5, the structure for this directory is:
+The code will need to go in your plugin directory inside a `yui` directory. Since Moodle 2.5, the structure for this directory is:
 
 ```bash
 yui/
@@ -86,7 +83,7 @@ yui/
         |-- js
         |   |-- fruitbowl.js
         |-- meta
-            |-- fruitbowl.json
+        |   |-- fruitbowl.json
 ```
 
 *Note: Moodle 2.5 onwards is backwards compatibly with the previous structure.*
@@ -98,8 +95,6 @@ So in the case of `moodle-block_fruit-fruitbowl`, the JavaScript code will need 
 ```
 
 (Sorry, it does look a little more complicated than it really is)
-
-See the notes in the [Shifter](https://docs.moodle.org/dev/Javascript/Shifter#How_do_I_write_a_YUI_module_which_uses_Shifter.3F) documentation for details on the build.json and meta/MODULENAME.json file contents.
 
 Now that you know where your code needs to be on disk, you can actually include and write it.
 

--- a/docs/guides/javascript/yui/modules.md
+++ b/docs/guides/javascript/yui/modules.md
@@ -1,0 +1,335 @@
+---
+title: YUI/Modules
+tags:
+  - Javascript
+---
+{{Deprecated|version=2.9}}
+
+Note: As of Moodle 2.9 we are transitioning away from YUI to AMD modules. This transition will take a long time, but it is important because the YUI team have stopped all new development on the YUI library ( http://yahooeng.tumblr.com/post/96098168666/important-announcement-regarding-yui ). See [JavaScript Modules](https://docs.moodle.org/dev/_Javascript_Modules_) for more information.
+
+{{Moodle 2.5}}
+{{Moodle 2.6}}
+{{Moodle 2.7}}
+
+## YUI modules
+
+You may want to [Jump straight to the complete example](https://docs.moodle.org/dev/#Additional_functions_instead_of_anonymous_functions).
+
+### What is a module and why would I want to use one?
+
+Many people are used to writing their JavaScript code either inline, or in a
+separate file included using <script> tags in their HTML. Although both of
+these are supported within Moodle, we highly recommend investing a little
+time in looking into the [YUI](./index.md) module system as it offers some really great
+features which will benefit you in the long run.
+
+These features and benefits include:
+
+- a host of existing modules that you can hook into and use; which offer
+- code sandboxing to ensure that you always have a good/clean copy of the code; with
+- powerful dependency management; which can utilise
+- asynchronous loading to load dependencies in parallel; and
+- loading of dependencies in any order (you don't have to include script tags in a set order); and
+- separation of loading from execution; and
+- combo loading to reduce the number of individual HTTP transactions.
+
+By using existing modules in your code, you can benefit in other ways too, such as:
+
+- a consistent look and feel across Moodle; and
+- most of the edge cases already catered for.
+
+The Moodle community is in the process of improving much of its JavaScript
+in areas such as code, documentation, and processes. This includes updating
+older code, adding documentation, seeding dependency information for
+modules to improve load efficiency for browsers, and much more.
+
+You may find the following resources particularly helpful:
+
+- [YUI](./index.md); and
+- [YUI/Shifter](https://docs.moodle.org/dev/YUI/Shifter).
+
+### Structure and naming
+
+A YUI module is structured in a particular way, both on file, and in the
+file itself. Before you start writing your module, you need to know a few
+bits of information:
+
+- what is the [Frankenstyle](/general/development/policies/codingstyle/frankenstyle) name of your Moodle plugin;
+- what does your YUI module do in a single word.
+
+You can use these pieces of information to work out the namespace for your
+plugin. This namespace fits into the template:
+
+  moodle-FRANKENSTYLE-MODULENAME
+
+As an example, writing a plugin for the fictional **'fruit**' **block** which
+offers fruit to users:
+
+- you may decide to call this module the **'fruitbowl**' as the module offers fruit to users, and presents it in an appealing way so that they can see it.
+- The block is fruit, therefore the frankenstyle name is block_fruit.
+
+Therefor the name for this module will be:
+
+    moodle-block_fruit-fruitbowl
+
+The other thing that you need to know in order to create your first module
+is where in your plugin the code needs to be.
+
+As described in the [JavaScript/Shifter#How do I write a YUI module which uses Shifter.3F](https://docs.moodle.org/dev/Javascript/Shifter#How_do_I_write_a_YUI_module_which_uses_Shifter.3F) documentation, the code will need to go in your plugin directory inside a yui directory.
+
+Since Moodle 2.5, the structure for this directory is:
+
+```bash
+yui/
+|-- src
+    |-- fruitbowl
+        |-- build.json
+        |-- js
+        |   |-- fruitbowl.js
+        |-- meta
+            |-- fruitbowl.json
+```
+
+*Note: Moodle 2.5 onwards is backwards compatibly with the previous structure.*
+
+So in the case of moodle-block_fruit-fruitbowl, the JavaScript code will need to go into:
+    /block/fruit/yui/src/fruitbowl/js/fruitbowl.js
+
+(Sorry, it does look a little more complicated than it really is)
+
+See the notes in the [Shifter](https://docs.moodle.org/dev/Javascript/Shifter#How_do_I_write_a_YUI_module_which_uses_Shifter.3F) documentation for details on the build.json and meta/MODULENAME.json file contents.
+
+Now that you know where your code needs to be on disk, you can actually include and write it.
+
+### Including your module from your PHP code
+
+Rather than using <script> tags to include JavaScript code, Moodle makes
+use of the YUI loader and a single inline script tag in the page footer.
+
+Moving JavaScript to a page footer is important to the perceived performance of a page, and the YUI loader helps further.
+
+The YUI loader also intelligiently loads page dependencies, in as few
+requests as possible by making use of a combo-loader system.
+It will also attempt to use the appropriate version of your JavaScript
+depending on your $CFG->jsrev settings. In normal operation, a minified
+version of your code is used; and with $CFG->cachejs false, then a debugging version is used.
+
+To ensure that your module is loaded, there is a **yui_module()**
+function on the page requirements class. This can be accessed using:
+
+```php
+$PAGE->requires->yui_module();
+// or:
+$this->page->requires->yui_module();
+```
+
+The yui_module function takes the module name, and the init function to
+call as it's first two arguments, and an optional list of arguments as a
+third argument:
+
+```php
+$PAGE->requires->yui_module('moodle-block_fruit-fruitbowl',
+        'M.block_fruit.fruitbowl.init');
+```
+
+#### Passing arguments from your PHP to your module
+
+You may want to pass a set of arguments to your JavaScript. You can do so
+using the optional third argument to yui_module which accepts an array of
+arguments.
+
+```php
+$PAGE->requires->yui_module('moodle-block_fruit-fruitbowl',
+        'M.block_fruit.fruitbowl.init',
+        array(
+            'value1',
+            'value2',
+        ));
+```
+
+These will be presented to the JavaScript function you name:
+
+```javascript
+init = function(argument1, argument2) {
+    // Use the arguments here.
+};
+```
+
+Often it makes more sense to pass a single argument with an associative array:
+
+```php
+$PAGE->requires->yui_module('moodle-block_fruit-fruitbowl',
+        'M.block_fruit.fruitbowl.init',
+        array(array(
+            'key1' => 'value1',
+            'key2' => 'value2',
+        )));
+```
+
+These will be presented to the JavaScript function you name:
+
+```javascript
+init = function(params) {
+    // Use the arguments through params.key1 and params.key2.
+};
+```
+
+### A basic module
+
+The most common use-case for JavaScript in Moodle is to utilise existing
+modules to do something. Your module isn't intended to be reused, or
+extended by some other piece of code. In these cases, you want to keep
+things simple.
+
+This section will build up the YUI module gradually, but you can cheat and skip to the [completed example](https://docs.moodle.org/dev/#Additional_functions_instead_of_anonymous_functions).
+
+#### Namespacing
+
+One of the great benefits of using YUI is the ability to sandbox code in
+such a way that you can be sure that it won't interfere with other JS code
+in Moodle, this is done by placing your object in a JavaScript object.
+Using our fictitious example, this namespace is very similar to the module
+name namespace:
+
+  M.FRANKENSTYLE.MODNAME
+
+As a JavaScript object this would look like:
+
+```bash
+M: {
+  FRANKENSTYLE: {
+    MODNAME: {
+      // Your code and functions go here.
+    }
+  }
+}
+```
+
+The easiest way of creating this structure is by using the logical OR operator.
+
+```javascript
+M.block_fruit = M.block_fruit || {};
+M.block_fruit.fruitbowl = {};
+var NS = M.block_fruit.fruitbowl;
+```
+
+This ensures that any existing code on the M.block_fruit object is not
+inadvertently overwritten, but also ensures that the definition for the
+fruitbowl code is clean.
+
+That's to say that, if you have already used your fruitbowl code once on
+the page, and have modified it in some way (for example to override a
+function), then the next time it is used, it will be in it's original state
+with the original function.
+
+#### Initialisation
+
+Once you have your namespace, you'll want to create one or more functions on this namespace in which to put your code. Typically, we use an 'init' function to perform the initial setup.
+The amount that this code does should be kept to a minimum because every
+piece of JavaScript which has to be executed at page load is a piece of
+code slowing the page down. As a best practice:
+
+- don't modify the DOM unless you need to do so;
+- don't create anything you aren't using immediately (for example a JS dialogue hidden until first used); and
+- use event delegation where possible.
+
+```javascript
+M.block_fruit = M.block_fruit || {};
+var NS = M.block_fruit.fruitbowl = {};
+
+NS.init = function() {
+    Y.delegate('click', function(e) {
+        // Alert users when they've clicked on some fruit to tell them the obvious.
+        alert("You clicked on some fruit");
+        
+        // Add a border to the fruit so we can see that it was selected.
+        e.setStyle('border', '1px solid black');
+    }, Y.config.doc, '.fruit');
+};
+```
+
+#### Separation of code from configuration and style (loose coupling)
+
+As another best practice, we encourage you to separate out the code from
+configuration, and not to apply any CSS styles directly. Instead, use
+techniques to move the configuration out of the code itself and into
+variables or attributes, and use CSS classes which the theme can modify.
+
+Typically to make it easier to read your code, and to modify it later, we
+recommend creating two static objects at the top of your code: one for CSS
+selectors, and one for CSS class names.
+
+```javascript
+var CSS = {
+        FRUIT: 'fruit',
+        SELECTED: 'selected'
+    },
+    SELECTORS = {
+        FRUIT: '.' + CSS.FRUIT
+    },
+    NS;
+
+M.block_fruit = M.block_fruit || {};
+NS = M.block_fruit.fruitbowl = {};
+
+NS.init = function() {
+    Y.delegate('click', function() {
+        // Alert users when they've clicked on some fruit to tell them the obvious.
+        alert("You clicked on some fruit");
+        
+        // Apply the relevant class which contains indications that this fruit was selected.
+        e.target.addClass(CSS.SELECTED);
+    }, Y.config.doc, SELECTORS.FRUIT, this);
+};
+```
+
+With this change, if at a later date you need to change the styling on a
+selected fruit, this can be done in the theme. An alternative theme can
+also choose to theme the same item in a completely different way.
+
+It also means that if you need to change the class names, you can do so
+once in the JavaScript without making it difficult to work out the purpose
+of a particular line of code from git.
+
+#### Additional functions instead of anonymous functions
+
+Although it's often quicker to write an inline anonymous function when
+you write your event handlers, loops, and at other times, it's often much
+easier to read the code if you move it to a function on your namespace and
+call it accordingly.
+
+```javascript
+var CSS = {
+        FRUIT: 'fruit',
+        SELECTED: 'selected'
+    },
+    SELECTORS = {
+        FRUIT: '.' + CSS.FRUIT
+    },
+    NS;
+
+M.block_fruit = M.block_fruit || {};
+NS = M.block_fruit.fruitbowl = {};
+
+NS.init = function() {
+    Y.delegate('click', this.handle_selection, Y.config.doc, SELECTORS.FRUIT, this);
+};
+
+NS.handle_selection = function(e) {
+    // Alert users when they've clicked on some fruit to tell them the obvious.
+    alert("You clicked on some fruit");
+    
+    // Apply the relevant class which contains indications that this fruit was selected.
+    e.target.addClass(CSS.SELECTED);
+};
+```
+
+Now you can clearly see your what your initialiser does, and you can call handle_selection for other events too without duplicating code.
+
+### A re-usable module
+
+{{Work in progress}} This section of documentation has yet to be written.
+
+### Notes
+
+There is a proposal to [alter the namespace](https://docs.moodle.org/dev/YUI/Namespacing) for YUI modules. This is likely to be implemented from Moodle 2.7 onwards.

--- a/docs/guides/javascript/yui/namespacing.md
+++ b/docs/guides/javascript/yui/namespacing.md
@@ -1,0 +1,123 @@
+---
+title: YUI/Namespacing
+tags: []
+---
+{{draft}}
+{{Work in progress}}
+{{Moodle 2.7}}
+
+## Introduction and Rationale
+
+One of the many fabtastic features of YUI is that it supports sandboxing of individual modules. This means that a third-party plugin cannot interfere with core plugins in such a way that will have undesired consequences to anything using the core code.
+
+As an example, a plugin could modify Y.Node to add a new function, or overwrite an existing function. This may be desirable for one instance of that Node, but undesirable for all others. For anyone wishing to use the additional function, they should depend upon the plugin instead which adds this functionality.
+
+To benefit from this sandboxing fully however, we must write our YUI modules under the Y namespace.
+
+To keep things consistent and clear, all Moodle-specific modules should be under a single Namespace. Ideally this namespace should be short, but still clear that it relates to Moodle.
+
+## Proposed namespace
+
+The proposed namespace fits into:
+
+    Y.M.<plugin_or_system_type>[_<component>].<YUI_modulename>[.<YUI_submodule>]
+
+The **plugin_or_system_type** should match the list defined in lib/classes/component.php in fetch_subsystems, with the additional 'core' subsytem used to for items within lib.
+
+The *optional* **component** will be the plugin name where relevant
+
+The ** YUI_modulename** should match module name
+
+The *optional* **YUI_submodule** should match the submodule if relevant
+
+## Examples
+
+<!--
+  Github Flavoured Markdown does not support tables without headers.
+  We must use an HTML table here.
+  Please note that Spacing in this table is important.
+  Markdown must have empty newlines between it and HTML markup.
+-->
+<table><tbody>
+<tr><td>
+
+YUI Module
+
+</td><td>
+
+Namespace
+
+</td></tr>
+<tr><td>
+
+moodle-core-dock
+
+</td><td>
+
+Y.M.core.dock
+
+</td></tr>
+<tr><td>
+
+moodle-core-dock-loader
+
+</td><td>
+
+Y.M.core.dock.loader
+
+</td></tr>
+<tr><td>
+
+moodle-course-toolboxes
+
+</td><td>
+
+Y.M.course.toolboxes
+
+</td></tr>
+<tr><td>
+
+moodle-mod_forum-inlinereply
+
+</td><td>
+
+Y.M.mod_forum.inlinereply
+
+</td></tr>
+<tr><td>
+
+moodle-block_navigation-navigation
+
+</td><td>
+
+Y.M.block_navigation.navigation
+
+</td></tr>
+<tr><td>
+
+moodle-mod_assign-history
+
+</td><td>
+
+Y.M.mod_assign.history
+
+</td></tr>
+<tr><td>
+
+moodle-form-dateselector
+
+</td><td>
+
+Y.M.form.dateselector
+
+</td></tr>
+<tr><td>
+
+moodle-form-listing
+
+</td><td>
+
+Y.M.form.listing
+
+</td></tr>
+</tbody></table>

--- a/docs/guides/javascript/yui/namespacing.md
+++ b/docs/guides/javascript/yui/namespacing.md
@@ -1,14 +1,23 @@
 ---
-title: YUI/Namespacing
-tags: []
+title: YUI Namespacing
+tags:
+  - Javascript
+  - YUI
 ---
-{{draft}}
-{{Work in progress}}
-{{Moodle 2.7}}
+
+import DeprecatedSince from '../../../../src/components/DeprecatedSince';
+
+<DeprecatedSince versions={["2.9"]} />
+
+:::caution
+
+As of Moodle 2.9 we are transitioning away from YUI to AMD modules. This transition will take a long time, but it is important because the YUI team have [stopped all new development on the YUI library](http://yahooeng.tumblr.com/post/96098168666/important-announcement-regarding-yui). See [JavaScript Modules](https://docs.moodle.org/dev/_Javascript_Modules_) for more information.
+
+:::
 
 ## Introduction and Rationale
 
-One of the many fabtastic features of YUI is that it supports sandboxing of individual modules. This means that a third-party plugin cannot interfere with core plugins in such a way that will have undesired consequences to anything using the core code.
+One of the many fantastic features of YUI is that it supports sandboxing of individual modules. This means that a third-party plugin cannot interfere with core plugins in such a way that will have undesired consequences to anything using the core code.
 
 As an example, a plugin could modify Y.Node to add a new function, or overwrite an existing function. This may be desirable for one instance of that Node, but undesirable for all others. For anyone wishing to use the additional function, they should depend upon the plugin instead which adds this functionality.
 
@@ -20,7 +29,9 @@ To keep things consistent and clear, all Moodle-specific modules should be under
 
 The proposed namespace fits into:
 
-    Y.M.<plugin_or_system_type>[_<component>].<YUI_modulename>[.<YUI_submodule>]
+```
+Y.M.<plugin_or_system_type>[_<component>].<YUI_modulename>[.<YUI_submodule>]
+```
 
 The **plugin_or_system_type** should match the list defined in lib/classes/component.php in fetch_subsystems, with the additional 'core' subsytem used to for items within lib.
 
@@ -32,92 +43,13 @@ The *optional* **YUI_submodule** should match the submodule if relevant
 
 ## Examples
 
-<!--
-  Github Flavoured Markdown does not support tables without headers.
-  We must use an HTML table here.
-  Please note that Spacing in this table is important.
-  Markdown must have empty newlines between it and HTML markup.
--->
-<table><tbody>
-<tr><td>
-
-YUI Module
-
-</td><td>
-
-Namespace
-
-</td></tr>
-<tr><td>
-
-moodle-core-dock
-
-</td><td>
-
-Y.M.core.dock
-
-</td></tr>
-<tr><td>
-
-moodle-core-dock-loader
-
-</td><td>
-
-Y.M.core.dock.loader
-
-</td></tr>
-<tr><td>
-
-moodle-course-toolboxes
-
-</td><td>
-
-Y.M.course.toolboxes
-
-</td></tr>
-<tr><td>
-
-moodle-mod_forum-inlinereply
-
-</td><td>
-
-Y.M.mod_forum.inlinereply
-
-</td></tr>
-<tr><td>
-
-moodle-block_navigation-navigation
-
-</td><td>
-
-Y.M.block_navigation.navigation
-
-</td></tr>
-<tr><td>
-
-moodle-mod_assign-history
-
-</td><td>
-
-Y.M.mod_assign.history
-
-</td></tr>
-<tr><td>
-
-moodle-form-dateselector
-
-</td><td>
-
-Y.M.form.dateselector
-
-</td></tr>
-<tr><td>
-
-moodle-form-listing
-
-</td><td>
-
-Y.M.form.listing
-
-</td></tr>
-</tbody></table>
+| YUI Module | Namespace |
+| --- | --- |
+| `moodle-core-dock` | `Y.M.core.dock` |
+| `moodle-core-dock-loader` | `Y.M.core.dock.loader` |
+| `moodle-course-toolboxes` | `Y.M.course.toolboxes` |
+| `moodle-mod_forum-inlinereply` | `Y.M.mod_forum.inlinereply` |
+| `moodle-block_navigation-navigation` | `Y.M.block_navigation.navigation` |
+| `moodle-mod_assign-history` | `Y.M.mod_assign.history` |
+| `moodle-form-dateselector` | `Y.M.form.dateselector` |
+| `moodle-form-listing` | `Y.M.form.listing` |


### PR DESCRIPTION
This series of commits migrates any YUI docs which are still relevant. Whilst we do not encourage any _new_ YUI development, we do still need to maintain what we have for the next few years.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/466"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

