### PR TITLE
Moodle App 4.1

### DIFF
--- a/general/app/accessibility.md
+++ b/general/app/accessibility.md
@@ -1,5 +1,5 @@
 ---
-title: Applying accessibility on Moodle App
+title: Applying accessibility on the Moodle App
 sidebar_label: Accessibility
 sidebar_position: 2
 tags:

--- a/general/app/customisation/remote-themes.md
+++ b/general/app/customisation/remote-themes.md
@@ -1,5 +1,5 @@
 ---
-title: Moodle App Remote themes
+title: Moodle App Remote Themes
 sidebar_label: Remote themes
 sidebar_position: 1
 tags:

--- a/general/app/customisation/remote-themes.md
+++ b/general/app/customisation/remote-themes.md
@@ -23,7 +23,7 @@ Once you have everything ready, you can configure your theme by going to "Site a
 You can get started with the following example, and you should see the background of the top bar change to red once you log into the app:
 
 ```css
-body {
+html {
     --core-header-toolbar-background: red;
 }
 ```
@@ -76,7 +76,7 @@ Each of these also define other variants: `rgb`, `contrast`, `contrast-rgb`, `sh
 For example, if you want to override the primary color, you'll need to override the following variables:
 
 ```css
-body {
+html {
     --ion-color-primary: #006600;
 
     /* RGB list of the color */
@@ -101,7 +101,7 @@ body {
 Other than the basic and semantic colors, other components and pages define their own variables that you can override. You can look at the source code to find more, but these are some of the most relevant:
 
 ```css
-body {
+html {
     /* Page background */
     --background-color: white;
     --ion-background-color-rgb: 255, 255, 255;
@@ -120,27 +120,27 @@ body {
 
 ### Targeting different environments
 
-The `html` and `body` elements contain classes that indicate the environment the app is running on.
+The `html` element contains classes that indicate the environment the app is running on.
 
 #### Platform
 
-The `html` element indicates which platform the app is running on. For example, you can specify styles that will only apply to iOS by prepending them with `html.ios`, or `html.md` for Android:
+You can specify styles that will only apply to iOS by prepending them with `html.ios`, or `html.md` for Android:
 
 ```css
 /* Red toolbar in iOS */
-html.ios body {
+html.ios {
     --core-header-toolbar-background: red;
 }
 
 /* Green toolbar in Android */
-html.md body {
+html.md {
     --core-header-toolbar-background: green;
 }
 ```
 
 #### Moodle App and Moodle site versions
 
-The `body` element indicates the versions of the app and the Moodle site, so you can restrict CSS rules to a specific version by prepending one of these classes to the selector. For example, when accessing a 3.11.2 site using the 3.9.5 app the following classes will be present in the body:
+You can restrict CSS rules to a specific version using one of these classes. For example, when accessing a 3.11.2 site using the 3.9.5 app the following classes will be present in the `html` element:
 
 - `version-3`
 - `version-3-11`
@@ -152,29 +152,29 @@ The `body` element indicates the versions of the app and the Moodle site, so you
 And here's how to use them:
 
 ```css
-/* Red toolbar for Moodle App version 3.9.X */
-body.moodleapp-3-9 {
+/* Red toolbar for Moodle App version 4.1.X */
+html.moodleapp-4-1 {
     --core-header-toolbar-background: red;
 }
 
 /* Green toolbar for all other versions */
-body {
+html {
     --core-header-toolbar-background: green;
 }
 ```
 
 #### Application theme
 
-The application uses a light theme by default, but it adds the `dark` class to the `body` element when it is using a dark theme:
+The application uses a light theme by default, but it adds the `dark` class to the `html` element when it is using a dark theme:
 
 ```css
 /* Red toolbar for the Light Theme */
-body {
+html {
     --core-header-toolbar-background: red;
 }
 
 /* Green toolbar for the Dark Theme */
-body.dark {
+html.dark {
     --core-header-toolbar-background: green;
 }
 ```
@@ -188,7 +188,7 @@ Of course, you can combine any of these classes to create more granular styles.
 Let's say you want to have a red toolbar only in iOS, with the Dark Theme, for a Moodle site running 3.11.X:
 
 ```css
-html.ios body.version-3-11.dark {
+html.ios.version-3-11.dark {
     --core-header-toolbar-background: red;
 }
 ```
@@ -300,7 +300,7 @@ core-tabs, core-tabs-outlet {
 ### Items
 
 ```css
-body {
+html {
     /* Background */
     --ion-item-background: green;
 
@@ -349,7 +349,7 @@ page-core-mainmenu-more {
 You can personalise some colors in the Login page, but keep in mind that this only includes the credentials page (the one after you select the site).
 
 ```css
-body {
+html {
     --core-login-background: red;
     --core-login-text-color: blue;
     --core-login-input-background: green;
@@ -360,7 +360,7 @@ body {
 ### Messages page
 
 ```css
-body {
+html {
     --addon-messages-message-bg: white;
     --addon-messages-message-activated-bg: gray-light;
     --addon-messages-message-note-text: gray-dark;

--- a/general/app/development/development-guide.md
+++ b/general/app/development/development-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Moodle App Development guide
+title: Moodle App Development Guide
 sidebar_label: Development guide
 sidebar_position: 2
 tags:

--- a/general/app/development/link-handling/app-links.md
+++ b/general/app/development/link-handling/app-links.md
@@ -1,5 +1,6 @@
 ---
-title: Links in the app
+title: Links in the Moodle App
+sidebar_label: Links in the app
 sidebar_position: 1
 tags:
  - Moodle App

--- a/general/app/development/link-handling/deep-linking.md
+++ b/general/app/development/link-handling/deep-linking.md
@@ -1,5 +1,6 @@
 ---
-title: Deep Linking
+title: Moodle App Deep Linking
+sidebar_label: Deep Linking
 sidebar_position: 2
 tags:
  - Moodle App

--- a/general/app/development/plugins-development-guide/index.md
+++ b/general/app/development/plugins-development-guide/index.md
@@ -191,7 +191,7 @@ Note that if your functions use additional custom parameters (for example, if yo
 
 **Lang**
 
-The language pack string ids used in the plugin by all the handlers. Normally these will be strings from your own plugin, however, you can list any strings you need here, like `['moodle']('cancel',)`. If you do this, be warned that in the app you will then need to refer to that string as `{{ 'plugin.myplugin.cancel' | translate }}` (not `{{ 'plugin.moodle.cancel' | translate }}`).
+The language pack string ids used in the plugin by all the handlers. Normally these will be strings from your own plugin, however, you can list any strings you need here, like `['cancel', 'moodle']`. If you do this, be warned that in the app you will then need to refer to that string as `{{ 'plugin.myplugin.cancel' | translate }}` (not `{{ 'plugin.moodle.cancel' | translate }}`).
 
 Please only include the strings you actually need. The Web Service that returns the plugin information will include the translation of each string id for every language installed in the platform, and this will then be cached, so listing too many strings is very wasteful.
 
@@ -1180,7 +1180,7 @@ If your code needs to run after the DOM has been updated, you can use `setTimeou
 
 ```php
 return [
-    'template' => [
+    'templates' => [
         // ...
     ],
     'javascript' => 'setTimeout(function() { console.log("DOM is available now"); });',

--- a/general/app/development/plugins-development-guide/index.md
+++ b/general/app/development/plugins-development-guide/index.md
@@ -1,5 +1,5 @@
 ---
-title: Moodle App Plugins development guide
+title: Moodle App Plugins Development Guide
 sidebar_label: Plugins development guide
 sidebar_position: 2
 tags:

--- a/general/app/development/plugins-development-guide/troubleshooting.md
+++ b/general/app/development/plugins-development-guide/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting on Moodle App Plugins development guide
+title: Troubleshooting Moodle App Plugins Development
 sidebar_label: Troubleshooting
 sidebar_position: 2
 tags:

--- a/general/app/development/release-process.md
+++ b/general/app/development/release-process.md
@@ -47,7 +47,8 @@ tags:
 | 6. | Unfreeze Cordova plugins and JavaScript libraries versions (node modules). | Developer |
 | 7. | Check that the [Docker image](https://cloud.docker.com/u/moodlehq/repository/docker/moodlehq/moodleapp/general) for the new version was successfully built. | Integration Lead |
 | 8. | Update of the [local_moodlemobileapp](https://moodle.org/plugins/view.php?id=997) plugin (as final release) in moodle.org/plugins. | Developer |
-| 8. | Update the `DEFAULT_LASTVERSION` variable on [scripts/lang_functions.sh](https://github.com/moodlehq/moodleapp/blob/master/scripts/lang_functions.sh) | Developer |
+| 9. | Update of the [local_moodleappbehat](https://github.com/moodlehq/moodle-local_moodleappbehat/) plugin (as final release) in moodle.org/plugins. | Developer |
+| 10. | Update the `DEFAULT_LASTVERSION` variable on [scripts/lang_functions.sh](https://github.com/moodlehq/moodleapp/blob/master/scripts/lang_functions.sh) | Developer |
 
 ## See also
 

--- a/general/app/development/release-process.md
+++ b/general/app/development/release-process.md
@@ -1,5 +1,5 @@
 ---
-title: Moodle App Release process
+title: Moodle App Release Process
 sidebar_label: Release process
 sidebar_position: 8
 tags:

--- a/general/app/development/setup/docker-images.md
+++ b/general/app/development/setup/docker-images.md
@@ -1,5 +1,5 @@
 ---
-title: Moodle App Docker images
+title: Moodle App Docker Images
 sidebar_label: Docker images
 sidebar_position: 2
 tags:

--- a/general/app/faq.md
+++ b/general/app/faq.md
@@ -44,4 +44,4 @@ You can read about that in the following forum posts:
 
 ## I am having problems running the app from the source code
 
-If you are having issues getting the app to compile, make sure to check out the troubleshooting section of the [Setting up your development environment for the Moodle App](./development/setup/index.md#troubleshooting) page.
+If you are having issues getting the app to compile, make sure to check out the [Troubleshooting](./development/setup/troubleshooting) page.

--- a/general/app/overview.md
+++ b/general/app/overview.md
@@ -22,7 +22,7 @@ This works because the app is not coupled to any specific Moodle site, it acts a
 
 The app can also be compiled to work with a single site, or a list of approved sites. Which may be desirable for building custom applications. For most people though, [the official app from MoodleHQ](https://moodle.com/app/) will be sufficient because it's not restricted to any site.
 
-Keep in mind that the application only works with moodle sites that allow it, and this is disabled by default. If you want to allow users to log into your site using the app, make sure to [enable it in the settings](https://docs.moodle.org/en/Moodle_app_guide_for_admins#Enable_mobile_services_on_your_site). If you are not the site owner, reach out to the administrators.
+Keep in mind that the application only works with moodle sites that allow it, and this is disabled by default in some sites. If you want to allow users to log into your site using the app, make sure to check that it's [enabled in the settings](https://docs.moodle.org/en/Moodle_app_guide_for_admins#Enable_mobile_services_on_your_site). If you are not the site owner, reach out to the administrators.
 
 ### Architecture
 

--- a/general/app/upgrading/acceptance-tests-upgrade-guide.md
+++ b/general/app/upgrading/acceptance-tests-upgrade-guide.md
@@ -1,0 +1,51 @@
+---
+title: Moodle App Acceptance Tests Upgrade Guide
+sidebar_label: Acceptance tests
+sidebar_position: 3
+tags:
+  - Moodle App
+  - Testing
+---
+
+In the following guide, you will learn how to upgrade your plugins' acceptance tests to support newer versions of the app.
+
+Depending on which version of the app you're upgrading from, you'll need to go through multiple version upgrades. This guide is divided by version ranges, so you should be able to start with your current version and build up from there.
+
+## 4.0 to 4.1
+
+The only relevant change in this version is that the location of the custom Behat steps for the app have moved again. This time, they've been moved into the repository of the app itself. In order to make this usable by plugins as well, the Behat code is mirrored automatically into a plugin.
+
+Your only required change should be to replace the old `local_moodlemobileapp` plugin with [local_moodleappbehat](https://github.com/moodlehq/moodle-local_moodleappbehat) and everything else should continue working as before.
+
+:::info
+If you were [using the browser console to debug tests](http://localhost:3000/devdocs/general/app/development/testing/acceptance-testing#debugging-tests), notice that some commands may have changed as well. We recommend heading to the documentation for writting Acceptance Tests for the Moodle App in order to learn about the new approach.
+:::
+
+## 3.9.5 to 4.0
+
+There haven't been any relevant changes in this version, but make sure to run your tests agains the latest version to check that they continue working properly. If you find something that stopped working, please [let us know](https://tracker.moodle.org/projects/MOBILE).
+
+## 3.9.4 to 3.9.5
+
+If you wrote tests before the app started using Ionic 5 (in version 3.9.5), it is possible that your tests are not working any longer. The [Acceptance Testing guide](../development/testing/acceptance-testing.md) has been rewritten with the latest information, so make sure to check it out to learn about the latest state of the art.
+
+In general though, upgrading your current tests should be mostly straightforward.
+
+The most relevant change is that Ionic 5 started using [the Shadow DOM](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), and that's the source of many issues you may find upgrading your tests. Because of this, the standard Behat steps no longer work, so we have implemented their equivalent for the app (you can notice these steps because the end with `in the app`). Another important difference is that they look for content using accessibility rules.
+
+In order to use these new steps, make sure that you have the [local_moodlemobileapp](https://github.com/moodlehq/moodle-local_moodlemobileapp/) plugin installed. Historically, Behat functionality for the mobile app was included with the LMS out of the box, but it has since been extracted to its own repository.
+
+:::caution
+If you're updating to version 4.1 or later, this changed again! Now, the functionality has been moved to the app repository itself, and it is automatically mirrored to the [local_moodleappbehat](https://github.com/moodlehq/moodle-local_moodleappbehat) plugin.
+
+Read more about this in the section to [upgrade to 4.1](#40-to-41)
+:::
+
+Here's some tips to get you started with the migration:
+
+- The standard `I press "..."` step has an equivalent called `I press "..." in the app"`. In general, most steps follow this pattern to make the migration easier. Keep in mind that the old steps may continue working in some situations, but we recommend updating all instances just in case.
+- The standard `I should see "..."` step has an equivalent called `I should find "..." in the app`. These steps use accessiblity rules to find content, so "find" is a more appropriate term than "see".
+- Because of the Shadow DOM, some radio inputs and checkboxes that worked before are broken. You should be able to use the new `I select "..." in the app` steps instead.
+- If you were relying in xpath or css selectors before, they will probably not work anymore. Even if you try to patch them, these selectors don't pierce through the Shadow DOM. In any case, it's always better to use accessible locators to test your plugin like a real user would, so you can use this opportunity to improve accessibility in your plugin.
+- Pay special attention to any assertions such as `should not exist` that you have in your tests. These assertions will not fail, because the elements won't be found. But if you get an eventual bug when something is shown that shouldn't, those steps will probably not pick it up because the locators may have changed. So make sure to change those to their equivalent `should not exist in the app`.
+- If you were running your tests in CI, make sure to install the plugin with the app steps as well.

--- a/general/app/upgrading/plugins-upgrade-guide.md
+++ b/general/app/upgrading/plugins-upgrade-guide.md
@@ -1,6 +1,6 @@
 ---
-title: Moodle App Plugins upgrade guide
-sidebar_label: Plugins upgrade guide
+title: Moodle App Plugins Upgrade Guide
+sidebar_label: Plugins
 sidebar_position: 7
 tags:
   - Moodle App

--- a/general/app/upgrading/remote-themes-upgrade-guide.md
+++ b/general/app/upgrading/remote-themes-upgrade-guide.md
@@ -1,40 +1,116 @@
 ---
 title: Moodle App Remote Themes Upgrade Guide
 sidebar_label: Remote themes
-sidebar_position: 2
+sidebar_position: 1
 tags:
   - Moodle App
 ---
 
-In the following guide, you will find some examples to migrate your styles from an older version to work with the Ionic 5 Moodle App (starting at version 3.9.5). You will find tables where each row is a migration to do; the left part is the old code and the right part the new one.
+<!-- markdownlint-disable no-inline-html -->
 
-We recommend that you keep your old CSS rules for older versions (see [Before starting the migration](#before-starting-the-migration)), by doing so users who are still using Moodle App 3.9.4 and earlier will see the same styling you had until now.
+import { CodeDiff, ValidExample, InvalidExample } from '@site/src/components';
 
-## Before starting the migration
+In the following guide, you will learn how to migrate your styles from an older version of the app.
 
-1. Remove all styles using ionic classes ending with `-wp` (Windows Phone is not supported, therefore it's not necessary to specify it).
-2. Check [the theme file](https://github.com/moodlehq/moodleapp/blob/master/src/theme/theme.light.scss), where most variables are specified.
-3. As in the previous version, do not use any Saas variables (the ones starting with `$`). But now you can use [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) (the ones starting with `--`).
-4. We recommend prepending all CSS rules with `body.ionic5` in order to make them only available for Ionic 5, and prepending the old ones with `body:not(.ionic5)` for the previous versions of the Moodle App (3.9.4, 3.9.3, and so on).
-5. Be aware that example rules may differ from your CSS, which could be more specific.
+However, keep in mind that not all your users will be using the latest version. We recommend that you keep your old CSS rules for older versions as indicated in the [Before starting the migration](#before-starting-the-migration) section. By doing so, users who haven't updated the app will continue seeing the same styles they had until now.
+
+Depending on which version of the app you're upgrading from, you'll need to go through multiple version upgrades. This guide is divided by version ranges, so you should be able to start with your current version and build up from there.
+
+### Before starting the migration
+
+We recommend prepending all conflicting CSS rules with the specific version they are targeting.
+
+For example, for a CSS stylesheet that targets both 4.0 and 4.1 versions, you should do the following:
+
+```css
+html.moodleapp-4-1 {
+    --ion-color-primary: red;
+}
+
+body.moodle-app-4-0 {
+    --ion-color-primary: green;
+}
+```
+
+You can use these classes to target specific major and patch versions as well, so for example version 4.1.0 ships with `moodleapp-4`, `moodleapp-4-1`, and `moodleapp-4-1-0` classes. You can also use ionic versions to filter styles, such as `ionic3` or `ionic5`.
+
+:::caution
+Notice that mode and version classes moved from the `body` tag to the `html` tag in version 4.1. Learn more about this when [upgrading from 4.0 to 4.1](#40-to-41).
+:::
 
 ### How to upgrade my theme
 
-You can follow the same process that is documented in the [Moodle App Remote themes](../customisation/remote-themes.md#how-can-you-create-your-own-theme) page.
+You can follow the same process that is documented in the [Moodle App Remote Themes](../customisation/remote-themes.md#how-can-you-create-your-own-theme) page.
 
-Make sure to read it in order to understand how to style your application for newer versions of the app. If you're upgrading your styles, it is likely that the documentation has been updated since you read it.
+Make sure to read it in order to understand how to style your application for newer versions of the app. If you're upgrading your styles, it is likely that the documentation has been updated since you read it. So we recommend taking a look even if you're already familiar with Remote Themes.
 
-## Colors
+## 4.0 to 4.1
+
+There is only one thing to look after when upgrading to 4.1, so it should be a relatively quick process.
+
+### Mode classes
+
+Starting in 4.1, mode and version classes have been moved from the `body` tag to the `html` tag. This change arised from [a bug on derivated CSS variables](https://tracker.moodle.org/browse/MOBILE-4127), and it should be fairly straightforward to make.
+
+<CodeDiff titles="4.0, 4.1">
+
+```css
+body {
+    --core-header-toolbar-background: red;
+}
+
+body.dark {
+    --core-header-toolbar-background: green;
+}
+```
+
+```css
+html {
+    --core-header-toolbar-background: red;
+}
+
+html.dark {
+    --core-header-toolbar-background: green;
+}
+```
+
+</CodeDiff>
+
+:::info
+In order to avoid breaking existing styles, version 4.1 will continue adding version classes both to `body` and `html` tags. But using the classes from the `body` tag is considered a deprecated approach, and won't be supported in future versions. So we recommend that you update your Remote Themes now.
+:::
+
+## 3.9.5 to 4.0
+
+There haven't been any breaking changes from 3.9.5 to 4.0 in terms of theming functionality, but the UI of the application has changed drastically so we recommend going over all the customisations to see that they are still relevant in the new version.
+
+## 3.9.4 to 3.9.5
+
+This upgrade requires more changes than usual because the Moodle App was upgraded the underlying Ionic framework from version 3 to version 5, which introduced many breaking changes.
+
+### Windows Phone
+
+Starting with this version, Windows Phone is no longer supported so you should remove all styles using Ionic classes ending with `-wp` since they are no longer necessary.
+
+### CSS variables
+
+Starting with this version, it is possible to use [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) to make easier customisations, so it's likely that you won't need to override as many styles as before.
+
+You can see some examples in the sections below, and you can also look at [the theme file](https://github.com/moodlehq/moodleapp/blob/master/src/theme/theme.light.scss) to find some of the main variables of the app.
+
+### Colors
 
 The main color in the app is Moodle Orange, but you can now change it by using the `--primary` variable. This will probably reduce the CSS you are applying right now, but this only covers the main color.
 
 For other colors, check out [the colors section in the main documentation](../customisation/remote-themes.md#working-with-colors).
 
-## Header toolbar
+### Header toolbar
+
+#### Border width and color (new)
 
 On the header toolbar, we've added a bottom border that you can disable.
 
-### Border width and color (new)
+<ValidExample title="3.9.5">
 
 ```css
 ion-header ion-toolbar {
@@ -43,161 +119,193 @@ ion-header ion-toolbar {
 }
 ```
 
-### Background
+</ValidExample>
 
-```css title="Ionic 3 legacy code"
+#### Background
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .toolbar-background-md, .toolbar-background-ios {
     background: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 ion-header ion-toolbar {
     --core-header-toolbar-background: red;
 }
 ```
 
-### Text and buttons
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Text and buttons
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .toolbar-title-md,
 .toolbar-title-ios {
     color: red;
-}
-```
-
-```css title="Ionic 5"
-ion-header ion-toolbar {
-    --core-header-toolbar-color: red;
-}
-```
-
-```css title="Ionic 5"
-.toolbar-title-md,
-.toolbar-title-ios {
     font-weight: normal;
 }
 ```
 
-```css title="Ionic 5"
+```css
+ion-header ion-toolbar {
+    --core-header-toolbar-color: red;
+}
+
 ion-header ion-toolbar.in-toolbar h1,
 ion-header ion-toolbar.in-toolbar h2 {
     font-weight: normal;
 }
 ```
 
-## Bottom tab bar (main menu)
+</CodeDiff>
 
-### Background
+### Bottom tab bar (main menu)
 
-```css title="Ionic 3 legacy code"
+#### Background
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .tabs-md .tabbar,
 .tabs-ios .tabbar {
     background: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 ion-tab-bar.mainmenu-tabs {
     --core-bottom-tabs-background: red;
     --core-bottom-tabs-background-selected: transparent;
 }
 ```
 
-### Tab icon color
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Tab icon color
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .tabs-md .tab-button-icon,
 .tabs-ios .tab-button-icon {
     color: blue;
 }
 ```
 
-```css title="Ionic 5"
+```css
 ion-tab-bar.mainmenu-tabs {
     --core-bottom-tabs-color: blue;
 }
 ```
 
-### Selected tab icon color
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Selected tab icon color
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 tabs-md .tab-button[.tab-button-icon,
 .tabs-ios .tab-button[aria-selected=true](aria-selected=true]) .tab-button-icon {
     color: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 ion-tab-bar.mainmenu-tabs {
     --core-bottom-tabs-color-selected: red;
 }
 ```
 
-### Badge color and text
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Badge color and text
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 core-ion-tabs .tab-badge.badge {
     color: white;
     background: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 ion-tab-bar.mainmenu-tabs {
     --core-bottom-tabs-badge-text-color: white;
     --core-bottom-tabs-badge-color: red;
 }
 ```
 
-## Top tabs
+</CodeDiff>
 
-### Tabs background
+### Top tabs
 
-```css title="Ionic 3 legacy code"
+#### Tabs background
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .core-tabs-bar {
   background-color: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 core-tabs, core-tabs-outlet {
     --core-tabs-background: red;
 }
 ```
 
-### Individual tab background
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Individual tab background
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .core-tabs-bar .tab-slide {
   background-color: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 core-tabs, core-tabs-outlet {
     --core-tab-background: red;
 }
 ```
 
-### Unselected tab styles
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Unselected tab styles
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .core-tabs-bar .tab-slide {
   color: red;
   border-bottom-color: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 core-tabs, core-tabs-outlet {
     --core-tab-color: red;
 }
 ```
 
-### Selected tab styles
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Selected tab styles
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .core-tabs-bar .tab-slide[aria-selected=true]{
    color: red;
    border-bottom-color: red;
@@ -205,7 +313,7 @@ core-tabs, core-tabs-outlet {
 }
 ```
 
-```css title="Ionic 5"
+```css
 core-tabs, core-tabs-outlet {
     --core-tab-color-active: red;
     --core-tab-border-color-active: red;
@@ -213,25 +321,33 @@ core-tabs, core-tabs-outlet {
 }
 ```
 
-## Items
+</CodeDiff>
 
-### Items background color
+### Items
 
-```css title="Ionic 3 legacy code"
+#### Items background color
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 ion-item {
     background: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 body {
     --ion-item-background: red;
 }
 ```
 
-### Item divider background color
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Item divider background color
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 .item-divider-md,
 .item-divider-ios {
     background: red;
@@ -239,26 +355,32 @@ body {
 }
 ```
 
-```css title="Ionic 5"
+```css
 body {
     --item-divider-background: red;
     --item-divider-color: yellow;
 }
 ```
 
-### Empty divider background
+</CodeDiff>
 
-```css title="Ionic 5"
+#### Empty divider background
+
+<ValidExample title="3.9.5">
+
+```css
 body {
     --spacer-background: red;
 }
 ```
 
-## Progress bar
+</ValidExample>
 
-You can now easily style progress bars.
+### Progress bar
 
-```css title="Ionic 5"
+<ValidExample title="3.9.5">
+
+```css
 core-progress-bar {
     --core-progressbar-height: 8px;
     --core-progressbar-color: red;
@@ -267,67 +389,87 @@ core-progress-bar {
 }
 ```
 
-## More page
+</ValidExample>
 
-### Icons
+### More page
+
+#### Icons
 
 The icons in the More page can now easily change their color:
 
-```css title="Ionic 3 legacy code"
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 page-core-mainmenu-more ion-icon {
     color: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 page-core-mainmenu-more {
     --core-more-icon: red;
 }
 ```
 
+</CodeDiff>
+
 To change a color on a particular icon, you'll have to use the class of each handler. For example, to change the color of the folder icon on the menu item named Files:
 
-```css title="Ionic 3 legacy code"
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 page-core-mainmenu-more .ion-md-folder,
 page-core-mainmenu-more .ion-ios-folder {
     color: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 page-core-mainmenu-more .addon-privatefiles-handler ion-icon {\
     color: red !important;
 }
 ```
 
-### Item border color
+</CodeDiff>
 
-```css title="Ionic 3 legacy code"
+#### Item border color
+
+<CodeDiff titles="3.9.4, 3.9.5">
+
+```css
 page-core-mainmenu-more .item-block.item-ios .item-inner,
 page-core-mainmenu-more .item-block.item-md .item-inner {
     border-bottom-color: red;
 }
 ```
 
-```css title="Ionic 5"
+```css
 page-core-mainmenu-more {
     --core-more-item-border: red;
 }
 ```
 
+</CodeDiff>
+
 The dividers background color can now be overridden using `--spacer-background`:
 
-```css title="Ionic 5"
+<ValidExample title="3.9.5">
+
+```css
 page-core-mainmenu-more {
     --spacer-background: blue;
 }
 ```
 
-## Login page
+</ValidExample>
+
+### Login page
 
 You can now personalise some colors in the Login page, but keep in mind that this only includes the credentials page (the one after you select the site).
 
-```css title="Ionic 5"
+<ValidExample title="3.9.5">
+
+```css
 body {
     --core-login-background: red;
     --core-login-text-color: blue;
@@ -336,11 +478,15 @@ body {
 }
 ```
 
-## Messages page
+</ValidExample>
+
+### Messages page
 
 Message discussion page, including chat activity and comments:
 
-```css title="Ionic 5"
+<ValidExample title="3.9.5">
+
+```css
 body {
     --addon-messages-message-bg: white;
     --addon-messages-message-activated-bg: gray-light;
@@ -352,7 +498,11 @@ body {
 }
 ```
 
+</ValidExample>
+
 You can also make some modifications on the input field:
+
+<ValidExample title="3.9.5">
 
 ```css
 body {
@@ -361,9 +511,13 @@ body {
 }
 ```
 
-## Full example
+</ValidExample>
+
+### Full example
 
 This is a full example showcasing how to handle multiple versions:
+
+<ValidExample title="3.9.4 and 3.9.5">
 
 ```css
 /* ----- Ionic 5 styles ----- */
@@ -396,4 +550,6 @@ body:not(.ionic5) .toolbar-background {
 }
 ```
 
-As you can see we recommend to always add `body.ionic` to start the CSS selectors, you can also use `:root body.ionic5` or even `html` before `body`.
+</ValidExample>
+
+As you can see we recommend to always add `body.ionic*` to start the CSS selectors, you can also use `:root body.ionic5` or even `html` before `body`.

--- a/general/app/upgrading/remote-themes-upgrade-guide.md
+++ b/general/app/upgrading/remote-themes-upgrade-guide.md
@@ -1,6 +1,6 @@
 ---
-title: Moodle App Remote themes upgrade guide
-sidebar_label: Remote themes upgrade guide
+title: Moodle App Remote Themes Upgrade Guide
+sidebar_label: Remote themes
 sidebar_position: 2
 tags:
   - Moodle App

--- a/general/app_releases/v3/v3.9.5.md
+++ b/general/app_releases/v3/v3.9.5.md
@@ -24,8 +24,8 @@ Release date: 27 August 2021
 
 In this version, we have upgraded the framework we use for building the app. Note that there are several changes which may impact plugins or sites using their own custom mobile CSS:
 
-- If you have developed a plugin that is supported for the Moodle app please read [Moodle App Plugins Upgrade Guide](../../app/upgrading/plugins-upgrade-guide)
-- If you have a Premium app subscription and your own Moodle app theme please read [Ionic5 style migration guide](../../app/upgrading/remote-themes-upgrade-guide.md)
+- If you have developed a plugin that is supported for the Moodle App please read the [Plugins Upgrade Guide](../../app/upgrading/plugins-upgrade-guide.md).
+- If you have a Premium app subscription and your own Moodle App theme please read the [Remote Themes Upgrade Guide](../../app/upgrading/remote-themes-upgrade-guide.md).
 
 ## Complete list of issues
 

--- a/src/components.js
+++ b/src/components.js
@@ -19,6 +19,7 @@ import AcademyLink from './components/AcademyLink';
 
 import Since from './components/Since';
 import DeprecatedSince from './components/DeprecatedSince';
+import CodeDiff from './components/CodeDiff';
 import CodeExample from './components/CodeExample';
 import ValidExample from './components/ValidExample';
 import InvalidExample from './components/InvalidExample';
@@ -35,6 +36,7 @@ export {
     Since,
     DeprecatedSince,
 
+    CodeDiff,
     CodeExample,
     ValidExample,
     InvalidExample,

--- a/src/components/CodeDiff/index.js
+++ b/src/components/CodeDiff/index.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Moodle Pty Ltd.
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React, { useMemo } from 'react';
+import styles from './styles.module.css';
+import { ValidExample, InvalidExample } from '@site/src/components';
+
+export default function CodeDiff(props) {
+    const titles = useMemo(() => props.titles?.split(', ').map((title) => title.trim()), [props.titles]);
+
+    return (
+        <div className={styles['code-diff']}>
+            <InvalidExample title={titles?.[0] ?? null}>
+                {props.children[0]}
+            </InvalidExample>
+            <ValidExample title={titles?.[1] ?? null}>
+                {props.children[1]}
+            </ValidExample>
+        </div>
+    );
+}

--- a/src/components/CodeDiff/index.js
+++ b/src/components/CodeDiff/index.js
@@ -21,9 +21,10 @@ import { ValidExample, InvalidExample } from '@site/src/components';
 
 export default function CodeDiff(props) {
     const titles = useMemo(() => props.titles?.split(', ').map((title) => title.trim()), [props.titles]);
+    const vertical = props.vertical ?? false;
 
     return (
-        <div className={styles['code-diff']}>
+        <div className={`${styles['code-diff']} ${vertical && styles.vertical}`}>
             <InvalidExample title={titles?.[0] ?? null}>
                 {props.children[0]}
             </InvalidExample>

--- a/src/components/CodeDiff/styles.module.css
+++ b/src/components/CodeDiff/styles.module.css
@@ -1,0 +1,5 @@
+.code-diff {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, auto));
+    gap: 1rem;
+}

--- a/src/components/CodeDiff/styles.module.css
+++ b/src/components/CodeDiff/styles.module.css
@@ -3,3 +3,8 @@
     grid-template-columns: repeat(2, minmax(0, auto));
     gap: 1rem;
 }
+
+.code-diff.vertical {
+    grid-template-columns: minmax(0, auto);
+    gap: 0;
+}


### PR DESCRIPTION
This PR contains the updated documentation for the upcoming release of the mobile app.

The only part that is not just relevant to mobile is the introduction of a new component called `CodeDiff`, used to compare before/after code snippets in the upgrade guides.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/489"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

