### PR TITLE
Add date data for the 4.2 release

### DIFF
--- a/data/versions.json
+++ b/data/versions.json
@@ -2,6 +2,14 @@
     "$schema": "../static/schema/versions.json",
     "versions": [
         {
+            "name": "4.2",
+            "releaseDate": "24 April 2023",
+            "generalEndDate": "22 April 2024",
+            "securityEndDate": "21 October 2024",
+            "isLTS": false,
+            "releases": []
+        },
+        {
             "name": "4.1",
             "releaseDate": "28 November 2022",
             "generalEndDate": "13 November 2023",


### PR DESCRIPTION
Added date information for the 4.2 release

- Release date: 24 April 2023
- General support end date: 22 April 2024 (Monday on its 12th month)
- Security support end date: 21 October 2024 (Monday on its 18th month)

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/470"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

