### PR TITLE
[docs] Add 4.1 LTS details

### DIFF
--- a/general/releases.md
+++ b/general/releases.md
@@ -86,7 +86,7 @@ Upcoming release dates can be found in the Moodle development calendar, which is
 
 :::
 
-## Moodle 4.1
+## Moodle 4.1 (LTS)
 
 <ReleaseTable releaseName="4.1" />
 

--- a/general/releases/4.1.md
+++ b/general/releases/4.1.md
@@ -8,6 +8,10 @@ moodleVersion: 4.1.0
 description: The release notes for Moodle version 4.1.0.
 ---
 
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+<ReleaseNoteIntro releaseName={frontMatter.moodleVersion} />
+
 If you are upgrading from a previous version, please see [Upgrading](https://docs.moodle.org/en/Upgrading) in the user docs.
 
 ## Server requirements


### PR DESCRIPTION
Add the missing (LTS) to the heading, and the missing release date info.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/488"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

