### PR TITLE
[repo] Only show version dropdown in versioned docs

### DIFF
--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Moodle Pty Ltd.
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import React from 'react';
+import DocsVersionDropdownNavbarItem from '@theme-original/NavbarItem/DocsVersionDropdownNavbarItem';
+import {
+    useActiveDocContext,
+} from '@docusaurus/plugin-content-docs/client';
+
+export default function DocsVersionDropdownNavbarItemWrapper({
+    docsPluginId,
+    ...props
+}) {
+    const activeDocContext = useActiveDocContext(docsPluginId);
+
+    if (!activeDocContext.activeDoc) {
+        return '';
+    }
+
+    return (
+        <DocsVersionDropdownNavbarItem {...props} />
+    );
+}


### PR DESCRIPTION
Fixes #478 

This wraps the standard `DocsVersionDropdownNavbarItem` component from Docusaurus and uses the active document context information to determine whether the current document _has_ any version.

If no version is present, then the code shortcircuits and just returns an empty string.
If there is a version, then the version dowpdown component is called.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/480"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

