### PR TITLE
Migrate ws docs

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -181,6 +181,9 @@ Enrolment_API:
 Enrolment_plugins:
 - filePath: "/docs/apis/plugintypes/enrol/index.md"
   slug: "/docs/apis/plugintypes/enrol/"
+External_services_description:
+- filePath: "/docs/apis/subsystems/external/description.md"
+  slug: "/docs/apis/subsystems/external/description"
 Favourites_API:
 - filePath: "/docs/apis/subsystems/favourites/index.md"
   slug: "/docs/apis/subsystems/favourites/"

--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1623,6 +1623,9 @@ User-related_APIs:
 Using_the_Moodle_App_in_a_browser:
 - filePath: "/general/app/development/setup/app-in-browser.md"
   slug: "/general/app/development/setup/app-in-browser"
+Web_services:
+- filePath: "/docs/apis/subsystems/external/index.md"
+  slug: "/docs/apis/subsystems/external/"
 Writing_acceptance_tests:
 - filePath: "/general/development/tools/behat/writing.md"
   slug: "/general/development/tools/behat/writing"

--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -28,6 +28,9 @@ Activity_modules:
 Add_a_block_cleanup:
 - filePath: "/general/projects/code/block-cleanup.md"
   slug: "/general/projects/code/block-cleanup"
+Adding_a_web_service_to_a_plugin:
+- filePath: "/docs/apis/subsystems/external/writing-a-service.md"
+  slug: "/docs/apis/subsystems/external/writing-a-service"
 Admin_settings:
 - filePath: "/docs/apis/subsystems/admin/index.md"
   slug: "/docs/apis/subsystems/admin/"

--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1632,6 +1632,9 @@ Using_the_Moodle_App_in_a_browser:
 Web_services:
 - filePath: "/docs/apis/subsystems/external/index.md"
   slug: "/docs/apis/subsystems/external/"
+Web_services_files_handling:
+- filePath: "/docs/apis/subsystems/external/files.md"
+  slug: "/docs/apis/subsystems/external/files"
 Writing_acceptance_tests:
 - filePath: "/general/development/tools/behat/writing.md"
   slug: "/general/development/tools/behat/writing"

--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -181,6 +181,9 @@ Enrolment_API:
 Enrolment_plugins:
 - filePath: "/docs/apis/plugintypes/enrol/index.md"
   slug: "/docs/apis/plugintypes/enrol/"
+External_functions_API:
+- filePath: "/docs/apis/subsystems/external/functions.md"
+  slug: "/docs/apis/subsystems/external/functions"
 External_services_description:
 - filePath: "/docs/apis/subsystems/external/description.md"
   slug: "/docs/apis/subsystems/external/description"

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -119,7 +119,7 @@ allows any plugin to generate and handle xAPI standard statements.
 
 ### External functions API (external)
 
-The [External functions API](https://docs.moodle.org/dev/External_functions_API) allows you to create fully parametrised methods that can be accessed by external programs (such as [Web services](https://docs.moodle.org/dev/Web_services)).
+The [External functions API](https://docs.moodle.org/dev/External_functions_API) allows you to create fully parametrised methods that can be accessed by external programs (such as [Web services](./apis/subsystems/external/index.md)).
 
 ### Favourites API
 

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -119,7 +119,7 @@ allows any plugin to generate and handle xAPI standard statements.
 
 ### External functions API (external)
 
-The [External functions API](https://docs.moodle.org/dev/External_functions_API) allows you to create fully parametrised methods that can be accessed by external programs (such as [Web services](./apis/subsystems/external/index.md)).
+The [External functions API](./apis/subsystems/external/functions.md) allows you to create fully parametrised methods that can be accessed by external programs (such as [Web services](./apis/subsystems/external/index.md)).
 
 ### Favourites API
 

--- a/docs/apis/_files/db-services-php.mdx
+++ b/docs/apis/_files/db-services-php.mdx
@@ -11,6 +11,6 @@ Web services should be named following the [naming convention for web services](
 
 For further information on external functions and web services, see:
 
-- [Adding a web service to a plugin](https://docs.moodle.org/dev/Adding_a_web_service_to_a_plugin)
+- [Adding a web service to a plugin](../subsystems/external/writing-a-service.md)
 - [Web services API](https://docs.moodle.org/dev/Web_services_API)
 - [External functions API](../subsystems/external/functions.md)

--- a/docs/apis/_files/db-services-php.mdx
+++ b/docs/apis/_files/db-services-php.mdx
@@ -13,4 +13,4 @@ For further information on external functions and web services, see:
 
 - [Adding a web service to a plugin](https://docs.moodle.org/dev/Adding_a_web_service_to_a_plugin)
 - [Web services API](https://docs.moodle.org/dev/Web_services_API)
-- [External functions API](https://docs.moodle.org/dev/External_functions_API)
+- [External functions API](../subsystems/external/functions.md)

--- a/docs/apis/_files/db-services-php.tsx
+++ b/docs/apis/_files/db-services-php.tsx
@@ -23,10 +23,8 @@ const defaultExample = `
 $functions = [
     'plugintype_pluginname_create_things' => [
         'classname' => 'plugintype_pluginname\\external\\create_things',
-        'methodname' => 'execute',
         'description' => 'Create a new thing',
         'type' => 'write',
-        'capabilities' => 'plugintype/pluginname:create_things',
         'ajax' => true,
         'services' => [
             MOODLE_OFFICIAL_MOBILE_SERVICE,

--- a/docs/apis/subsystems/external/advanced/_category_.json
+++ b/docs/apis/subsystems/external/advanced/_category_.json
@@ -1,0 +1,6 @@
+{
+    "position": 6,
+    "label": "Advanced topics",
+    "collapsible": true,
+    "collapsed": true
+}

--- a/docs/apis/subsystems/external/advanced/custom-services.md
+++ b/docs/apis/subsystems/external/advanced/custom-services.md
@@ -1,0 +1,71 @@
+---
+title: Service creation
+tags:
+  - Web Services
+  - core_external
+  - external
+  - API
+---
+
+Moodle comes with two built-in services that your functions can be attached to.
+
+In rare situations, you may need to create a create a _custom_ service declaration.
+
+The recommended way of creating a new _service_ declaration is by placing it into the `db/services.php` file as a new service declaration.
+
+Moodle Administrators can also manually create a service declaration using the web interface.
+
+This is an advanced feature and, in most cases, _you will not need to use this feature_.
+
+:::note
+
+Whilst writing a service declaration is _optional_, if you do not create a service declaration, then the Moodle administrator will have to create one manually through the Web UI.
+
+If you define a web service here, then the administrator cannot add or remove any function from it.
+
+:::
+
+## Declaring a custom service declaration
+
+Service declarations should be placed in the `db/services.php` file of your plugin, for example `local/groupmanager/db/services.php`.
+
+```php title="local/groupmanager/db/services.php"
+$services = [
+    // The name of the service.
+    // This does not need to include the component name.
+    'myintegration' => [
+
+        // A list of external functions available in this service.
+        'functions' => [
+            'local_groupmanager_create_groups',
+        ],
+
+        // If set, the external service user will need this capability to access
+        // any function of this service.
+        // For example: 'local_groupmanager/integration:access'
+        'requiredcapability' => 'local_groupmanager/integration:access',
+
+        // If enabled, the Moodle administrator must link a user to this service from the Web UI.
+        'restrictedusers' => 0,
+
+        // Whether the service is enabled by default or not.
+        'enabled' => 1,
+
+        // This field os optional, but requried if the `restrictedusers` value is
+        // set, so as to allow configuration via the Web UI.
+        'shortname' =>  '',
+
+        // Whether to allow file downloads.
+        'downloadfiles' => 0,
+
+        // Whether to allow file uploads.
+        'uploadfiles'  => 0,
+    )
+);
+```
+
+:::note
+
+It is not possible for an administrator to add/remove any function from a pre-built service.
+
+:::

--- a/docs/apis/subsystems/external/description.md
+++ b/docs/apis/subsystems/external/description.md
@@ -1,0 +1,467 @@
+---
+title: Service Descriptions
+tags:
+  - Web Services
+  - core_external
+  - external
+  - API
+---
+{{Moodle_2.0}}
+
+## Purpose
+
+This document explains how we describe and where we store the external services and functions in Moodle 2.0.
+
+### Service discovery
+
+We store the service descriptions and a part of the function descriptions in the component/db/services.php file. Function implementations are located under \component\external classes (previously in externallib.php files). These external functions, one per class (and file) also contain the other part of the function descriptions (the function parameters descriptions).
+
+During the upgrades the descriptions are parsed by a service discovery function that fills the database tables. Administrative UI may be used to change some configuration details. Services can also be defined via the admin UI, but it is recommended to use the new local plugin (look at the readme.txt into the Moodle local folder) when adding custom new services.
+
+### Administration pages
+
+Moodle administrators will be able to manage services. By default all services will be disabled.
+
+List of administration functionalities:
+
+- enable a service (all the functions into this service will be available)
+- associate a web service user (the user has web service capability) to some services => a user can only call a service that he is associated with
+- create a custom service (name the service + add and remove existing external functions from this service)
+- search easily function by component in order to create a custom service
+
+### external_functions table
+
+This table lists the web service functions. It makes sense to call it external_functions as 1 web service function <=> 1 external function. This table maps the web service function name to the actual implementation of that function.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| **id** | int(10) | auto-incrementing |  |
+| **name** | varchar(200) |  | the web service name (e.g. the unique name of the external function in the web service API) - a unique identifier for each function; ex.: core_get_users, mod_assignment_submit |
+| classname | varchar(100) |  | name of the class that contains method implementation; ex.: core_user_external, mod_assignment_external |
+| methodname | varchar(100) |  | static method; ex.: get_users, submit |
+| classpath | varchar(255) | NULL | optional path to file with class definition - recommended for core classes only, null means use component/externallib.php; this path is relative to dirroot; ex.: user/externallib.php |
+| component | varchar(100) |  | Component where function defined, needed for automatic updates. Service description file is found in the db folder of this component. |
+| description | text |  | A short human readable description of the function. It will be used to generate documentation and help the administrator to search a web service function. (NB: decide later if it's really improving the performance compare to add an access to the phpfile) |
+
+Detailed function description is stored as a complex PHP structure in the implementation class using suffix _parameters and _returns.
+
+### external_services table
+
+A *service* is defined as a group of external functions. The main purpose of these *services* is to allow defining of granular access control for multiple external systems.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| **id** | int(10) | auto-incrementing |  |
+| **name** | varchar(150) |  | Name of service (gradeexport_xml_export, mod_chat_export) - appears on the admin page. This name is not human readable when displayed into administration. We will use lang file to translate them automatically if a lang string exist. |
+| enabled | int(1) | 0 | service enabled, for security reasons some services may be disabled- administrators may disable any service via the admin UI |
+| requiredcapability | varchar(255) | NULL | if capability name specified, user needs to have this permission in security context or in system context if context restriction not specified |
+| restrictedusers | int(1) | 1 | 1 means on users explicitly listed in external_services_users may access this service, 0 means any user may use this service |
+| component | varchar(100) | NULL | Component where service defined - null means custom service defined in admin UI. |
+| timecreated | bigint(10) |  | The time the service was enabled or defined? |
+| timemodified | bigint(10) |  | The last time the service was updated |
+| shortname | varchar(255) |  | The short name of the service |
+| downloadfiles | tinyint(1) |  | A flag for something to do with download and files? |
+
+### external_services_functions table
+
+Lists all functions that are available in each service.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| **id** | int(10) | auto-incrementing |  |
+| **externalserviceid** | int(10) |  | foreign key, reference external_services.id |
+| **functionname** | varchar(200) |  | unique name of external function: references external_functions.name; the string value here simplifies service discovery and maintenance |
+
+### Function description
+
+We need to describe each function in detail, including input and output, so that we can:
+
+- help programmers quickly understand what they have to send and what to expect
+- validate all incoming data as automatically as possible for security/correctness
+- generate WSDL files for SOAP
+- generate documentation for other protocols
+
+There are three main parts working together to do this:
+
+#### services.php
+
+In the db/services.php of each component, is a structure something like this to describe the web service functions, and optionally, any larger services built up of several functions.
+
+```php
+$functions = array(
+    'moodle_user_create_users' => array(           //web service name (unique in all Moodle)
+        'classname'   => 'moodle_user_external', //class containing the function implementation
+        'methodname'  => 'create_users',              //name of the function into the class
+        'classpath'   => 'user/externallib.php',     //file containing the class (only used for core external function, not needed if your file is 'component/externallib.php'),
+        'description' => 'create some users',
+        'type' => 'write',
+        'services' => array(MOODLE_OFFICIAL_MOBILE_SERVICE)    // Optional, only available for Moodle 3.1 onwards. List of built-in services (by shortname) where the function will be included. Services created manually via the Moodle interface are not supported.
+    )
+);
+
+$services = array(
+    'servicename' => array(
+        'functions' => array ('functionname', 'secondfunctionname'), //web service function name
+        'requiredcapability' => 'some/capability:specified',
+        'restrictedusers' => 1,
+        'enabled'=>0, //used only when installing the services
+    )
+);
+```
+
+The function name is arbitrary, but must follow [the naming convention](https://docs.moodle.org/dev/Web_service_API_functions#Naming_convention). This helps ensure that it is globally unique.
+
+The actual param description and description of returned values can be obtained from the same class by static method calls by adding '_parameters' and '_returns' to the methodname value.
+
+#### externallib.php
+
+It's the file referenced as the location for the web service function implementation. It also contains complete descriptions of the required parameters.
+
+*Base description classes:*
+
+```php
+abstract class external_description {
+    public $desc; //human readable description
+    public $required;
+
+    public function __construct($desc, $required) {
+        $this->desc = $desc;
+        $this->required = $required;
+    }
+}
+
+class external_value extends external_description {
+    public $type;
+    public $default;
+    public $allownull;
+
+    public function __construct($type, $desc='', $required=VALUE_REQUIRED, $default=null, $allownull=true) {
+        parent::_construct($desc, $required);
+        $this->type      = $type;
+        $this->default   = $default;
+        $this->allownull = $allownull;
+    }
+}
+
+class external_single_structure extends external_description {
+    public $keys; //an associative array of external_description
+
+    public function __construct(array $keys, $desc='', $required=VALUE_REQUIRED) {
+        parent::_construct($desc, $required);
+        $this->keys = $keys; //key=>external_description
+    }
+}
+
+class external_multiple_structure extends external_description {
+    public $content; //the content type of the list => external_description
+
+    public function __construct(external_description $content, $desc='', $required=VALUE_REQUIRED) {
+        parent::_construct($desc, $required);
+        $this->content = $content;
+    }
+}
+
+class external_function_parameters extends external_single_structure {
+}
+
+```
+
+*Externallib.php examples:*<br/>
+These examples include param/return value descriptions and function implementations. See the create_users function for difference between Mandatory/Optional/Default.
+
+```php
+class moodle_group_external extends external_api { //see following chapter 'function implementation' to have a look to the external_api class
+    public static function add_member_parameters() {
+        return new external_function_parameters(
+            array(
+                'groupid' => new external_value(PARAM_INT, 'some group id'),
+                'userid'  => new external_value(PARAM_INT, 'some user id')
+            )
+        );
+    }
+    public static function add_member($groupid, $userid) {
+        $params = self::validate_parameters(self::add_member_parameters(), array('groupid'=>$groupid, 'userid'=>$userid));
+
+        // all the parameter/behavioural checks and security constrainsts go here,
+        // throwing exceptions if neeeded and and calling low level (grouplib)
+        // add_member() function that will be one in charge of the functionality without
+        // further checks.
+
+    }
+    public static function add_member_returns() {
+        return null;
+    }
+
+
+    public static function add_members_parameters() {
+        return new external_function_parameters(
+            array(
+                'membership' => new external_multiple_structure(
+                    self::add_member_parameters()
+                )
+            )
+        );
+    }
+    public static function add_members(array $membership) {
+        $params = self::validate_parameters(self::add_members_parameters(), array('membership'=>$membership));
+        foreach($params['membership'] as $one) { // simply one iterator over the "single" function if possible
+            self::add_member($one->groupid, $one->userid);
+        }
+    }
+    public static function add_members_returns() {
+        return null;
+    }
+
+
+    public static function get_groups_parameters() {
+        return new external_function_parameters(
+            array(
+                'groups' => new external_multiple_structure(
+                    new external_single_structure(
+                        array(
+                            'groupid' => new external_value(PARAM_INT, 'some group id')
+                        )
+                    )
+                )
+            )
+        );
+    }
+    public static function get_groups(array $groups) {
+        $params = self::validate_parameters(self::get_groups_parameters(), array('groups'=>$groups));
+
+        // all the parameter/behavioural checks and security constrainsts go here,
+        // throwing exceptions if needed and and calling low level (grouplib)
+        // get_groups() function that will be one in charge of the functionality without
+        // further checks.
+
+    }
+    public static function get_groups_returns() {
+        return new external_multiple_structure(
+            new external_single_structure(
+                array(
+                    'id' => new external_value(PARAM_INT, 'some group id'),
+                    'name' => new external_value(PARAM_TEXT, 'multilang compatible name, course unique'),
+                    'description' => new external_value(PARAM_RAW, 'just some text'),
+                    'enrolmentkey' => new external_value(PARAM_RAW, 'group enrol secret phrase')
+                )
+            )
+        );
+    }
+}
+
+
+class moodle_user_external extends external_api {
+    public static function create_users_parameters() {
+        new external_function_parameters(
+            array(
+                'users' => new external_multiple_structure(
+                    new external_single_structure(
+                        array(
+                            'username'    => new external_value(PARAM_RAW, 'Username policy is defined in Moodle security config'),
+                            'password'    => new external_value(PARAM_RAW, 'Plain text password consisting of any characters'),
+                            'firstname'   => new external_value(PARAM_NOTAGS, 'The first name(s) of the user'),
+                            'lastname'    => new external_value(PARAM_NOTAGS, 'The family name of the user'),
+                            'email'       => new external_value(PARAM_EMAIL, 'A valid and unique email address'),
+                            'auth'        => new external_value(PARAM_SAFEDIR, 'Auth plugins include manual, ldap,
+                                                                imap, etc', VALUE_DEFAULT,'manual', false),
+                            'idnumber'    => new external_value(PARAM_RAW, 'An arbitrary ID code number perhaps from the institution',
+                                                                VALUE_DEFAULT, null),
+                            'emailstop'   => new external_value(PARAM_NUMBER, 'Email is blocked: 1 is blocked and 0 otherwise',
+                                                                VALUE_DEFAULT, 0),
+                            'lang'        => new external_value(PARAM_SAFEDIR, 'Language code such as "en_utf8" must exist on server',
+                                                                VALUE_DEFAULT, $CFG->lang, false),
+                            'theme'       => new external_value(PARAM_SAFEDIR, 'Theme name such as "standard" must exist on server',
+                                                                VALUE_OPTIONAL),
+                            'timezone'    => new external_value(PARAM_ALPHANUMEXT, 'Timezone code such as Australia/Perth,or 99 for default',
+                                                                VALUE_OPTIONAL),
+                            'mailformat'  => new external_value(PARAM_INTEGER, 'Mail format code is 0 for plain text, 1 for HTML etc',
+                                                                VALUE_OPTIONAL),
+                            'description' => new external_value(PARAM_TEXT, 'User profile description, as HTML', VALUE_OPTIONAL),
+                            'city'        => new external_value(PARAM_NOTAGS, 'Home city of the user', VALUE_OPTIONAL),
+                            'country'     => new external_value(PARAM_ALPHA, 'Home country code of the user, such as AU or CZ',
+                                                                VALUE_OPTIONAL),
+                            'preferences' => new external_multiple_structure(
+                                new external_single_structure(
+                                    array(
+                                        'type'  => new external_value(PARAM_ALPHANUMEXT, 'The name of the preference'),
+                                        'value' => new external_value(PARAM_RAW, 'The value of the preference')
+                                    )
+                                ), 'User preferences', VALUE_OPTIONAL),
+                            'customfields' => new external_multiple_structure(
+                                new external_single_structure(
+                                    array(
+                                        'type'  => new external_value(PARAM_ALPHANUMEXT, 'The name of the custom field'),
+                                        'value' => new external_value(PARAM_RAW, 'The value of the custom field')
+                                    )
+                                ), 'User custom fields', VALUE_OPTIONAL)
+                        )
+                    )
+                )
+            )
+        );
+    }
+    public static function create_users(array $users) {
+        $params = self::validate_parameters(self::create_users_parameters(), array('users'=>$users));
+
+        foreach ($params['users'] as $user) {
+            // all the parameter/behavioural checks and security constrainsts go here,
+            // throwing exceptions if neeeded and and calling low level (userlib)
+            // add_user() function that will be one in charge of the functionality without
+            // further checks.
+        }
+    }
+    public static function create_users_returns() {
+        return new external_multiple_structure(
+            new external_value('userid', PARAM_INT, 'id of the created user')
+        );
+    }
+}
+```
+
+Note the use of Moodle-oriented PARAM_XXXX constants to define the format of each field.  These are used by the validation function *validate_parameters()* to verify the data and throw an exception and abort the operation completely if the data changed during cleaning (ie it was malformed).
+
+#### Params
+
+We use the clean_param function to check data.  We have added in *moodlelib.php* some new checks for common Moodle data so that we get better cleaning.  eg
+
+```php
+...
+        case PARAM_AUTH:
+            $param = clean_param($param, PARAM_SAFEDIR);
+            if (exists_auth_plugin($param)) {
+                return $param;
+            } else {
+                return '';
+            }
+
+        case PARAM_LANG:
+            $param = clean_param($param, PARAM_SAFEDIR);
+            $langs = get_list_of_languages(false, true);
+            if (in_array($param, $langs)) {
+                return $param;
+            } else {
+                return '';  // Specified language is not installed
+            }
+
+        case PARAM_THEME:
+            $param = clean_param($param, PARAM_SAFEDIR);
+            if (file_exists($CFG->dirroot.'/theme/'.$param)) {
+                return $param;
+            } else {
+                return '';  // Specified theme is not installed
+            }
+...
+```
+
+##### Parameters types
+
+Note, this list will almost certainly be out of date by the time you read it. Do yourself a favour, and look at the list in lib/moodlelib.php. That is guaranteed to be up-to-date.
+
+- 'PARAM_ALPHA',    'alpha'
+- 'PARAM_ALPHAEXT', 'alphaext'
+- 'PARAM_ALPHANUM', 'alphanum'
+- 'PARAM_ALPHANUMEXT', 'alphanumext'
+- 'PARAM_AUTH',  'auth'
+- 'PARAM_BASE64',   'base64'
+- 'PARAM_BOOL',     'bool'
+- 'PARAM_CAPABILITY',   'capability'
+- 'PARAM_CLEANHTML', 'cleanhtml'
+- 'PARAM_EMAIL',   'email'
+- 'PARAM_FILE',   'file'
+- 'PARAM_FLOAT',  'float'
+- 'PARAM_HOST',     'host'
+- 'PARAM_INT',      'int'
+- 'PARAM_LANG',  'lang'
+- 'PARAM_LOCALURL', 'localurl'
+- 'PARAM_NOTAGS',   'notags'
+- 'PARAM_PATH',     'path'
+- 'PARAM_PEM',      'pem'
+- 'PARAM_PERMISSION',   'permission'
+- 'PARAM_RAW', 'raw'
+- 'PARAM_RAW_TRIMMED', 'raw_trimmed'
+- 'PARAM_SAFEDIR',  'safedir'
+- 'PARAM_SAFEPATH',  'safepath'
+- 'PARAM_SEQUENCE',  'sequence'
+- 'PARAM_TAG',   'tag'
+- 'PARAM_TAGLIST',   'taglist'
+- 'PARAM_TEXT',  'text'
+- 'PARAM_THEME',  'theme'
+- 'PARAM_URL',      'url'
+- 'PARAM_USERNAME',    'username'
+- 'PARAM_STRINGID',    'stringid'
+- 'PARAM_CLEAN',    'clean'
+- 'PARAM_INTEGER',  'int'
+- 'PARAM_NUMBER',  'float'
+- 'PARAM_ACTION',   'alphanumext'
+- 'PARAM_FORMAT',   'alphanumext'
+- 'PARAM_MULTILANG',  'text'
+- 'PARAM_TIMEZONE', 'timezone'
+- 'PARAM_CLEANFILE', 'file'
+- 'PARAM_COMPONENT', 'component'
+- 'PARAM_AREA', 'area'
+- 'PARAM_PLUGIN', 'plugin'
+
+### Function implementation
+
+As you probably understood when you read the previous chapter examples, the functions are generally stored in externallib.php files, as methods in a class that extends **'external_api**'.  The actual file location is referenced by **'classpath**' in the services.php description.
+
+```php
+class moodle_user_external extends external_api {
+    public static function create_users($users)
+    $params = self::validate_parameters(self::create_users_parameters(), array('users'=>$users)); //ws object are associative array, ws list are non associative array
+
+        foreach ($params['users'] as $user) {
+            // all the parameter/behavioural checks and security constraints go here,
+            // throwing exceptions if needed and and calling low level (userlib)
+            // add_user() function that will be one in charge of the functionality without
+            // further checks.
+        }
+    }
+}
+```
+
+Note: there is more examples in the previous chapter
+
+external_api file:
+
+```php
+/**
+ * Base class for external api methods.
+ */
+class external_api {
+
+     ...
+
+     /**
+     * Validates submitted function parameters, if anything is incorrect
+     * invalid_parameter_exception is thrown.
+     * This is a simple recursive method which is intended to be called from
+     * each implementation method of external API.
+     * @param external_description $description description of parameters
+     * @param mixed $params the actual parameters
+     * @return mixed params with added defaults for optional items, invalid_parameters_exception thrown if any problem found
+     */
+    public static function validate_parameters(external_description $description, $params) {
+         ...
+    }
+
+    ...
+}
+```
+
+### Way to fill the database tables
+
+The Moodle upgrade takes care of the updates. We added two functions *lib/upgradelib.php/external_update_description()* and *lib/upgradelib.php/external_delete_description()* that update all web service descriptions into the database. *lib/upgradelib.php/external_update_description()* is also called during Moodle installation process.
+
+### Return values are filtered by the servers
+
+Web service functions should be able to return whatever they want. Each server should be looking at the web services description and returns the expected values.
+
+Some bulk requests may terminate unexpectedly in the middle of processing elements, these partial failures should be indicated by special exceptions classes which include list of completed elements and original exception.
+
+TODO: special exceptions and the way to manage them need to be detailed.
+
+# See also
+
+- [Web services](./index.md)
+- [External services security](./security.md)

--- a/docs/apis/subsystems/external/description.md
+++ b/docs/apis/subsystems/external/description.md
@@ -1,467 +1,83 @@
 ---
-title: Service Descriptions
+title: Function Declarations
 tags:
   - Web Services
   - core_external
   - external
   - API
+sidebar_position: 1
 ---
-{{Moodle_2.0}}
 
-## Purpose
+Before they can be used, all functions must be _declared_ to Moodle, and their inputs and outputs must be _defined_.
 
-This document explains how we describe and where we store the external services and functions in Moodle 2.0.
+- Functions are _declared_ by noting them in the `db/services.php` file for a plugin.
+- Functions are _defined_ within their own class located within the `\component\external` namespace of a component.
 
-### Service discovery
+Function implementation classes consist of one class containing a number of functions, some of which are mandatory.
 
-We store the service descriptions and a part of the function descriptions in the component/db/services.php file. Function implementations are located under \component\external classes (previously in externallib.php files). These external functions, one per class (and file) also contain the other part of the function descriptions (the function parameters descriptions).
+During a Moodle installation or upgrade, the service and function _declarations_ are parsed by a service discovery process and stored within the database. An administrative UI may be used to change _some_ configuration details of these declarations.
 
-During the upgrades the descriptions are parsed by a service discovery function that fills the database tables. Administrative UI may be used to change some configuration details. Services can also be defined via the admin UI, but it is recommended to use the new local plugin (look at the readme.txt into the Moodle local folder) when adding custom new services.
+## Service declarations
 
-### Administration pages
+Each component wishing to create an external service function must declare that the function exists by describing it in the `db/services.php` file for that component.
 
-Moodle administrators will be able to manage services. By default all services will be disabled.
+This information is stored internally within Moodle, and collected as part of the service discovery during installation and upgrade.
 
-List of administration functionalities:
+```php title="local/groupmanager/db/services.php"
+$functions = [
+    // The name of your web service function, as discussed above.
+    'local_myplugin_create_groups' => [
+        // The name of the namespaced class that the function is located in.
+        'classname'   => 'local_groupmanager\create_groups',
 
-- enable a service (all the functions into this service will be available)
-- associate a web service user (the user has web service capability) to some services => a user can only call a service that he is associated with
-- create a custom service (name the service + add and remove existing external functions from this service)
-- search easily function by component in order to create a custom service
+        // A brief, human-readable, description of the web service function.
+        'description' => 'Creates new groups.',
 
-### external_functions table
+        // Options include read, and write.
+        'type'        => 'write',
 
-This table lists the web service functions. It makes sense to call it external_functions as 1 web service function <=> 1 external function. This table maps the web service function name to the actual implementation of that function.
+        // Whether the service is available for use in AJAX calls from the web.
+        'ajax'        => true,
 
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| **id** | int(10) | auto-incrementing |  |
-| **name** | varchar(200) |  | the web service name (e.g. the unique name of the external function in the web service API) - a unique identifier for each function; ex.: core_get_users, mod_assignment_submit |
-| classname | varchar(100) |  | name of the class that contains method implementation; ex.: core_user_external, mod_assignment_external |
-| methodname | varchar(100) |  | static method; ex.: get_users, submit |
-| classpath | varchar(255) | NULL | optional path to file with class definition - recommended for core classes only, null means use component/externallib.php; this path is relative to dirroot; ex.: user/externallib.php |
-| component | varchar(100) |  | Component where function defined, needed for automatic updates. Service description file is found in the db folder of this component. |
-| description | text |  | A short human readable description of the function. It will be used to generate documentation and help the administrator to search a web service function. (NB: decide later if it's really improving the performance compare to add an access to the phpfile) |
-
-Detailed function description is stored as a complex PHP structure in the implementation class using suffix _parameters and _returns.
-
-### external_services table
-
-A *service* is defined as a group of external functions. The main purpose of these *services* is to allow defining of granular access control for multiple external systems.
-
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| **id** | int(10) | auto-incrementing |  |
-| **name** | varchar(150) |  | Name of service (gradeexport_xml_export, mod_chat_export) - appears on the admin page. This name is not human readable when displayed into administration. We will use lang file to translate them automatically if a lang string exist. |
-| enabled | int(1) | 0 | service enabled, for security reasons some services may be disabled- administrators may disable any service via the admin UI |
-| requiredcapability | varchar(255) | NULL | if capability name specified, user needs to have this permission in security context or in system context if context restriction not specified |
-| restrictedusers | int(1) | 1 | 1 means on users explicitly listed in external_services_users may access this service, 0 means any user may use this service |
-| component | varchar(100) | NULL | Component where service defined - null means custom service defined in admin UI. |
-| timecreated | bigint(10) |  | The time the service was enabled or defined? |
-| timemodified | bigint(10) |  | The last time the service was updated |
-| shortname | varchar(255) |  | The short name of the service |
-| downloadfiles | tinyint(1) |  | A flag for something to do with download and files? |
-
-### external_services_functions table
-
-Lists all functions that are available in each service.
-
-| Field | Type | Default | Description |
-| --- | --- | --- | --- |
-| **id** | int(10) | auto-incrementing |  |
-| **externalserviceid** | int(10) |  | foreign key, reference external_services.id |
-| **functionname** | varchar(200) |  | unique name of external function: references external_functions.name; the string value here simplifies service discovery and maintenance |
-
-### Function description
-
-We need to describe each function in detail, including input and output, so that we can:
-
-- help programmers quickly understand what they have to send and what to expect
-- validate all incoming data as automatically as possible for security/correctness
-- generate WSDL files for SOAP
-- generate documentation for other protocols
-
-There are three main parts working together to do this:
-
-#### services.php
-
-In the db/services.php of each component, is a structure something like this to describe the web service functions, and optionally, any larger services built up of several functions.
-
-```php
-$functions = array(
-    'moodle_user_create_users' => array(           //web service name (unique in all Moodle)
-        'classname'   => 'moodle_user_external', //class containing the function implementation
-        'methodname'  => 'create_users',              //name of the function into the class
-        'classpath'   => 'user/externallib.php',     //file containing the class (only used for core external function, not needed if your file is 'component/externallib.php'),
-        'description' => 'create some users',
-        'type' => 'write',
-        'services' => array(MOODLE_OFFICIAL_MOBILE_SERVICE)    // Optional, only available for Moodle 3.1 onwards. List of built-in services (by shortname) where the function will be included. Services created manually via the Moodle interface are not supported.
-    )
-);
-
-$services = array(
-    'servicename' => array(
-        'functions' => array ('functionname', 'secondfunctionname'), //web service function name
-        'requiredcapability' => 'some/capability:specified',
-        'restrictedusers' => 1,
-        'enabled'=>0, //used only when installing the services
-    )
+        // An optional list of services where the function will be included.
+        'services'    => [
+            // A standard Moodle install includes one default service:
+            // - MOODLE_OFFICIAL_MOBILE_SERVICE.
+            // Specifying this service means that your function will be available for
+            // use in the Moodle Mobile App.
+            MOODLE_OFFICIAL_MOBILE_SERVICE,
+        ],
+    ),
 );
 ```
+
+<details>
+<summary>Advanced options</summary>
+
+A number of advanced options are also available, as described below:
+
+```php title="local/groupmanager/db/services.php"
+$functions = [
+    // The name of your web service function, as discussed above.
+    'local_myplugin_create_groups' => [
+        // A comma-separated list of capabilities used by the function.
+        // This is advisory only and used to indicate to the administrator
+        // configuring a custom service definition.
+        'capabilities' => 'moodle/course:creategroups,moodle/course:managegroups',
+
+        // The following parameters are also available, but are no longer recommended.
+
+        // The name of the external function name.
+        // If not specified, this will default to 'execute'.
+        'methodname'  => 'execute',
+
+        // The file containing the class/external function.
+        // Do not use if using namespaced auto-loading classes.
+        'classpath'   => 'local/groupmanager/externallib.php',
+    ),
+);
+```
+
+</details>
 
 The function name is arbitrary, but must follow [the naming convention](https://docs.moodle.org/dev/Web_service_API_functions#Naming_convention). This helps ensure that it is globally unique.
-
-The actual param description and description of returned values can be obtained from the same class by static method calls by adding '_parameters' and '_returns' to the methodname value.
-
-#### externallib.php
-
-It's the file referenced as the location for the web service function implementation. It also contains complete descriptions of the required parameters.
-
-*Base description classes:*
-
-```php
-abstract class external_description {
-    public $desc; //human readable description
-    public $required;
-
-    public function __construct($desc, $required) {
-        $this->desc = $desc;
-        $this->required = $required;
-    }
-}
-
-class external_value extends external_description {
-    public $type;
-    public $default;
-    public $allownull;
-
-    public function __construct($type, $desc='', $required=VALUE_REQUIRED, $default=null, $allownull=true) {
-        parent::_construct($desc, $required);
-        $this->type      = $type;
-        $this->default   = $default;
-        $this->allownull = $allownull;
-    }
-}
-
-class external_single_structure extends external_description {
-    public $keys; //an associative array of external_description
-
-    public function __construct(array $keys, $desc='', $required=VALUE_REQUIRED) {
-        parent::_construct($desc, $required);
-        $this->keys = $keys; //key=>external_description
-    }
-}
-
-class external_multiple_structure extends external_description {
-    public $content; //the content type of the list => external_description
-
-    public function __construct(external_description $content, $desc='', $required=VALUE_REQUIRED) {
-        parent::_construct($desc, $required);
-        $this->content = $content;
-    }
-}
-
-class external_function_parameters extends external_single_structure {
-}
-
-```
-
-*Externallib.php examples:*<br/>
-These examples include param/return value descriptions and function implementations. See the create_users function for difference between Mandatory/Optional/Default.
-
-```php
-class moodle_group_external extends external_api { //see following chapter 'function implementation' to have a look to the external_api class
-    public static function add_member_parameters() {
-        return new external_function_parameters(
-            array(
-                'groupid' => new external_value(PARAM_INT, 'some group id'),
-                'userid'  => new external_value(PARAM_INT, 'some user id')
-            )
-        );
-    }
-    public static function add_member($groupid, $userid) {
-        $params = self::validate_parameters(self::add_member_parameters(), array('groupid'=>$groupid, 'userid'=>$userid));
-
-        // all the parameter/behavioural checks and security constrainsts go here,
-        // throwing exceptions if neeeded and and calling low level (grouplib)
-        // add_member() function that will be one in charge of the functionality without
-        // further checks.
-
-    }
-    public static function add_member_returns() {
-        return null;
-    }
-
-
-    public static function add_members_parameters() {
-        return new external_function_parameters(
-            array(
-                'membership' => new external_multiple_structure(
-                    self::add_member_parameters()
-                )
-            )
-        );
-    }
-    public static function add_members(array $membership) {
-        $params = self::validate_parameters(self::add_members_parameters(), array('membership'=>$membership));
-        foreach($params['membership'] as $one) { // simply one iterator over the "single" function if possible
-            self::add_member($one->groupid, $one->userid);
-        }
-    }
-    public static function add_members_returns() {
-        return null;
-    }
-
-
-    public static function get_groups_parameters() {
-        return new external_function_parameters(
-            array(
-                'groups' => new external_multiple_structure(
-                    new external_single_structure(
-                        array(
-                            'groupid' => new external_value(PARAM_INT, 'some group id')
-                        )
-                    )
-                )
-            )
-        );
-    }
-    public static function get_groups(array $groups) {
-        $params = self::validate_parameters(self::get_groups_parameters(), array('groups'=>$groups));
-
-        // all the parameter/behavioural checks and security constrainsts go here,
-        // throwing exceptions if needed and and calling low level (grouplib)
-        // get_groups() function that will be one in charge of the functionality without
-        // further checks.
-
-    }
-    public static function get_groups_returns() {
-        return new external_multiple_structure(
-            new external_single_structure(
-                array(
-                    'id' => new external_value(PARAM_INT, 'some group id'),
-                    'name' => new external_value(PARAM_TEXT, 'multilang compatible name, course unique'),
-                    'description' => new external_value(PARAM_RAW, 'just some text'),
-                    'enrolmentkey' => new external_value(PARAM_RAW, 'group enrol secret phrase')
-                )
-            )
-        );
-    }
-}
-
-
-class moodle_user_external extends external_api {
-    public static function create_users_parameters() {
-        new external_function_parameters(
-            array(
-                'users' => new external_multiple_structure(
-                    new external_single_structure(
-                        array(
-                            'username'    => new external_value(PARAM_RAW, 'Username policy is defined in Moodle security config'),
-                            'password'    => new external_value(PARAM_RAW, 'Plain text password consisting of any characters'),
-                            'firstname'   => new external_value(PARAM_NOTAGS, 'The first name(s) of the user'),
-                            'lastname'    => new external_value(PARAM_NOTAGS, 'The family name of the user'),
-                            'email'       => new external_value(PARAM_EMAIL, 'A valid and unique email address'),
-                            'auth'        => new external_value(PARAM_SAFEDIR, 'Auth plugins include manual, ldap,
-                                                                imap, etc', VALUE_DEFAULT,'manual', false),
-                            'idnumber'    => new external_value(PARAM_RAW, 'An arbitrary ID code number perhaps from the institution',
-                                                                VALUE_DEFAULT, null),
-                            'emailstop'   => new external_value(PARAM_NUMBER, 'Email is blocked: 1 is blocked and 0 otherwise',
-                                                                VALUE_DEFAULT, 0),
-                            'lang'        => new external_value(PARAM_SAFEDIR, 'Language code such as "en_utf8" must exist on server',
-                                                                VALUE_DEFAULT, $CFG->lang, false),
-                            'theme'       => new external_value(PARAM_SAFEDIR, 'Theme name such as "standard" must exist on server',
-                                                                VALUE_OPTIONAL),
-                            'timezone'    => new external_value(PARAM_ALPHANUMEXT, 'Timezone code such as Australia/Perth,or 99 for default',
-                                                                VALUE_OPTIONAL),
-                            'mailformat'  => new external_value(PARAM_INTEGER, 'Mail format code is 0 for plain text, 1 for HTML etc',
-                                                                VALUE_OPTIONAL),
-                            'description' => new external_value(PARAM_TEXT, 'User profile description, as HTML', VALUE_OPTIONAL),
-                            'city'        => new external_value(PARAM_NOTAGS, 'Home city of the user', VALUE_OPTIONAL),
-                            'country'     => new external_value(PARAM_ALPHA, 'Home country code of the user, such as AU or CZ',
-                                                                VALUE_OPTIONAL),
-                            'preferences' => new external_multiple_structure(
-                                new external_single_structure(
-                                    array(
-                                        'type'  => new external_value(PARAM_ALPHANUMEXT, 'The name of the preference'),
-                                        'value' => new external_value(PARAM_RAW, 'The value of the preference')
-                                    )
-                                ), 'User preferences', VALUE_OPTIONAL),
-                            'customfields' => new external_multiple_structure(
-                                new external_single_structure(
-                                    array(
-                                        'type'  => new external_value(PARAM_ALPHANUMEXT, 'The name of the custom field'),
-                                        'value' => new external_value(PARAM_RAW, 'The value of the custom field')
-                                    )
-                                ), 'User custom fields', VALUE_OPTIONAL)
-                        )
-                    )
-                )
-            )
-        );
-    }
-    public static function create_users(array $users) {
-        $params = self::validate_parameters(self::create_users_parameters(), array('users'=>$users));
-
-        foreach ($params['users'] as $user) {
-            // all the parameter/behavioural checks and security constrainsts go here,
-            // throwing exceptions if neeeded and and calling low level (userlib)
-            // add_user() function that will be one in charge of the functionality without
-            // further checks.
-        }
-    }
-    public static function create_users_returns() {
-        return new external_multiple_structure(
-            new external_value('userid', PARAM_INT, 'id of the created user')
-        );
-    }
-}
-```
-
-Note the use of Moodle-oriented PARAM_XXXX constants to define the format of each field.  These are used by the validation function *validate_parameters()* to verify the data and throw an exception and abort the operation completely if the data changed during cleaning (ie it was malformed).
-
-#### Params
-
-We use the clean_param function to check data.  We have added in *moodlelib.php* some new checks for common Moodle data so that we get better cleaning.  eg
-
-```php
-...
-        case PARAM_AUTH:
-            $param = clean_param($param, PARAM_SAFEDIR);
-            if (exists_auth_plugin($param)) {
-                return $param;
-            } else {
-                return '';
-            }
-
-        case PARAM_LANG:
-            $param = clean_param($param, PARAM_SAFEDIR);
-            $langs = get_list_of_languages(false, true);
-            if (in_array($param, $langs)) {
-                return $param;
-            } else {
-                return '';  // Specified language is not installed
-            }
-
-        case PARAM_THEME:
-            $param = clean_param($param, PARAM_SAFEDIR);
-            if (file_exists($CFG->dirroot.'/theme/'.$param)) {
-                return $param;
-            } else {
-                return '';  // Specified theme is not installed
-            }
-...
-```
-
-##### Parameters types
-
-Note, this list will almost certainly be out of date by the time you read it. Do yourself a favour, and look at the list in lib/moodlelib.php. That is guaranteed to be up-to-date.
-
-- 'PARAM_ALPHA',    'alpha'
-- 'PARAM_ALPHAEXT', 'alphaext'
-- 'PARAM_ALPHANUM', 'alphanum'
-- 'PARAM_ALPHANUMEXT', 'alphanumext'
-- 'PARAM_AUTH',  'auth'
-- 'PARAM_BASE64',   'base64'
-- 'PARAM_BOOL',     'bool'
-- 'PARAM_CAPABILITY',   'capability'
-- 'PARAM_CLEANHTML', 'cleanhtml'
-- 'PARAM_EMAIL',   'email'
-- 'PARAM_FILE',   'file'
-- 'PARAM_FLOAT',  'float'
-- 'PARAM_HOST',     'host'
-- 'PARAM_INT',      'int'
-- 'PARAM_LANG',  'lang'
-- 'PARAM_LOCALURL', 'localurl'
-- 'PARAM_NOTAGS',   'notags'
-- 'PARAM_PATH',     'path'
-- 'PARAM_PEM',      'pem'
-- 'PARAM_PERMISSION',   'permission'
-- 'PARAM_RAW', 'raw'
-- 'PARAM_RAW_TRIMMED', 'raw_trimmed'
-- 'PARAM_SAFEDIR',  'safedir'
-- 'PARAM_SAFEPATH',  'safepath'
-- 'PARAM_SEQUENCE',  'sequence'
-- 'PARAM_TAG',   'tag'
-- 'PARAM_TAGLIST',   'taglist'
-- 'PARAM_TEXT',  'text'
-- 'PARAM_THEME',  'theme'
-- 'PARAM_URL',      'url'
-- 'PARAM_USERNAME',    'username'
-- 'PARAM_STRINGID',    'stringid'
-- 'PARAM_CLEAN',    'clean'
-- 'PARAM_INTEGER',  'int'
-- 'PARAM_NUMBER',  'float'
-- 'PARAM_ACTION',   'alphanumext'
-- 'PARAM_FORMAT',   'alphanumext'
-- 'PARAM_MULTILANG',  'text'
-- 'PARAM_TIMEZONE', 'timezone'
-- 'PARAM_CLEANFILE', 'file'
-- 'PARAM_COMPONENT', 'component'
-- 'PARAM_AREA', 'area'
-- 'PARAM_PLUGIN', 'plugin'
-
-### Function implementation
-
-As you probably understood when you read the previous chapter examples, the functions are generally stored in externallib.php files, as methods in a class that extends **'external_api**'.  The actual file location is referenced by **'classpath**' in the services.php description.
-
-```php
-class moodle_user_external extends external_api {
-    public static function create_users($users)
-    $params = self::validate_parameters(self::create_users_parameters(), array('users'=>$users)); //ws object are associative array, ws list are non associative array
-
-        foreach ($params['users'] as $user) {
-            // all the parameter/behavioural checks and security constraints go here,
-            // throwing exceptions if needed and and calling low level (userlib)
-            // add_user() function that will be one in charge of the functionality without
-            // further checks.
-        }
-    }
-}
-```
-
-Note: there is more examples in the previous chapter
-
-external_api file:
-
-```php
-/**
- * Base class for external api methods.
- */
-class external_api {
-
-     ...
-
-     /**
-     * Validates submitted function parameters, if anything is incorrect
-     * invalid_parameter_exception is thrown.
-     * This is a simple recursive method which is intended to be called from
-     * each implementation method of external API.
-     * @param external_description $description description of parameters
-     * @param mixed $params the actual parameters
-     * @return mixed params with added defaults for optional items, invalid_parameters_exception thrown if any problem found
-     */
-    public static function validate_parameters(external_description $description, $params) {
-         ...
-    }
-
-    ...
-}
-```
-
-### Way to fill the database tables
-
-The Moodle upgrade takes care of the updates. We added two functions *lib/upgradelib.php/external_update_description()* and *lib/upgradelib.php/external_delete_description()* that update all web service descriptions into the database. *lib/upgradelib.php/external_update_description()* is also called during Moodle installation process.
-
-### Return values are filtered by the servers
-
-Web service functions should be able to return whatever they want. Each server should be looking at the web services description and returns the expected values.
-
-Some bulk requests may terminate unexpectedly in the middle of processing elements, these partial failures should be indicated by special exceptions classes which include list of completed elements and original exception.
-
-TODO: special exceptions and the way to manage them need to be detailed.
-
-# See also
-
-- [Web services](./index.md)
-- [External services security](./security.md)

--- a/docs/apis/subsystems/external/files.md
+++ b/docs/apis/subsystems/external/files.md
@@ -1,0 +1,93 @@
+---
+title: File handling
+tags:
+  - Web_Services
+  - core_external
+  - external
+  - core_files
+---
+
+## Summary
+
+Since Moodle 2.0, we provide web service functions to upload and download files. They are:
+
+1. moodle_file_get_files (Deprecated, use core_files_get_files since moodle 2.2 onward)
+1. moodle_file_upload (Deprecated, use core_files_upload since moodle 2.2 onward)
+
+File contents are encoded in base64, and for web service transmission, it's not efficient. Mobile devices don't have enough memory to decode/encode web service request/response containing large files.
+
+So we developed some alternative solutions to upload/download files.
+
+## File upload
+
+The entry point is */webservice/upload.php*, simply use HTTP POST method to upload files, it requires a web service token for authentication. If the upload is successfully, the files will be saved, prior to at least Moodle 2.9 in the user private file area but since in the user draft area.  Previously you could force the files to be saved in the draft area by specifying the then  optional parameter: *filearea=draft*.  Since at least Moodle 2.9, only two optional parameters are used, *itemid* to specify the draft area id – default 0 which is a new draft area - and *filepath* default  \'/\' to specify the file's path.
+
+It is envisaged the *itemid* parameter will be used when the files are uploaded singularly in separate HTTP calls and the files are required to be in the same draft file area.  The client retrieves the *itemid* of the first uploaded file and uses it in subsequent uploads to specify the files must be saved in the same draft file area.
+
+On every successful upload, the file/s information are returned in JSON format. If an error occurs, an error message will be sent back in JSON format too.
+
+Say, we want to upload <tt>users.csv</tt> from current directory using <tt>curl</tt>:
+
+```bash
+$ curl -X POST -F "file_1=@users.csv" https://SITENAME/webservice/upload.php?token=TOKEN \
+| jq
+
+[
+  {
+    "component": "user",
+    "contextid": 567,
+    "userid": "123",
+    "filearea": "draft",
+    "filename": "users.csv",
+    "filepath": "/",
+    "itemid": 880413555,
+    "license": "allrightsreserved",
+    "author": "User User",
+    "source": "O:8:\"stdClass\":1:{s:6:\"source\";s:13:\"users.csv\";}"
+  }
+]
+```
+
+Once all the files are uploaded, you can call the webservice that accepts files and pass it the *itemid* of the draft area containing the list of files for the request. The service can identify the uploads and manipulate them as necessary.  An example of a webservice that accepts files is: *mod_assign_save_submission*.
+
+To accept file uploads, the the service must allow "files download" (*Administration > Plugins > Web services > Manage services > Edit service > Advanced button*)
+
+There is an oldish code example on [code example on Github](https://github.com/moodlehq/sample-ws-clients/tree/master/PHP-HTTP-filehandling).
+
+## File download
+
+We serve the files through */webservice/pluginfile.php*. This script requires a web service token for authentication.
+
+Look at the [code example on Github](https://github.com/moodlehq/sample-ws-clients/tree/master/PHP-HTTP-filehandling).
+
+In case of issue, think to check that:
+
+1. the service associated with the token allow "*files download*"  (*Administration > Plugins > Web services > Manage services > Edit service > Advanced button*)
+1. the web service is valid
+
+Note: you could notice that */webservice/pluginfile.php* has the exact same stucture than */pluginfile.php*. We don't serve the files through */pluginfile.php* for web service clients because this script requires user's login session to work. It's why it might not be an option for web service client.
+
+## Returning files in Web Services
+
+Since Moodle 3.2, you can return a complete file area list via Web Services using the static get_area_files method in external_util.
+
+```php
+    $forum->introfiles = external_util::get_area_files($context->id, 'mod_forum', 'intro', false, false);
+```
+
+You can also use the external_files structure definition in combination with the method to return the most common file fields required by WS clientes.
+
+```php
+     public static function get_forums_by_courses_returns() {
+        return new external_multiple_structure(
+            new external_single_structure(
+                array(
+                    'id' => new external_value(PARAM_INT, 'Forum id'),
+                     ....
+                    'introfiles' => new external_files('Files in the introduction text', VALUE_OPTIONAL),
+```
+
+## See also
+
+- [Web services developer documentation](./index.md)
+- [Web services user documentation](https://docs.moodle.org/en/Web_services)

--- a/docs/apis/subsystems/external/functions.md
+++ b/docs/apis/subsystems/external/functions.md
@@ -1,100 +1,118 @@
 ---
-title: External Functions API
+title: Function Definitions
 tags:
   - Web_Services
   - API
   - core_external
   - external
+sidebar_position: 2
 ---
 
-## Overview
+An External function _definition_ is the class, and collection of functions, used to define:
 
-The external functions API allows you to create fully parameterised methods that can be accessed by external programs (such as [Web services API](https://docs.moodle.org/dev/Web_services_API)).
+- any parameters that the function expects to take, including any types
+- what the function will return, including any types
+- whether the function has been deprecated, or not
 
-The external functions are located under every component\external\[](optional\sub\) namespace (previously in externallib.php files). Each external function is implemented inside an individual class and is complemented by two description functions:
+It also includes the code that will actually be executed by the function.
 
-- FUNCTIONNAME_parameters() which describes the parameters of the functions
-- FUNCTIONNAME_returns() which describes the return value
+The function definition should be located within the `external` namespace of a component.
 
-The description functions uses external_description classes that have been created for this purpose.
+:::info Example
 
-## component\external\something.php
+For a component named `local_groupmanager` located in `local/groupmanager` which is responsible for creating groups on request, you may have:
 
-- This file is located under the classes/external dir of your plugin (https://docs.moodle.org/dev/Frankenstyle#Plugin_types). And it's namespaced accordingly.
-- This file is composed by a class that contains the external functions and their description functions.
+- a Web service function named: `local_groupmanager_create_groups`
+- defined in a class named `local_groupmanager\external\create_groups`
+- which is located `local/groupmanager/classes/external/create_groups.php`
 
-```php
+:::
+
+A service definition:
+
+- _must_ `require_once` the `lib/externallib.php` file
+- _must_ extend the `external_api` class
+- _must_ declare an `execute_parameters` function to describe the expected parameters of the function
+- _must_ declare an `execute` function which is called with the functions and performs the expected actions
+- _must_ declare an `execute_returns` function to describe the values returned by the function
+- _may_ declare an `execute_is_deprecated` function to declare a function as deprecated
+
+### An example definition
+
+```php title="local/groupmanager/classes/external/create_groups.php"
 <?php
 
-/**
- * PLUGIN external file
- *
- * @package    component
- * @category   external
- * @copyright  20XX YOURSELF
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace local_groupmanager\external;
 
-defined('MOODLE_INTERNAL') || die();
+defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->libdir . "/externallib.php");
+require_once("{$CFG->libdir}/externallib.php");
 
-class something extends external_api {
+class create_groups extends external_api {
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'groups' => new external_multiple_structure(
+                new external_single_structure([
+                    'courseid'  => new external_value(PARAM_INT, 'The course to create the group for'),
+                    'idnumber'    => new external_value(
+                        PARAM_RAW,
+                        'An arbitrary ID code number perhaps from the institution',
+                        VALUE_DEFAULT,
+                        null
+                    ),
+                    'name' => new external_value(
+                        PARAM_RAW,
+                        'The name of the group'
+                    ),
+                    'description' => new external_value(
+                        PARAM_TEXT,
+                        'A description',
+                        VALUE_OPTIONAL
+                    ),
+                ]),
+                'A list of groups to create'
+            ),
+        ]);
+    }
 
-    /**
-     * Returns description of method parameters
-     * @return external_function_parameters
-     */
-    public static function FUNCTIONNAME_parameters() {
-        // FUNCTIONNAME_parameters() always return an external_function_parameters(). 
-        // The external_function_parameters constructor expects an array of external_description.
-        return new external_function_parameters(
-                // a external_description can be: external_value, external_single_structure or external_multiple structure
-                array('PARAM1' => new external_value(PARAM_TYPE, 'human description of PARAM1')) 
+    public static function execute(array $groups): array {
+        // Validate all of the parameters.
+        [
+            'groups' => $groups,
+        ] = self::validate_parameters(self::execute_parameters(), [
+            'groups' => $groups,
+        ]);
+
+        // Perform security checks, for example:
+        $coursecontext = \context_course::instance($courseid);
+        self::validate_context($coursecontext);
+        require_capability('moodle/course:creategroups', $coursecontext);
+
+        // Create the group using existing Moodle APIs.
+        $createdgroups = \local_groupmanager\util::create_groups($groups)
+
+        // Return a value as described in the returns function.
+        return [
+            'groups' => $createdgroups,
+        ];
+    }
+
+    public static function execute_returns(): external_single_structure {
+        return new external_single_structure(
+            'groups' => new external_multiple_structure([
+                'id' => new external_value(PARAM_INT, 'Id of the created user'),
+                'name' => new external_value(PARAM_RAW, 'The name of the group'),
+            ])
         );
     }
-
-    /**
-     * The function itself
-     * @return string welcome message
-     */
-    public static function FUNCTIONNAME($PARAM1) {
- 
-        //Parameters validation
-        $params = self::validate_parameters(self::FUNCTIONNAME_parameters(),
-                array('PARAM1' => $PARAM1));
-
-        //Note: don't forget to validate the context and check capabilities
-
-        return $returnedvalue;
-    }
-
-    /**
-     * Returns description of method result value
-     * @return external_description
-     */
-    public static function FUNCTIONNAME_returns() {
-        return new external_value(PARAM_TYPE, 'human description of the returned value');
-    }
-
-
-
 }
 ```
 
-To go further, read this core developer tutorial: [Creating a web service and a web service function](https://docs.moodle.org/dev/Creating_a_web_service_and_a_web_service_function).
+:::note
 
-## Security
+Available parameter types are defined in `lib/moodlelib.php` and are used by the `validate_parameters()` function and during return value checking to ensure that the service is called and working as defined.
 
-Before operating on any data in an external function, you must call external_api::validate_context() on the most specific context for the data. This will perform some sanity and security checks, as well as setup the correct theme, language and filters for rendering content. If your function only uses one context, validate it once at the start of your external function. If your function operates on multiple contexts (like a list of courses), you  must validate each context right before generating any response data related to that context (e.g. calling any $OUTPUT functions or $PAGE->get_renderer() ). Do not call require_login from an external function, that function is reserved for php scripts returning a web page. Do not call $PAGE->set_context() manually, this will generate warning notices. validate_context() is the only correct way to write external functions.
-
-Also make sure you pass all arguments through external_api::validate_parameters() before using them to ensure proper cleaning/sanitisation of the input.
-
-Also be sure to enforce proper capability checks everywhere - external functions are a public API.
-
-## Example
-
-You will find an example of an external.php file in the [web service template plugin](https://github.com/moodlehq/moodle-local_wstemplate). This plugin contains a web service hello_world function. To make testing easy for you, the plugin is distributed with a test client in the folder /client.
+:::
 
 ## See also
 

--- a/docs/apis/subsystems/external/functions.md
+++ b/docs/apis/subsystems/external/functions.md
@@ -1,0 +1,102 @@
+---
+title: External Functions API
+tags:
+  - Web_Services
+  - API
+  - core_external
+  - external
+---
+
+## Overview
+
+The external functions API allows you to create fully parameterised methods that can be accessed by external programs (such as [Web services API](https://docs.moodle.org/dev/Web_services_API)).
+
+The external functions are located under every component\external\[](optional\sub\) namespace (previously in externallib.php files). Each external function is implemented inside an individual class and is complemented by two description functions:
+
+- FUNCTIONNAME_parameters() which describes the parameters of the functions
+- FUNCTIONNAME_returns() which describes the return value
+
+The description functions uses external_description classes that have been created for this purpose.
+
+## component\external\something.php
+
+- This file is located under the classes/external dir of your plugin (https://docs.moodle.org/dev/Frankenstyle#Plugin_types). And it's namespaced accordingly.
+- This file is composed by a class that contains the external functions and their description functions.
+
+```php
+<?php
+
+/**
+ * PLUGIN external file
+ *
+ * @package    component
+ * @category   external
+ * @copyright  20XX YOURSELF
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->libdir . "/externallib.php");
+
+class something extends external_api {
+
+    /**
+     * Returns description of method parameters
+     * @return external_function_parameters
+     */
+    public static function FUNCTIONNAME_parameters() {
+        // FUNCTIONNAME_parameters() always return an external_function_parameters(). 
+        // The external_function_parameters constructor expects an array of external_description.
+        return new external_function_parameters(
+                // a external_description can be: external_value, external_single_structure or external_multiple structure
+                array('PARAM1' => new external_value(PARAM_TYPE, 'human description of PARAM1')) 
+        );
+    }
+
+    /**
+     * The function itself
+     * @return string welcome message
+     */
+    public static function FUNCTIONNAME($PARAM1) {
+ 
+        //Parameters validation
+        $params = self::validate_parameters(self::FUNCTIONNAME_parameters(),
+                array('PARAM1' => $PARAM1));
+
+        //Note: don't forget to validate the context and check capabilities
+
+        return $returnedvalue;
+    }
+
+    /**
+     * Returns description of method result value
+     * @return external_description
+     */
+    public static function FUNCTIONNAME_returns() {
+        return new external_value(PARAM_TYPE, 'human description of the returned value');
+    }
+
+
+
+}
+```
+
+To go further, read this core developer tutorial: [Creating a web service and a web service function](https://docs.moodle.org/dev/Creating_a_web_service_and_a_web_service_function).
+
+## Security
+
+Before operating on any data in an external function, you must call external_api::validate_context() on the most specific context for the data. This will perform some sanity and security checks, as well as setup the correct theme, language and filters for rendering content. If your function only uses one context, validate it once at the start of your external function. If your function operates on multiple contexts (like a list of courses), you  must validate each context right before generating any response data related to that context (e.g. calling any $OUTPUT functions or $PAGE->get_renderer() ). Do not call require_login from an external function, that function is reserved for php scripts returning a web page. Do not call $PAGE->set_context() manually, this will generate warning notices. validate_context() is the only correct way to write external functions.
+
+Also make sure you pass all arguments through external_api::validate_parameters() before using them to ensure proper cleaning/sanitisation of the input.
+
+Also be sure to enforce proper capability checks everywhere - external functions are a public API.
+
+## Example
+
+You will find an example of an external.php file in the [web service template plugin](https://github.com/moodlehq/moodle-local_wstemplate). This plugin contains a web service hello_world function. To make testing easy for you, the plugin is distributed with a test client in the folder /client.
+
+## See also
+
+- [Core APIs](../../../apis.md)
+- [Web services API](https://docs.moodle.org/dev/Web_services_API)

--- a/docs/apis/subsystems/external/index.md
+++ b/docs/apis/subsystems/external/index.md
@@ -28,7 +28,7 @@ The full API can be found on any Moodle sites under ** Administration block > Pl
 **Note:** Additional services are available for uploading and downloading files which are not in the API Documentation - they are accessed in a different way. See [Web services files handling](./files.md)
 
 - [How to contribute a web service function to core](https://docs.moodle.org/dev/How_to_contribute_a_web_service_function_to_core)
-- [Adding a web service to your plugin](https://docs.moodle.org/dev/Adding_a_web_service_to_a_plugin)
+- [Adding a web service to your plugin](./writing-a-service.md)
 - Code example: [Adding a web service, using APIs](https://gist.github.com/timhunt/51987ad386faca61fe013904c242e9b4) by (Tim Hunt)
 - [Implement a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client_)
 - [Web services files handling](./files.md)

--- a/docs/apis/subsystems/external/index.md
+++ b/docs/apis/subsystems/external/index.md
@@ -1,0 +1,49 @@
+---
+title: Web Services
+tags:
+  - external
+  - core_external
+  - API
+---
+
+### How it works
+
+This example will give you an idea of how our web services infrastructure works.
+
+1. The client sends a username and password to the web service login script.
+1. The script returns a token for that user account.
+1. The client calls a particular web service function on a protocol server including the token .
+1. The protocol server uses the token to check that the user can call the function.
+1. The protocol server calls the matching external function, located under the \component\external namespace (previously in a externallib.php file inside the relevant module).
+1. The external function checks that the current user has_capability to do this operation.
+1. The external function calls the matching Moodle core function (in lib.php usually).
+1. The core function can return a result to the external function.
+1. The external function will return a result to the protocol server.
+1. The protocol server returns the result to the client.
+
+## Developer documentation
+
+The full API can be found on any Moodle sites under ** Administration block > Plugins > Web services > API Documentation**.
+
+**Note:** Additional services are available for uploading and downloading files which are not in the API Documentation - they are accessed in a different way. See [Web services files handling](https://docs.moodle.org/dev/Web_services_files_handling)
+
+- [How to contribute a web service function to core](https://docs.moodle.org/dev/How_to_contribute_a_web_service_function_to_core)
+- [Adding a web service to your plugin](https://docs.moodle.org/dev/Adding_a_web_service_to_a_plugin)
+- Code example: [Adding a web service, using APIs](https://gist.github.com/timhunt/51987ad386faca61fe013904c242e9b4) by (Tim Hunt)
+- [Implement a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client_)
+- [Web services files handling](https://docs.moodle.org/dev/Web_services_files_handling)
+- [Web service Listing & Roadmap](https://docs.moodle.org/dev/Web_services_Roadmap_)
+
+## Specification and brainstorming
+
+- [External services security](https://docs.moodle.org/dev/External_services_security_)
+- [External services description](https://docs.moodle.org/dev/External_services_description_)
+
+## See also
+
+- [Web service API functions](https://docs.moodle.org/dev/Web_service_API_functions)
+- [Web services FAQ](https://docs.moodle.org/en/Web_services_FAQ)
+- [How to create and enable a web service](https://docs.moodle.org/en/How_to_create_and_enable_a_web_service)
+- [How to enable the mobile web service](https://docs.moodle.org/en/Enable_mobile_web_services)
+- [Web services user documentation](https://docs.moodle.org/en/Web_services)
+- [Mastering Moodle Web Services development](http://www.slideshare.net/juanleyva/mastering-moodle-web-services-development) - Last session of the Hackfest in the MoodleMoot UK 2016

--- a/docs/apis/subsystems/external/index.md
+++ b/docs/apis/subsystems/external/index.md
@@ -1,43 +1,56 @@
 ---
-title: Web Services
+title: External Services
 tags:
   - external
   - core_external
   - API
 ---
 
-### How it works
+Moodle has a full-featured Web Service framework, allowing you to use and create web services for use in external systems.
+The Web Service framework and the External API work closely together providing a number of _Endpoints_, and self-describing classes to support a wide range of uses.
 
-This example will give you an idea of how our web services infrastructure works.
+Moodle uses these web services internally for:
 
-1. The client sends a username and password to the web service login script.
-1. The script returns a token for that user account.
-1. The client calls a particular web service function on a protocol server including the token .
-1. The protocol server uses the token to check that the user can call the function.
-1. The protocol server calls the matching external function, located under the \component\external namespace (previously in a externallib.php file inside the relevant module).
-1. The external function checks that the current user has_capability to do this operation.
-1. The external function calls the matching Moodle core function (in lib.php usually).
-1. The core function can return a result to the external function.
-1. The external function will return a result to the protocol server.
-1. The protocol server returns the result to the client.
+- AJAX interactions in the Moodle Web Interface; and
+- The official Moodle Mobile App.
+
+The following example shows a typical authentication and protocol workflow.
+
+```mermaid
+sequenceDiagram
+    Client ->> Login Endpoint: Login attempted
+    Note right of Client: Authentication using <br> Username and Password
+    Login Endpoint ->> Client: Session token
+    Client ->> Protocol Server: Function and authentication token
+    Protocol Server -->> External API: Access Control Check
+    Note right of Protocol Server: The Session token is <br>used to confirm <br> user permission against <br> the specified API.
+    External API -->> Protocol Server: Authentication granted
+    Protocol Server ->> Plugin API: Function called against <br> relevant API
+    Plugin API ->> Protocol Server: Result passed back to Protocol server
+    Protocol Server -->> External API: Return value validated
+    Protocol Server ->> Client: Validated data returned to Client
+```
 
 ## Developer documentation
 
-The full API can be found on any Moodle sites under ** Administration block > Plugins > Web services > API Documentation**.
+The External Service API has two categories of documentation:
 
-**Note:** Additional services are available for uploading and downloading files which are not in the API Documentation - they are accessed in a different way. See [Web services files handling](./files.md)
+1. this documentation details how to _write_ a web service and use the External API; and
+2. API documentation for a live Moodle site, which can be found under ** Site administration > Plugins > Web services > API Documentation **.
+
+In addition to the standard API endpoints, several additional API endpoints are available for the purpose of uploading, and downloading, files. For more information on these endpoints, see the [file handling](./files.md) documentation.
 
 - [How to contribute a web service function to core](https://docs.moodle.org/dev/How_to_contribute_a_web_service_function_to_core)
 - [Adding a web service to your plugin](./writing-a-service.md)
 - Code example: [Adding a web service, using APIs](https://gist.github.com/timhunt/51987ad386faca61fe013904c242e9b4) by (Tim Hunt)
-- [Implement a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client_)
+- [Implement a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client)
 - [Web services files handling](./files.md)
-- [Web service Listing & Roadmap](https://docs.moodle.org/dev/Web_services_Roadmap_)
+- [Web service Listing & Roadmap](https://docs.moodle.org/dev/Web_services_Roadmap)
 
 ## Specification and brainstorming
 
-- [External services security](https://docs.moodle.org/dev/External_services_security_)
-- [External services description](https://docs.moodle.org/dev/External_services_description_)
+- [External services security](./security.md)
+- [External services description](./description.md)
 
 ## See also
 

--- a/docs/apis/subsystems/external/index.md
+++ b/docs/apis/subsystems/external/index.md
@@ -25,13 +25,13 @@ This example will give you an idea of how our web services infrastructure works.
 
 The full API can be found on any Moodle sites under ** Administration block > Plugins > Web services > API Documentation**.
 
-**Note:** Additional services are available for uploading and downloading files which are not in the API Documentation - they are accessed in a different way. See [Web services files handling](https://docs.moodle.org/dev/Web_services_files_handling)
+**Note:** Additional services are available for uploading and downloading files which are not in the API Documentation - they are accessed in a different way. See [Web services files handling](./files.md)
 
 - [How to contribute a web service function to core](https://docs.moodle.org/dev/How_to_contribute_a_web_service_function_to_core)
 - [Adding a web service to your plugin](https://docs.moodle.org/dev/Adding_a_web_service_to_a_plugin)
 - Code example: [Adding a web service, using APIs](https://gist.github.com/timhunt/51987ad386faca61fe013904c242e9b4) by (Tim Hunt)
 - [Implement a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client_)
-- [Web services files handling](https://docs.moodle.org/dev/Web_services_files_handling)
+- [Web services files handling](./files.md)
 - [Web service Listing & Roadmap](https://docs.moodle.org/dev/Web_services_Roadmap_)
 
 ## Specification and brainstorming

--- a/docs/apis/subsystems/external/security.md
+++ b/docs/apis/subsystems/external/security.md
@@ -1,0 +1,85 @@
+---
+title: Security
+tags:
+  - Web Services
+  - core_external
+  - external
+  - API
+sidebar_position: 3
+---
+
+Before operating on any data in an external function, you must ensure that the user:
+
+- has access to context that the data is located in
+- has permission to perform the relevant action
+
+## Validating function parameters
+
+Before working with any data provided by a user you **must** validate the parameters against the definitions you have defined.
+
+To do so you should call the `validate_parameters()` function, passing in the reference to your `execute_parameters()` function, and the complete list of parameters for the function. The function will return the validated and cleaned parameters.
+
+The `validate_parameters()` function is defined on the `external_api` class, and can be called as follows:
+
+```php title="local/groupmanager/classes/external/create_groups.php"
+public static function execute(array $groups): array {
+    [
+        'groups' => $groups,
+    ] = self::validate_parameters(self::execute_parameters(), [
+        'groups' => $groups,
+    ]);
+    // ...
+}
+```
+
+## Validating access to the Moodle context
+
+Whenever fetching or updating any data within Moodle using an External function definition, you **must** validate the context that the data exists within.
+
+To do so you should call the `validate_context()` function, passing the _most specific_ context for the data.
+
+For example, if you are working with data belonging to a specific activity, you should use the _activity_ context. If you are working with data belonging to a course, you should use the _course_ context.
+
+If your function operates on multiple contexts (like a list of courses), you must validate each context right before generating any response data related to that context.
+
+The `validate_context()` function is defined on the `external_api` class, and can be called as follows:
+
+```php title="local/groupmanager/classes/external/create_groups.php"
+public static function execute(array $groups): array {
+    // ...
+    foreach ($groups as $group) {
+        $coursecontext = \context_course::instance($group['courseid']);
+        self::validate_context($coursecontext);
+        // ...
+    }
+}
+```
+
+:::tip
+
+The `validate_context()` function will also configure the correct theme, language, and filters required to render content for the current user.
+
+:::
+
+:::caution
+
+You should not:
+
+- use the `require_login` function from an external function - this function is reserved for php scripts returning a web page.
+- call `$PAGE->set_context()` manually - this will generate warning notices.
+
+The `validate_context()` function is the only correct way to write external functions.
+
+:::
+
+## Ensuring that a user has the appropriate rights
+
+Once you have confirmed that the provided data is of the correct type, and configured Moodle for the specific context, you should also ensure that all capabilities are checked correctly.
+
+You can use the standard capability functions, including:
+
+- `has_capability()` - to check that a user has a single capability
+- `has_any_capability()` - to check that a user has any capability in a set
+- `has_all_capability()` - to check that a user has all capabilities in a set
+- `require_capability()` - to require a single capability
+- `require_all_capabilities()` - to require that a user has all capabilities in a set

--- a/docs/apis/subsystems/external/writing-a-service.md
+++ b/docs/apis/subsystems/external/writing-a-service.md
@@ -1,0 +1,428 @@
+---
+title: Writing a new service
+tags:
+  - Web Services
+  - Plugins
+  - core_external
+  - external
+---
+{{Moodle_2.0}}
+
+# Quick start
+
+## File structure
+
+The file structure is explained in these two documents:
+
+- [Web services API](https://docs.moodle.org/dev/Web_services_API)
+- [External function API](./functions.md)
+
+# Tutorial
+
+We will create a web service into a local plugin. This service will contain one *local_myplugin_create_groups($groups)* web service function. This web service function will create a group into a Moodle course.
+
+## Write the specification documentation
+
+Before starting coding, let's identify our needs writing some short specification documents.
+
+### functional specification
+
+*local_myplugin_create_groups($groups)* will take a list of groups as parameters and it will return the same groups with their newly created id. If ever one group creation fails, the function will throw an exception, and no creation will happen.
+
+### technical specification
+
+- **the core function the external function will call**: *groups_create_group()* from [/group/lib.php](http://cvs.moodle.org/moodle/group/).
+- **the parameter types**: a list of object. This object are groups, with id/name/courseid.
+- **the returned value types**: a list of objects (groups) with their id.
+- **the user capabilities to check**: *moodle/course:managegroups*
+
+## Write a simple test client
+
+The first thing you should code is a web service test client. You will often discover use cases that you didn't think about. We are not showing any test client code here, see [How to create a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client).
+
+## Declare the service
+
+This step is optional. You can pre-build a service including any web service functions, so the Moodle administrator doesn't need to do it. Add into /local/myplugin/db/services.php:
+
+```php
+  $services = array(
+      'mypluginservice' => array(                                                // the name of the web service
+          'functions' => array ('local_myplugin_create_groups'), // web service functions of this service
+          'requiredcapability' => '',                // if set, the web service user need this capability to access 
+                                                                              // any function of this service. For example: 'some/capability:specified'                 
+          'restrictedusers' => 0,                                             // if enabled, the Moodle administrator must link some user to this service
+                                                                              // into the administration
+          'enabled' => 1,                                                       // if enabled, the service can be reachable on a default installation
+          'shortname' =>  '',       // optional – but needed if restrictedusers is set so as to allow logins.
+          'downloadfiles' => 0,    // allow file downloads.
+          'uploadfiles'  => 0      // allow file uploads.
+       )
+  );
+```
+
+Note: it is not possible for an administrator to add/remove any function from a pre-built service.
+
+## Declare the web service function
+
+Following the [Web service API](https://docs.moodle.org/dev/Web_services_API), you must declare the web service function in the *local/myplugin/db/services.php* file.
+
+```php
+$functions = array(
+    'local_myplugin_create_groups' => array(         //web service function name
+        'classname'   => 'local_myplugin_external',  //class containing the external function OR namespaced class in classes/external/XXXX.php
+        'methodname'  => 'create_groups',          //external function name
+        'classpath'   => 'local/myplugin/externallib.php',  //file containing the class/external function - not required if using namespaced auto-loading classes.
+                                                   // defaults to the service's externalib.php
+        'description' => 'Creates new groups.',    //human readable description of the web service function
+        'type'        => 'write',                  //database rights of the web service function (read, write)
+        'ajax' => true,        // is the service available to 'internal' ajax calls. 
+        'services' => array(MOODLE_OFFICIAL_MOBILE_SERVICE)    // Optional, only available for Moodle 3.1 onwards. List of built-in services (by shortname) where the function will be included.  Services created manually via the Moodle interface are not supported.
+        'capabilities' => '', // comma separated list of capabilities used by the function.
+    ),
+);
+```
+
+Web service functions should match the [naming convention](https://docs.moodle.org/dev/Web_services_Roadmap#Naming_convention).
+
+## Write the external function descriptions
+
+Every web service function is mapped to an external function. External function are described in the [External functions API](./functions.md).
+Each external function is written with two other functions describing the parameters and the return values. These description functions are used by web service servers to:
+
+- validate the web service function parameters
+- validate the web service function returned values
+- build WSDL files or other protocol documents
+These two description functions are located in the same file and the same class mentioned in local/myplugin/db/services.php.
+
+Thus for the web service function **local_myplugin_create_groups()**, we need write a class named **local_myplugin_external** in the file **local/myplugin/externallib.php**. The class will contain:
+
+- create_groups(...)
+- create_groups_parameters()
+- create_groups_return()
+
+### create_groups_parameters()
+
+```php
+require_once("$CFG->libdir/externallib.php");
+
+class local_myplugin_external extends external_api {
+
+    /**
+     * Returns description of method parameters
+     * @return external_function_parameters
+     */
+    public static function create_groups_parameters() {
+        return new external_function_parameters(
+            array(
+                'groups' => new external_multiple_structure(
+                    new external_single_structure(
+                        array(
+                            'courseid' => new external_value(PARAM_INT, 'id of course'),
+                            'name' => new external_value(PARAM_TEXT, 'multilang compatible name, course unique'),
+                            'description' => new external_value(PARAM_RAW, 'group description text'),
+                            'enrolmentkey' => new external_value(PARAM_RAW, 'group enrol secret phrase'),
+                        )
+                    )
+                )
+            )
+        );
+    }
+```
+
+A web service function without parameters will have a parameter description function like that:
+
+```php
+/**
+     * Returns description of method parameters
+     * @return external_function_parameters
+     */
+    public static function functionname_parameters() {
+        return new external_function_parameters(
+            array(
+               //if I had any parameters, they would be described here. But I don't have any, so this array is empty.
+            )
+        );
+    }
+```
+
+A parameter can be described as:
+
+- a list => external_multiple_structure
+- an object => external_single_structure
+- a primary type => external_value
+
+Our create_groups() function expects one parameter named *groups*, so we will first write:
+
+```php
+    /**
+     * Returns description of method parameters
+     * @return external_function_parameters
+     */
+    public static function create_groups_parameters() {
+        return new external_function_parameters(
+            array(
+                'groups' => ...
+                
+            )
+        );
+    }
+```
+
+This *groups* parameter is a list of group. So we will write :
+
+```php
+                'groups' => new external_multiple_structure(
+                    ...
+                )          
+```
+
+An external_multiple_structure object (list) can be constructed with:
+
+- *external_multiple_structure* (list)
+- *external_single_structure* (object)
+- *external_value* (primary type).
+
+For our function it will be a *external_single_structure*:
+
+```php
+                    new external_single_structure(
+                        array(
+                            'courseid' => ...,
+                            'name' => ...,
+                            'description' => ...,
+                            'enrolmentkey' => ...,
+                        )
+                    )           
+```
+
+Thus we obtain :
+
+```php
+                'groups' => new external_multiple_structure(
+                    new external_single_structure(
+                        array(
+                            'courseid' => ...,
+                            'name' => ...,
+                            'description' => ...,
+                            'enrolmentkey' => ...,
+                        )
+                    )
+                )          
+```
+
+Each group values is a *external_value* (primary type):
+
+- *courseid* is an integer
+- *name* is a string (text only, not tag)
+- *description* is a string (can be anything)
+- *enrolmentkey* is also a string (can be anything)
+
+We add them to the description :
+
+```php
+                'groups' => new external_multiple_structure(
+                    new external_single_structure(
+                        array(
+                            'courseid' => new external_value(PARAM_INT, 'id of course'), //the second argument is a human readable description text. This text is displayed in the automatically generated documentation.
+                            'name' => new external_value(PARAM_TEXT, 'multilang compatible name, course unique'),
+                            'description' => new external_value(PARAM_RAW, 'group description text'),
+                            'enrolmentkey' => new external_value(PARAM_RAW, 'group enrol secret phrase'),
+                        )
+                    )
+                )          
+```
+
+### create_groups_returns()
+
+It's similar to create_groups_parameters(), but instead of describing the parameters, it describes the return values.
+
+```php
+public static function create_groups_returns() {
+        return new external_multiple_structure(
+            new external_single_structure(
+                array(
+                    'id' => new external_value(PARAM_INT, 'group record id'),
+                    'courseid' => new external_value(PARAM_INT, 'id of course'),
+                    'name' => new external_value(PARAM_TEXT, 'multilang compatible name, course unique'),
+                    'description' => new external_value(PARAM_RAW, 'group description text'),
+                    'enrolmentkey' => new external_value(PARAM_RAW, 'group enrol secret phrase'),
+                )
+            )
+        );
+    }
+```
+
+### Required, Optional or Default value
+
+A value can be VALUE_REQUIRED, VALUE_OPTIONAL, or VALUE_DEFAULT. If not mentioned, a value is VALUE_REQUIRED by default.
+
+```php
+                            'yearofstudy' => new external_value(PARAM_INT, 'year of study',VALUE_DEFAULT, 1979),                        
+```
+
+- VALUE_REQUIRED - if the value is not supplied => the server throws an error message
+- VALUE_OPTIONAL - if the value is not supplied => the value is ignored. Note that VALUE_OPTIONAL can't be used in top level parameters, it must be used only within array/objects key definition. If you need top level Optional parameters you should use VALUE_DEFAULT instead.
+- VALUE_DEFAULT - if the value is not supplied => the default value is used
+Note: Because some web service protocols are strict about the number and types of arguments - it is not possible to specify an optional parameter as one of the top-most parameters for a function. Examples:
+
+Not cool:
+
+```php
+    public static function get_biscuit_parameters() {                                                                  
+        return new external_function_parameters(                                                                                    
+            array(                                                                                                                  
+                'chocolatechips' => new external_value(PARAM_BOOL, PARAM_REQUIRED),
+                'glutenfree' => new external_value(PARAM_BOOL, PARAM_DEFAULT, false),
+                'icingsugar' => new external_value(PARAM_BOOL, VALUE_OPTIONAL), // ERROR! top level optional parameter!!!
+            )
+        );
+    }
+             
+```
+
+Cool:
+
+```php
+
+    public static function get_biscuit_parameters() {                                                                  
+        return new external_function_parameters(                                                                                    
+            array(
+                'ifeellike' => new external_single_structure(
+                    array(                                                                                                                  
+                        'chocolatechips' => new external_value(PARAM_BOOL, VALUE_REQUIRED),
+                        'glutenfree' => new external_value(PARAM_BOOL, PARAM_DEFAULT, false),
+                        'icingsugar' => new external_value(PARAM_BOOL, VALUE_OPTIONAL), // ALL GOOD!! We have nested the params in a external_single_structure.
+                    )
+                )
+            )
+        );
+    }
+     
+```
+
+## Implement the external function
+
+We declared our web service function and we defined the external function parameters and return values. We will now implement the external function:
+
+```php
+    /**
+     * Create groups
+     * @param array $groups array of group description arrays (with keys groupname and courseid)
+     * @return array of newly created groups
+     */
+    public static function create_groups($groups) { //Don't forget to set it as static
+        global $CFG, $DB;
+        require_once("$CFG->dirroot/group/lib.php");
+
+        $params = self::validate_parameters(self::create_groups_parameters(), array('groups'=>$groups));
+
+        $transaction = $DB->start_delegated_transaction(); //If an exception is thrown in the below code, all DB queries in this code will be rollback.
+
+        $groups = array();
+
+        foreach ($params['groups'] as $group) {
+            $group = (object)$group;
+
+            if (trim($group->name) == '') {
+                throw new invalid_parameter_exception('Invalid group name');
+            }
+            if ($DB->get_record('groups', array('courseid'=>$group->courseid, 'name'=>$group->name))) {
+                throw new invalid_parameter_exception('Group with the same name already exists in the course');
+            }
+
+            // now security checks
+            $context = get_context_instance(CONTEXT_COURSE, $group->courseid);
+            self::validate_context($context);
+            require_capability('moodle/course:managegroups', $context);
+
+            // finally create the group
+            $group->id = groups_create_group($group, false);
+            $groups[] = (array)$group;
+        }
+
+        $transaction->allow_commit();
+
+        return $groups;
+    }
+```
+
+### Parameter validation
+
+```php
+ $params = self::validate_parameters(self::create_groups_parameters(), array('groups'=>$groups));
+```
+
+This *validate_parameters* function validates the external function parameters against the description. It will return an exception if some required parameters are missing, if parameters are not well-formed, and check the parameters validity. It is essential that you do this call to avoid potential hack.
+
+**Important:** the parameters of the external function and their declaration in the description **must be the same order**. In this example we have only one parameter named $groups, so we don't need to worry about the order.
+
+### Context and Capability checks
+
+```php
+/// now security checks
+$context = context_course::instance($group->courseid);
+self::validate_context($context);
+require_capability('moodle/course:managegroups', $context);
+```
+
+Note: validate_context() is required in all external functions before operating on any data belonging to a context. This function does sanity and security checks on the context that was passed to the external function - and sets up the global $PAGE and $OUTPUT for rendering return values. Do NOT use require_login(), or $PAGE->set_context() in an external function.
+
+### Exceptions
+
+You can throw exceptions. These are automatically handled by Moodle web service servers.
+
+```php
+//Note: it is good practice to add detailled information in $debuginfo, 
+//         and only send back a generic exception message when Moodle DEBUG mode < NORMAL.
+//         It's what we do here throwing the invalid_parameter_exception($debug) exception
+throw new invalid_parameter_exception('Group with the same name already exists in the course'); 
+```
+
+### Correct return values
+
+The return values will be validated by the Moodle web service servers:
+
+- return values contain some values not described => these values will be skipped.
+- return values miss some required values (VALUE_REQUIRED) => the server will return an error.
+- return values types don't match the description (int != PARAM_ALPHA) => the server will return an error
+**Note:** cast all your returned objects into arrays.
+
+## Making web service accessible through Apache Thrift
+
+This step is optional. If you wish to generate SDK for different programming languages and platforms using [Apache Thrift framework](http://thrift.apache.org) then [Moodle Thrift tools](https://bitbucket.org/hhteam/moodle_thrift_tools/wiki/Home) can help you.
+
+Two steps should be performed:
+
+- Generate .thrift files for Moodle API using thriftgenerator script.
+- Generate thrift handlers for PHP and copy the php files generated to your plugin source tree.
+It is also recommended to include thrift files into the distribution of your plugin in order to simplify creation of client bindings for the users of your API.
+
+That's it. Now the web API of your plugin is accessible through Apache Thrift Framework.
+
+## Bump the plugin version
+
+Edit your local/myplugin/version.php and increase the plugin version. This should trigger a Moodle upgrade and the new web service should be available in the administration (*Administration > Plugins > Web Services > Manage services*)
+
+## Deprecation
+
+External functions deprecation process is slightly different from the standard deprecation. If you are interested in deprecating any of your external functions you should **also** (apart from the applicable points detailed in the [standard deprecation docs](/general/development/policies/deprecation)) create a <tt>FUNCTIONNAME_is_deprecated()</tt> method in your external function class. Return true if the external function is deprecated. This is an example:
+
+```php
+     * Mark the function as deprecated.
+     * @return bool
+     */
+    public static function create_groups_is_deprecated() {
+        return true;
+    }
+```
+
+# See also
+
+- [Web services developer documentation](./index.md)
+- [Web services user documentation](https://docs.moodle.org/en/Web_services)
+- [Implement a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client)
+- Code example: [Adding a web service, using APIs](https://gist.github.com/timhunt/51987ad386faca61fe013904c242e9b4) by (Tim Hunt)
+Specification:
+- [External services security](./security.md)
+- [External services description](./description.md)
+- [Session locks#Read only sessions in web services](https://docs.moodle.org/dev/Session_locks#Read_only_sessions_in_web_services)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,6 +73,12 @@ const config = {
         defaultLocale: 'en-AU',
     },
 
+    markdown: {
+        mermaid: true,
+    },
+
+    themes: ['@docusaurus/theme-mermaid'],
+
     presets: [
         [
             'classic',

--- a/general/app/overview.md
+++ b/general/app/overview.md
@@ -8,7 +8,7 @@ tags:
 
 The Moodle App is a mobile application that helps users make the best of their Moodle sites on handheld devices. It has some additional features like offline access, and a dedicated interface adapted to mobile. It's focused on student functionality, so you won't find all the features you have on the web for teachers and admins. You can learn more about the features available in [the user documentation](https://docs.moodle.org/).
 
-On a technical level, it's a completely different codebase from the Moodle LMS, and interacts with a Moodle site using [web services](https://docs.moodle.org/dev/Web_services). You can find the source code of the application in github: [github.com/moodlehq/moodleapp](https://github.com/moodlehq/moodleapp).
+On a technical level, it's a completely different codebase from the Moodle LMS, and interacts with a Moodle site using [web services](/docs/apis/subsystems/external/). You can find the source code of the application in github: [github.com/moodlehq/moodleapp](https://github.com/moodlehq/moodleapp).
 
 Before embarking into any Moodle-specific documentation, we recommend that you are at least familiar with [Angular](https://angular.io/) and [Ionic Framework](https://ionicframework.com/). These are the core technologies used in the application. We'll reference any relevant concepts, but having a basic idea will take you a long way in understanding the Moodle App.
 
@@ -36,7 +36,7 @@ Pages and navigation are defined using [Angular Router](https://angular.io/guide
 
 ### Web services and caching
 
-The entire communication between the app and a site happens through a layer of [web services](https://docs.moodle.org/dev/Web_services). Each time a user logs into the application, a new session starts and that session is what the concept of a "site" encapsulates in the application. For this reason, you could log multiple times into the same site and from the point of view of the application those would be different sites.
+The entire communication between the app and a site happens through a layer of [web services](/docs/apis/subsystems/external/). Each time a user logs into the application, a new session starts and that session is what the concept of a "site" encapsulates in the application. For this reason, you could log multiple times into the same site and from the point of view of the application those would be different sites.
 
 For performance reasons, the data retrieved from some web services is cached automatically. For example, the list of courses that a user is enrolled in. This is also useful so that the application works offline. However, not everything is cached automatically, and some things like entire courses can be downloaded manually. This is referred to as "prefetching".
 

--- a/general/development/policies.md
+++ b/general/development/policies.md
@@ -161,7 +161,7 @@ Web services enable other systems to login to Moodle and perform operations. The
 
 :::info
 
-For more about this, see [Web services](https://docs.moodle.org/dev/Web_services).
+For more about this, see [Web services](/docs/apis/subsystems/external/).
 
 :::
 

--- a/general/development/policies/deprecation.md
+++ b/general/development/policies/deprecation.md
@@ -53,7 +53,7 @@ Deprecation affects only the current master version, in other words, the depreca
 
 - If the deprecated function has been replaced with a new function, ideally the new function should be called from the deprecated function, so that the new functionality is used. This will make maintenance easier moving forward.
 - A `@deprecated` tag should be added to the PHPDoc for the function description so that IDEs describing the function will note that it is deprecated, documenting which version it was deprecated in and the MDL issue associated with it. See the guidelines in [Coding style](./codingstyle/index.md#deprecated-and-todo).
-- If the function is an external function, then an additional deprecation-specific method needs to be created and set to return true. See the [adding a web service to a plugin](https://docs.moodle.org/dev/Adding_a_web_service_to_a_plugin#Deprecation) docs on that process. You should continue to add the `@deprecated since x.x` tag to the docs of all three of the relevant external methods (parameters, main method, returns) to make it clear to IDEs that the function is deprecated.
+- If the function is an external function, then an additional deprecation-specific method needs to be created and set to return true. See the [adding a web service to a plugin](/docs/apis/subsystems/external/writing-a-service#deprecation) docs on that process. You should continue to add the `@deprecated since x.x` tag to the docs of all three of the relevant external methods (parameters, main method, returns) to make it clear to IDEs that the function is deprecated.
 - There will need to be an issue associated with the initial part of the deprecation. A second issue needs to be created to finish the job. The first issue will be linked to second issue. The second issue needs to be a sub-task of an appropriate [deprecation META](https://tracker.moodle.org/issues/?jql=%28summary%20~%20%22meta%22%20or%20type%20%3D%20Epic%29%20AND%20summary%20~%20%22together%20deprecated%22%20order%20by%20created&runQuery=true&clear=true).
 
 :::note Example
@@ -120,7 +120,7 @@ Remember the phpDoc parameter type should also be updated to `null`.
 ## See also...
 
 - [String deprecation](../../projects/api/string-deprecation.md)
-- [External functions deprecation](https://docs.moodle.org/dev/Adding_a_web_service_to_a_plugin#Deprecation)
+- [External functions deprecation](/docs/apis/subsystems/external/writing-a-service#deprecation)
 - [Capabilities deprecation](/docs/apis/subsystems/access#deprecating-a-capability)
 - [Process](../process.md)
 - [Release process](../process/release/index.md)

--- a/general/releases/2.2.md
+++ b/general/releases/2.2.md
@@ -99,7 +99,7 @@ This is the list of some outdated / unused libraries that aren't bundled anymore
 - [MDL-29279](https://tracker.moodle.org/browse/MDL-29279) - REST server can return JSON
 - [MDL-29276](https://tracker.moodle.org/browse/MDL-29276) - Many other web service improvements
 - Many web service [demo clients](https://github.com/moodlehq/sample-ws-clients)
-- Full web service [user](https://docs.moodle.org/en/Web_services) and [developer](https://docs.moodle.org/dev/Web_services) documentation update
+- Full web service [user](https://docs.moodle.org/en/Web_services) and [developer](/docs/apis/subsystems/external/) documentation update
 - New [web service roadmap](https://docs.moodle.org/dev/Web_services_Roadmap_)
 
 #### Other deleted items

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@docusaurus/core": "^2.2.0",
     "@docusaurus/plugin-pwa": "^2.2.0",
     "@docusaurus/preset-classic": "^2.2.0",
+    "@docusaurus/theme-mermaid": "^2.2.0",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mdx-js/react": "^1.6.22",

--- a/versioned_docs/version-4.1/apis/subsystems/external/advanced/_category_.json
+++ b/versioned_docs/version-4.1/apis/subsystems/external/advanced/_category_.json
@@ -1,0 +1,6 @@
+{
+    "position": 6,
+    "label": "Advanced topics",
+    "collapsible": true,
+    "collapsed": true
+}

--- a/versioned_docs/version-4.1/apis/subsystems/external/advanced/custom-services.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/advanced/custom-services.md
@@ -1,0 +1,71 @@
+---
+title: Service creation
+tags:
+  - Web Services
+  - core_external
+  - external
+  - API
+---
+
+Moodle comes with two built-in services that your functions can be attached to.
+
+In rare situations, you may need to create a create a _custom_ service declaration.
+
+The recommended way of creating a new _service_ declaration is by placing it into the `db/services.php` file as a new service declaration.
+
+Moodle Administrators can also manually create a service declaration using the web interface.
+
+This is an advanced feature and, in most cases, _you will not need to use this feature_.
+
+:::note
+
+Whilst writing a service declaration is _optional_, if you do not create a service declaration, then the Moodle administrator will have to create one manually through the Web UI.
+
+If you define a web service here, then the administrator cannot add or remove any function from it.
+
+:::
+
+## Declaring a custom service declaration
+
+Service declarations should be placed in the `db/services.php` file of your plugin, for example `local/groupmanager/db/services.php`.
+
+```php title="local/groupmanager/db/services.php"
+$services = [
+    // The name of the service.
+    // This does not need to include the component name.
+    'myintegration' => [
+
+        // A list of external functions available in this service.
+        'functions' => [
+            'local_groupmanager_create_groups',
+        ],
+
+        // If set, the external service user will need this capability to access
+        // any function of this service.
+        // For example: 'local_groupmanager/integration:access'
+        'requiredcapability' => 'local_groupmanager/integration:access',
+
+        // If enabled, the Moodle administrator must link a user to this service from the Web UI.
+        'restrictedusers' => 0,
+
+        // Whether the service is enabled by default or not.
+        'enabled' => 1,
+
+        // This field os optional, but requried if the `restrictedusers` value is
+        // set, so as to allow configuration via the Web UI.
+        'shortname' =>  '',
+
+        // Whether to allow file downloads.
+        'downloadfiles' => 0,
+
+        // Whether to allow file uploads.
+        'uploadfiles'  => 0,
+    )
+);
+```
+
+:::note
+
+It is not possible for an administrator to add/remove any function from a pre-built service.
+
+:::

--- a/versioned_docs/version-4.1/apis/subsystems/external/description.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/description.md
@@ -1,0 +1,83 @@
+---
+title: Function Declarations
+tags:
+  - Web Services
+  - core_external
+  - external
+  - API
+sidebar_position: 1
+---
+
+Before they can be used, all functions must be _declared_ to Moodle, and their inputs and outputs must be _defined_.
+
+- Functions are _declared_ by noting them in the `db/services.php` file for a plugin.
+- Functions are _defined_ within their own class located within the `\component\external` namespace of a component.
+
+Function implementation classes consist of one class containing a number of functions, some of which are mandatory.
+
+During a Moodle installation or upgrade, the service and function _declarations_ are parsed by a service discovery process and stored within the database. An administrative UI may be used to change _some_ configuration details of these declarations.
+
+## Service declarations
+
+Each component wishing to create an external service function must declare that the function exists by describing it in the `db/services.php` file for that component.
+
+This information is stored internally within Moodle, and collected as part of the service discovery during installation and upgrade.
+
+```php title="local/groupmanager/db/services.php"
+$functions = [
+    // The name of your web service function, as discussed above.
+    'local_myplugin_create_groups' => [
+        // The name of the namespaced class that the function is located in.
+        'classname'   => 'local_groupmanager\create_groups',
+
+        // A brief, human-readable, description of the web service function.
+        'description' => 'Creates new groups.',
+
+        // Options include read, and write.
+        'type'        => 'write',
+
+        // Whether the service is available for use in AJAX calls from the web.
+        'ajax'        => true,
+
+        // An optional list of services where the function will be included.
+        'services'    => [
+            // A standard Moodle install includes one default service:
+            // - MOODLE_OFFICIAL_MOBILE_SERVICE.
+            // Specifying this service means that your function will be available for
+            // use in the Moodle Mobile App.
+            MOODLE_OFFICIAL_MOBILE_SERVICE,
+        ],
+    ),
+);
+```
+
+<details>
+<summary>Advanced options</summary>
+
+A number of advanced options are also available, as described below:
+
+```php title="local/groupmanager/db/services.php"
+$functions = [
+    // The name of your web service function, as discussed above.
+    'local_myplugin_create_groups' => [
+        // A comma-separated list of capabilities used by the function.
+        // This is advisory only and used to indicate to the administrator
+        // configuring a custom service definition.
+        'capabilities' => 'moodle/course:creategroups,moodle/course:managegroups',
+
+        // The following parameters are also available, but are no longer recommended.
+
+        // The name of the external function name.
+        // If not specified, this will default to 'execute'.
+        'methodname'  => 'execute',
+
+        // The file containing the class/external function.
+        // Do not use if using namespaced auto-loading classes.
+        'classpath'   => 'local/groupmanager/externallib.php',
+    ),
+);
+```
+
+</details>
+
+The function name is arbitrary, but must follow [the naming convention](https://docs.moodle.org/dev/Web_service_API_functions#Naming_convention). This helps ensure that it is globally unique.

--- a/versioned_docs/version-4.1/apis/subsystems/external/files.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/files.md
@@ -1,0 +1,137 @@
+---
+title: File handling
+tags:
+  - Web_Services
+  - core_external
+  - external
+  - core_files
+sidebar_position: 4
+---
+
+Moodle provides two ways to fetch and upload files:
+
+1. A set of web service functions; and
+2. A pair of dedicated endpoints.
+
+## Web service functions
+
+You can use the following functions to upload, and fetch, file content:
+
+1. `core_files_get_files()`; and
+1. `core_files_upload()`.
+
+When using these functions, the file content is base64-encoded.
+
+:::note
+
+Many devices do not have enough memory to encode and decode requests containing large files. As such we recommend using the dedicated endpoints instead.
+
+:::
+
+## Dedicated endpoints
+
+Moodle provides two dedicated endpoints which can be used, alongside the authentication token, to upload and fetch content. These are:
+
+- to upload a file: `/webservice/upload.php`; and
+- to fetch a file: `/webservice/pluginfile.php`.
+
+### File upload
+
+The recommended way to upload file content from an external service is by issue a `POST` request to the `/webservice/upload.php` endpoint, passing in a valid web service token for authentication.
+
+Upon successful upload, any files passed will be saved in the user's draft file area.
+
+The endpoint takes two optional arguments:
+
+- An `itemid` to upload the files to, defaulting to `0`. If none is specified then a new id is generated for the current user's draft file area
+- A `filepath` to store the file in, defaulting to `/`.
+
+The endpoint will return a JSON-encoded summary of the uploaded file, including the `itemid` that it was stored in.
+
+:::tip
+
+It is typical that the `itemid` parameter will be used when the files are uploaded singularly in separate HTTP calls and the files are required to be in the same draft file area.
+
+The client retrieves the `itemid` from the first uploaded file and uses it in subsequent uploads.
+
+This allows multiple files to be uploaded to the same draft file area.
+
+:::
+
+On every successful upload, the file/s information are returned in JSON format. If an error occurs, an error message will be sent back in JSON format too.
+
+:::note Example
+
+To upload a file, `users.csv`, you could use curl as follows:
+
+```bash
+$ curl -X POST -F "file_1=@users.csv" https://SITENAME/webservice/upload.php?token=TOKEN \
+| jq
+
+[
+  {
+    "component": "user",
+    "contextid": 567,
+    "userid": "123",
+    "filearea": "draft",
+    "filename": "users.csv",
+    "filepath": "/",
+    "itemid": 880413555,
+    "license": "allrightsreserved",
+    "author": "User User",
+    "source": "O:8:\"stdClass\":1:{s:6:\"source\";s:13:\"users.csv\";}"
+  }
+]
+```
+
+The returned JSON response includes the key parts of the file record, including the `itemid`.
+
+:::
+
+Once all the files are uploaded, you can call a webserivce function to process the files from the user drafts area, passing in the `itemid` of the draft area containing the list of files for the request. The service can identify the uploads and manipulate them as necessary.
+
+An example of a webservice that accepts files is: `mod_assign_save_submission`.
+
+To accept file uploads, the service must allow "files download" (*Administration > Plugins > Web services > Manage services > Edit service > Advanced button*)
+
+## File download
+
+We serve the files through `/webservice/pluginfile.php`. This script requires a web service token for authentication.
+
+To support file downloads, the service must allow "files download".
+
+:::note
+
+The `/webservice/pluginfile.php` endpoint has the exact same structure as `/pluginfile.php` and `/tokenpluginfile.php`.
+
+We don't serve the files through `/pluginfile.php` for web service clients because it requires the user's login session to work, however it is possible to use the `/tokenpluginfile.php` endpoint with an appropriate token.
+
+:::
+
+## Returning files in Web Services
+
+Since Moodle 3.2, you can return a complete file area list via Web Services using the static `get_area_files` method, defined in `external_util`.
+
+```php
+$forum->introfiles = external_util::get_area_files($context->id, 'mod_forum', 'intro', false, false);
+```
+
+You can also use the `external_files` structure definition in combination with the method to return the most common file fields required by WS clients.
+
+```php
+public static function execute_returns(): external_multiple_structure {
+    return new external_multiple_structure(
+        new external_single_structure([
+            'id' => new external_value(PARAM_INT, 'Forum id'),
+            // ...
+            'introfiles' => new external_files('Files in the introduction text', VALUE_OPTIONAL),
+            // ...
+        ])
+    );
+}
+```
+
+## See also
+
+- [Web services developer documentation](./index.md)
+- [Web services user documentation](https://docs.moodle.org/en/Web_services)

--- a/versioned_docs/version-4.1/apis/subsystems/external/functions.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/functions.md
@@ -1,0 +1,120 @@
+---
+title: Function Definitions
+tags:
+  - Web_Services
+  - API
+  - core_external
+  - external
+sidebar_position: 2
+---
+
+An External function _definition_ is the class, and collection of functions, used to define:
+
+- any parameters that the function expects to take, including any types
+- what the function will return, including any types
+- whether the function has been deprecated, or not
+
+It also includes the code that will actually be executed by the function.
+
+The function definition should be located within the `external` namespace of a component.
+
+:::info Example
+
+For a component named `local_groupmanager` located in `local/groupmanager` which is responsible for creating groups on request, you may have:
+
+- a Web service function named: `local_groupmanager_create_groups`
+- defined in a class named `local_groupmanager\external\create_groups`
+- which is located `local/groupmanager/classes/external/create_groups.php`
+
+:::
+
+A service definition:
+
+- _must_ `require_once` the `lib/externallib.php` file
+- _must_ extend the `external_api` class
+- _must_ declare an `execute_parameters` function to describe the expected parameters of the function
+- _must_ declare an `execute` function which is called with the functions and performs the expected actions
+- _must_ declare an `execute_returns` function to describe the values returned by the function
+- _may_ declare an `execute_is_deprecated` function to declare a function as deprecated
+
+### An example definition
+
+```php title="local/groupmanager/classes/external/create_groups.php"
+<?php
+
+namespace local_groupmanager\external;
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once("{$CFG->libdir}/externallib.php");
+
+class create_groups extends external_api {
+    public static function execute_parameters(): external_function_parameters {
+        return new external_function_parameters([
+            'groups' => new external_multiple_structure(
+                new external_single_structure([
+                    'courseid'  => new external_value(PARAM_INT, 'The course to create the group for'),
+                    'idnumber'    => new external_value(
+                        PARAM_RAW,
+                        'An arbitrary ID code number perhaps from the institution',
+                        VALUE_DEFAULT,
+                        null
+                    ),
+                    'name' => new external_value(
+                        PARAM_RAW,
+                        'The name of the group'
+                    ),
+                    'description' => new external_value(
+                        PARAM_TEXT,
+                        'A description',
+                        VALUE_OPTIONAL
+                    ),
+                ]),
+                'A list of groups to create'
+            ),
+        ]);
+    }
+
+    public static function execute(array $groups): array {
+        // Validate all of the parameters.
+        [
+            'groups' => $groups,
+        ] = self::validate_parameters(self::execute_parameters(), [
+            'groups' => $groups,
+        ]);
+
+        // Perform security checks, for example:
+        $coursecontext = \context_course::instance($courseid);
+        self::validate_context($coursecontext);
+        require_capability('moodle/course:creategroups', $coursecontext);
+
+        // Create the group using existing Moodle APIs.
+        $createdgroups = \local_groupmanager\util::create_groups($groups)
+
+        // Return a value as described in the returns function.
+        return [
+            'groups' => $createdgroups,
+        ];
+    }
+
+    public static function execute_returns(): external_single_structure {
+        return new external_single_structure(
+            'groups' => new external_multiple_structure([
+                'id' => new external_value(PARAM_INT, 'Id of the created user'),
+                'name' => new external_value(PARAM_RAW, 'The name of the group'),
+            ])
+        );
+    }
+}
+```
+
+:::note
+
+Available parameter types are defined in `lib/moodlelib.php` and are used by the `validate_parameters()` function and during return value checking to ensure that the service is called and working as defined.
+
+:::
+
+## See also
+
+- [Core APIs](../../../apis.md)
+- [Web services API](https://docs.moodle.org/dev/Web_services_API)

--- a/versioned_docs/version-4.1/apis/subsystems/external/index.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/index.md
@@ -1,0 +1,62 @@
+---
+title: External Services
+tags:
+  - external
+  - core_external
+  - API
+---
+
+Moodle has a full-featured Web Service framework, allowing you to use and create web services for use in external systems.
+The Web Service framework and the External API work closely together providing a number of _Endpoints_, and self-describing classes to support a wide range of uses.
+
+Moodle uses these web services internally for:
+
+- AJAX interactions in the Moodle Web Interface; and
+- The official Moodle Mobile App.
+
+The following example shows a typical authentication and protocol workflow.
+
+```mermaid
+sequenceDiagram
+    Client ->> Login Endpoint: Login attempted
+    Note right of Client: Authentication using <br> Username and Password
+    Login Endpoint ->> Client: Session token
+    Client ->> Protocol Server: Function and authentication token
+    Protocol Server -->> External API: Access Control Check
+    Note right of Protocol Server: The Session token is <br>used to confirm <br> user permission against <br> the specified API.
+    External API -->> Protocol Server: Authentication granted
+    Protocol Server ->> Plugin API: Function called against <br> relevant API
+    Plugin API ->> Protocol Server: Result passed back to Protocol server
+    Protocol Server -->> External API: Return value validated
+    Protocol Server ->> Client: Validated data returned to Client
+```
+
+## Developer documentation
+
+The External Service API has two categories of documentation:
+
+1. this documentation details how to _write_ a web service and use the External API; and
+2. API documentation for a live Moodle site, which can be found under ** Site administration > Plugins > Web services > API Documentation **.
+
+In addition to the standard API endpoints, several additional API endpoints are available for the purpose of uploading, and downloading, files. For more information on these endpoints, see the [file handling](./files.md) documentation.
+
+- [How to contribute a web service function to core](https://docs.moodle.org/dev/How_to_contribute_a_web_service_function_to_core)
+- [Adding a web service to your plugin](./writing-a-service.md)
+- Code example: [Adding a web service, using APIs](https://gist.github.com/timhunt/51987ad386faca61fe013904c242e9b4) by (Tim Hunt)
+- [Implement a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client)
+- [Web services files handling](./files.md)
+- [Web service Listing & Roadmap](https://docs.moodle.org/dev/Web_services_Roadmap)
+
+## Specification and brainstorming
+
+- [External services security](./security.md)
+- [External services description](./description.md)
+
+## See also
+
+- [Web service API functions](https://docs.moodle.org/dev/Web_service_API_functions)
+- [Web services FAQ](https://docs.moodle.org/en/Web_services_FAQ)
+- [How to create and enable a web service](https://docs.moodle.org/en/How_to_create_and_enable_a_web_service)
+- [How to enable the mobile web service](https://docs.moodle.org/en/Enable_mobile_web_services)
+- [Web services user documentation](https://docs.moodle.org/en/Web_services)
+- [Mastering Moodle Web Services development](http://www.slideshare.net/juanleyva/mastering-moodle-web-services-development) - Last session of the Hackfest in the MoodleMoot UK 2016

--- a/versioned_docs/version-4.1/apis/subsystems/external/security.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/security.md
@@ -1,0 +1,85 @@
+---
+title: Security
+tags:
+  - Web Services
+  - core_external
+  - external
+  - API
+sidebar_position: 3
+---
+
+Before operating on any data in an external function, you must ensure that the user:
+
+- has access to context that the data is located in
+- has permission to perform the relevant action
+
+## Validating function parameters
+
+Before working with any data provided by a user you **must** validate the parameters against the definitions you have defined.
+
+To do so you should call the `validate_parameters()` function, passing in the reference to your `execute_parameters()` function, and the complete list of parameters for the function. The function will return the validated and cleaned parameters.
+
+The `validate_parameters()` function is defined on the `external_api` class, and can be called as follows:
+
+```php title="local/groupmanager/classes/external/create_groups.php"
+public static function execute(array $groups): array {
+    [
+        'groups' => $groups,
+    ] = self::validate_parameters(self::execute_parameters(), [
+        'groups' => $groups,
+    ]);
+    // ...
+}
+```
+
+## Validating access to the Moodle context
+
+Whenever fetching or updating any data within Moodle using an External function definition, you **must** validate the context that the data exists within.
+
+To do so you should call the `validate_context()` function, passing the _most specific_ context for the data.
+
+For example, if you are working with data belonging to a specific activity, you should use the _activity_ context. If you are working with data belonging to a course, you should use the _course_ context.
+
+If your function operates on multiple contexts (like a list of courses), you must validate each context right before generating any response data related to that context.
+
+The `validate_context()` function is defined on the `external_api` class, and can be called as follows:
+
+```php title="local/groupmanager/classes/external/create_groups.php"
+public static function execute(array $groups): array {
+    // ...
+    foreach ($groups as $group) {
+        $coursecontext = \context_course::instance($group['courseid']);
+        self::validate_context($coursecontext);
+        // ...
+    }
+}
+```
+
+:::tip
+
+The `validate_context()` function will also configure the correct theme, language, and filters required to render content for the current user.
+
+:::
+
+:::caution
+
+You should not:
+
+- use the `require_login` function from an external function - this function is reserved for php scripts returning a web page.
+- call `$PAGE->set_context()` manually - this will generate warning notices.
+
+The `validate_context()` function is the only correct way to write external functions.
+
+:::
+
+## Ensuring that a user has the appropriate rights
+
+Once you have confirmed that the provided data is of the correct type, and configured Moodle for the specific context, you should also ensure that all capabilities are checked correctly.
+
+You can use the standard capability functions, including:
+
+- `has_capability()` - to check that a user has a single capability
+- `has_any_capability()` - to check that a user has any capability in a set
+- `has_all_capability()` - to check that a user has all capabilities in a set
+- `require_capability()` - to require a single capability
+- `require_all_capabilities()` - to require that a user has all capabilities in a set

--- a/versioned_docs/version-4.1/apis/subsystems/external/writing-a-service.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/writing-a-service.md
@@ -1,0 +1,460 @@
+---
+title: Writing a new service
+tags:
+  - Web Services
+  - Plugins
+  - core_external
+  - external
+sidebar_position: 5
+---
+
+This documentation covers the creation of a new external service for use in a web service of a fictional local plugin, `local_groupmanager`.
+
+## Functional specification
+
+The `local_groupmanager` plugin has a need to create groups within a course and would like to do so using its own web service.
+
+:::important
+
+When defining a new service definition, Moodle requires that the name of the definition be in the form:
+
+```sh
+[frankenstyle_component]_[methodname]
+```
+
+The [naming convention](https://docs.moodle.org/dev/Web_service_API_functions#Naming_convention) further dictates that the `methodname` component be in the form:
+
+```sh
+[methodname]  - The name of the method in the form of [verb]_[noun]
+[verb]        - Usually one of get, create, delete, update
+                A similar verb that well describes the action may also be used
+[noun]        - The object being modified
+                Usually in Plural form
+```
+
+:::
+
+import { CodeBlock, ValidExample, InvalidExample } from '@site/src/components';
+
+Per the Moodle naming convention for web services the name of the function should be:
+
+```
+local_groupmanager_create_groups
+```
+
+### Inputs
+
+The `local_groupmanager_create_groups` external service definition will take a list of _groups_ as its only parameters.
+
+### Outputs
+
+The service will return a list of the created groups, including the `id` element of those groups.
+
+### Exceptions and failures
+
+If _any_ group creation fails, the function will throw an exception, and no groups will be created.
+
+## Technical specification
+
+- **the core function the external function will call**: `groups_create_group()` from [/group/lib.php](http://github.com/moodle/moodle/tree/master/moodle/group/lib.php).
+- **the parameter types**: a list of object. This object are groups, with `id`/`name`/`courseid`.
+- **the returned value types**: a list of objects (groups) with their id.
+- **the user capabilities to check**: `moodle/course:managegroups`
+
+## Declare the web service function
+
+An external function must be declared before it can be used in your plugin.
+Function declarations should be placed in the `db/services.php` file of your plugin. For example in our fictitious plugin this would be located in `local/groupmanager/db/services.php`.
+
+```php
+$functions = [
+    // The name of your web service function, as discussed above.
+    'local_groupmanager_create_groups' => [
+        // The name of the namespaced class that the function is located in.
+        'classname'   => 'local_groupmanager\create_groups',
+
+        // A brief, human-readable, description of the web service function.
+        'description' => 'Creates new groups.',
+
+        // Options include read, and write.
+        'type'        => 'write',
+
+        // Whether the service is available for use in AJAX calls from the web.
+        'ajax'        => true,
+
+        // An optional list of services where the function will be included.
+        'services' => [
+            // A standard Moodle install includes one default service:
+            // - MOODLE_OFFICIAL_MOBILE_SERVICE.
+            // Specifying this service means that your function will be available for
+            // use in the Moodle Mobile App.
+            MOODLE_OFFICIAL_MOBILE_SERVICE,
+        ]
+    ),
+);
+```
+
+<details>
+<summary>Advanced options</summary>
+
+A number of advanced options are also available, as described below:
+
+```php
+$functions = [
+    // The name of your web service function, as discussed above.
+    'local_groupmanager_create_groups' => [
+        // A comma-separated list of capabilities used by the function.
+        // This is advisory only and used to indicate to the administrator configuring a custom service definition.
+        'capabilities' => 'moodle/course:creategroups,moodle/course:managegroups',
+
+        // The following parameters are also available, but are no longer recommended.
+
+        // The name of the external function name.
+        // If not specified, this will default to 'execute'.
+        // 'methodname'  => 'execute',
+
+        // The file containing the class/external function.
+        // Do not use if using namespaced auto-loading classes.
+        // 'classpath'   => 'local/groupmanager/externallib.php',
+    ),
+);
+```
+
+</details>
+
+## Write the external function descriptions
+
+Every web service function is mapped to an external function. External function are described in the [External functions API](./functions.md).
+Each external function is written with two other functions describing the parameters and the return values. These description functions are used by web service servers to:
+
+- validate the web service function parameters
+- validate the web service function returned values
+- build WSDL files or other protocol documents
+
+These two description functions are located in the class declared in `local/groupmanager/db/services.php`.
+
+Thus for the web service function `local_groupmanager_create_groups()`, we should write a class named `create_groups` in the `local_groupmanager\external` namespace.
+
+This will be located in the file `local/groupmanager/classes/external/create_groups.php`. The class will contain:
+
+- `execute_groups(...)`
+- `execute_groups_parameters()`
+- `execute_groups_return()`
+
+### Defining parameters
+
+```php
+<?php
+namespace local_groupmanager\external;
+
+require_once("{$CFG->libdir}/externallib.php");
+
+class create_groups extends \external_api {
+
+    /**
+     * Returns description of method parameters
+     * @return external_function_parameters
+     */
+    public static function execute_parameters() {
+        return new external_function_parameters([
+            'groups' => new external_multiple_structure(
+                new external_single_structure([
+                    'courseid' => new external_value(PARAM_INT, 'id of course'),
+                    'name' => new external_value(
+                        PARAM_TEXT,
+                        'multilang compatible name, course unique'
+                    ),
+                    'description' => new external_value(
+                        PARAM_RAW,
+                        'group description text'
+                    ),
+                    'enrolmentkey' => new external_value(
+                        PARAM_RAW,
+                        'group enrol secret phrase'
+                    ),
+                ])
+            )
+        ]);
+    }
+}
+```
+
+A web service function without parameters will have a parameter description function like that:
+
+```php
+/**
+ * Returns description of method parameters
+ * @return external_function_parameters
+ */
+public static function execute_parameters(): external_function_parameters {
+    return new external_function_parameters([
+        // If this function had any parameters, they would be described here.
+        // This example has no parameters, so the array is empty.
+    ]);
+}
+```
+
+A parameter can be described as:
+
+- a list => `external_multiple_structure`
+- an object => `external_single_structure`
+- a primary type => `external_value`
+
+Our `create_groups()` function expects one parameter named `groups`, so we will first write:
+
+```php
+/**
+ * Returns description of method parameters
+ * @return external_function_parameters
+ */
+public static function execute_parameters(): external_function_parameters {
+    return new external_function_parameters([
+        'groups' => ...
+    ]);
+}
+```
+
+This *groups* parameter is a list of group. So we will write :
+
+```php
+'groups' => new external_multiple_structure(
+    ...
+)
+```
+
+An external_multiple_structure object (list) can be constructed with:
+
+- `external_multiple_structure` (list)
+- `external_single_structure` (object)
+- `external_value` (primary type).
+
+For our function it will be a `external_single_structure`:
+
+```php
+new external_single_structure([
+    'courseid' => ...,
+    'name' => ...,
+    'description' => ...,
+    'enrolmentkey' => ...,
+])
+```
+
+Thus we obtain :
+
+```php
+'groups' => new external_multiple_structure(
+    new external_single_structure([
+        'courseid' => ...,
+        'name' => ...,
+        'description' => ...,
+        'enrolmentkey' => ...,
+    ])
+)
+```
+
+Each group values is a *external_value* (primary type):
+
+- `courseid` is an integer
+- `name` is a string (text only, not tag)
+- `description` is a string (can be anything)
+- `enrolmentkey` is also a string (can be anything)
+
+We add them to the description :
+
+```php
+'groups' => new external_multiple_structure(
+    new external_single_structure([
+        // The second argument is a human readable description text.
+        // This text is displayed in the automatically generated documentation.
+        'courseid' => new external_value(PARAM_INT, 'id of course'),
+        'name' => new external_value(PARAM_TEXT, 'multilang compatible name, course unique'),
+        'description' => new external_value(PARAM_RAW, 'group description text'),
+        'enrolmentkey' => new external_value(PARAM_RAW, 'group enrol secret phrase'),
+    ])
+)
+```
+
+### execute_returns()
+
+It's similar to execute_parameters(), but instead of describing the parameters, it describes the return values.
+
+```php
+public static function execute_returns() {
+    return new external_multiple_structure(
+        new external_single_structure([
+            'id' => new external_value(PARAM_INT, 'group record id'),
+            'courseid' => new external_value(PARAM_INT, 'id of course'),
+            'name' => new external_value(PARAM_TEXT, 'multilang compatible name, course unique'),
+            'description' => new external_value(PARAM_RAW, 'group description text'),
+            'enrolmentkey' => new external_value(PARAM_RAW, 'group enrol secret phrase'),
+        ])
+    );
+}
+```
+
+### Required, Optional or Default value
+
+A value can be `VALUE_REQUIRED`, `VALUE_OPTIONAL`, or `VALUE_DEFAULT`. If not mentioned, a value is `VALUE_REQUIRED` by default.
+
+```php
+'yearofstudy' => new external_value(PARAM_INT, 'year of study', VALUE_DEFAULT, 1979),
+```
+
+- `VALUE_REQUIRED` - if the value is not supplied => the server throws an error message
+- `VALUE_OPTIONAL` - if the value is not supplied => the value is ignored. Note that VALUE_OPTIONAL can't be used in top level parameters, it must be used only within array/objects key definition. If you need top level Optional parameters you should use VALUE_DEFAULT instead.
+- `VALUE_DEFAULT` - if the value is not supplied => the default value is used
+
+:::caution
+
+Because some web service protocols are strict about the number and types of arguments - it is not possible to specify an optional parameter as one of the top-most parameters for a function.
+
+<InvalidExample>
+
+```php
+public static function get_biscuit_parameters() {
+    return new external_function_parameters([
+        'chocolatechips' => new external_value(PARAM_BOOL, PARAM_REQUIRED),
+        'glutenfree' => new external_value(PARAM_BOOL, PARAM_DEFAULT, false),
+        // ERROR! top level optional parameter!!!
+        'icingsugar' => new external_value(PARAM_BOOL, VALUE_OPTIONAL),
+    ]);
+}
+```
+
+</InvalidExample>
+
+<ValidExample>
+
+```php
+public static function get_biscuit_parameters() {
+    return new external_function_parameters([
+            'ifeellike' => new external_single_structure([
+                    'chocolatechips' => new external_value(PARAM_BOOL, VALUE_REQUIRED),
+                    'glutenfree' => new external_value(PARAM_BOOL, PARAM_DEFAULT, false),
+                    // ALL GOOD!! We have nested the params in a external_single_structure.
+                    'icingsugar' => new external_value(PARAM_BOOL, VALUE_OPTIONAL),
+        ])
+    ]);
+}
+```
+
+</ValidExample>
+
+:::
+
+## Implement the external function
+
+We declared our web service function and we defined the external function parameters and return values. We will now implement the external function:
+
+```php
+    /**
+     * Create groups
+     * @param array $groups array of group description arrays (with keys groupname and courseid)
+     * @return array of newly created groups
+     */
+    public static function eceute_groups($groups) { //Don't forget to set it as static
+        global $CFG, $DB;
+        require_once("$CFG->dirroot/group/lib.php");
+
+        $params = self::validate_parameters(self::execute_parameters(), array('groups'=>$groups));
+
+        $transaction = $DB->start_delegated_transaction(); //If an exception is thrown in the below code, all DB queries in this code will be rollback.
+
+        $groups = array();
+
+        foreach ($params['groups'] as $group) {
+            $group = (object)$group;
+
+            if (trim($group->name) == '') {
+                throw new invalid_parameter_exception('Invalid group name');
+            }
+            if ($DB->get_record('groups', array('courseid'=>$group->courseid, 'name'=>$group->name))) {
+                throw new invalid_parameter_exception('Group with the same name already exists in the course');
+            }
+
+            // now security checks
+            $context = get_context_instance(CONTEXT_COURSE, $group->courseid);
+            self::validate_context($context);
+            require_capability('moodle/course:managegroups', $context);
+
+            // finally create the group
+            $group->id = groups_create_group($group, false);
+            $groups[] = (array)$group;
+        }
+
+        $transaction->allow_commit();
+
+        return $groups;
+    }
+```
+
+### Parameter validation
+
+```php
+ $params = self::validate_parameters(self::execute_parameters(), [
+    'groups' => $groups,
+]);
+```
+
+This *validate_parameters* function validates the external function parameters against the description. It will return an exception if some required parameters are missing, if parameters are not well-formed, and check the parameters validity. It is essential that you do this call to avoid potential hack.
+
+**Important:** the parameters of the external function and their declaration in the description **must be the same order**. In this example we have only one parameter named $groups, so we don't need to worry about the order.
+
+### Context and Capability checks
+
+```php
+// Perform security checks.
+$context = context_course::instance($group->courseid);
+self::validate_context($context);
+require_capability('moodle/course:managegroups', $context);
+```
+
+Note: validate_context() is required in all external functions before operating on any data belonging to a context. This function does sanity and security checks on the context that was passed to the external function - and sets up the global $PAGE and $OUTPUT for rendering return values. Do NOT use require_login(), or $PAGE->set_context() in an external function.
+
+### Exceptions
+
+You can throw exceptions. These are automatically handled by Moodle web service servers.
+
+```php
+// Note: It is good practice to add detailled information in $debuginfo,
+//       and only send back a generic exception message when Moodle DEBUG mode < NORMAL.
+//       It's what we do here throwing the invalid_parameter_exception($debug) exception
+throw new invalid_parameter_exception('Group with the same name already exists in the course');
+```
+
+### Correct return values
+
+The return values will be validated by the Moodle web service servers:
+
+- return values contain some values not described => these values will be skipped.
+- return values miss some required values (VALUE_REQUIRED) => the server will return an error.
+- return values types don't match the description (int != PARAM_ALPHA) => the server will return an error
+**Note:** cast all your returned objects into arrays.
+
+## Bump the plugin version
+
+Edit your `local/groupmanager/version.php` and increase the plugin version. This should trigger a Moodle upgrade and the new web service should be available in the administration (*Administration > Plugins > Web Services > Manage services*)
+
+## Deprecation
+
+External functions deprecation process is slightly different from the standard deprecation. If you are interested in deprecating any of your external functions you should **also** (apart from the applicable points detailed in the [standard deprecation docs](/general/development/policies/deprecation)) create a `FUNCTIONNAME_is_deprecated()` method in your external function class. Return true if the external function is deprecated. This is an example:
+
+```php
+     * Mark the function as deprecated.
+     * @return bool
+     */
+    public static function execute_is_deprecated() {
+        return true;
+    }
+```
+
+## See also
+
+- [Web services developer documentation](./index.md)
+- [Web services user documentation](https://docs.moodle.org/en/Web_services)
+- [Implement a web service client](https://docs.moodle.org/dev/Creating_a_web_service_client)
+- Code example: [Adding a web service, using APIs](https://gist.github.com/timhunt/51987ad386faca61fe013904c242e9b4) by (Tim Hunt)
+Specification:
+- [External services security](./security.md)
+- [External services description](./description.md)
+- [Session locks#Read only sessions in web services](https://docs.moodle.org/dev/Session_locks#Read_only_sessions_in_web_services)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3515,6 +3515,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@braintree/sanitize-url@npm:^6.0.0":
+  version: 6.0.2
+  resolution: "@braintree/sanitize-url@npm:6.0.2"
+  checksum: 6a9dfd4081cc96516eeb281d1a83d3b5f1ad3d2837adf968fcc2ba18889ee833554f9c641b4083c36d3360a932e4504ddf25b0b51e9933c3742622df82cf7c9a
+  languageName: node
+  linkType: hard
+
 "@colors/colors@npm:1.5.0":
   version: 1.5.0
   resolution: "@colors/colors@npm:1.5.0"
@@ -4361,6 +4368,25 @@ __metadata:
     react: ^16.8.4 || ^17.0.0
     react-dom: ^16.8.4 || ^17.0.0
   checksum: 23cbba8e7e24494c6d106ce3d0b90ef461580bfacef9f27dfbc4f0b33fcb349394faf2bedf0a44db8c455535e50e828e82270c8f159c3d8d60f0e0980170be4e
+  languageName: node
+  linkType: hard
+
+"@docusaurus/theme-mermaid@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@docusaurus/theme-mermaid@npm:2.2.0"
+  dependencies:
+    "@docusaurus/core": 2.2.0
+    "@docusaurus/module-type-aliases": 2.2.0
+    "@docusaurus/theme-common": 2.2.0
+    "@docusaurus/types": 2.2.0
+    "@docusaurus/utils-validation": 2.2.0
+    "@mdx-js/react": ^1.6.22
+    mermaid: ^9.1.1
+    tslib: ^2.4.0
+  peerDependencies:
+    react: ^16.8.4 || ^17.0.0
+    react-dom: ^16.8.4 || ^17.0.0
+  checksum: cc1fcb93657750debb95eb454a23739a590746d171bae0d56a8856f9178aff6aeaa89894d28e9655affc57198332921af0e029a81e3a025e52ce3c89c706edff
   languageName: node
   linkType: hard
 
@@ -8239,17 +8265,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:7, commander@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
+  languageName: node
+  linkType: hard
+
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
-  languageName: node
-  linkType: hard
-
-"commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
   languageName: node
   linkType: hard
 
@@ -8980,6 +9006,334 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.2.0":
+  version: 3.2.1
+  resolution: "d3-array@npm:3.2.1"
+  dependencies:
+    internmap: 1 - 2
+  checksum: 0bed33cc33b70f9d48ccef3e7a5956e134862e09179bf14df0bf9c8fc0ec02b8f847d4f5e1d32729cd5e02032af1d0a32bcc968ff1333795028455a749994623
+  languageName: node
+  linkType: hard
+
+"d3-axis@npm:3":
+  version: 3.0.0
+  resolution: "d3-axis@npm:3.0.0"
+  checksum: 227ddaa6d4bad083539c1ec245e2228b4620cca941997a8a650cb0af239375dc20271993127eedac66f0543f331027aca09385e1e16eed023f93eac937cddf0b
+  languageName: node
+  linkType: hard
+
+"d3-brush@npm:3":
+  version: 3.0.0
+  resolution: "d3-brush@npm:3.0.0"
+  dependencies:
+    d3-dispatch: 1 - 3
+    d3-drag: 2 - 3
+    d3-interpolate: 1 - 3
+    d3-selection: 3
+    d3-transition: 3
+  checksum: 1d042167769a02ac76271c71e90376d7184206e489552b7022a8ec2860209fe269db55e0a3430f3dcbe13b6fec2ff65b1adeaccba3218991b38e022390df72e3
+  languageName: node
+  linkType: hard
+
+"d3-chord@npm:3":
+  version: 3.0.1
+  resolution: "d3-chord@npm:3.0.1"
+  dependencies:
+    d3-path: 1 - 3
+  checksum: ddf35d41675e0f8738600a8a2f05bf0858def413438c12cba357c5802ecc1014c80a658acbbee63cbad2a8c747912efb2358455d93e59906fe37469f1dc6b78b
+  languageName: node
+  linkType: hard
+
+"d3-color@npm:1 - 3, d3-color@npm:3":
+  version: 3.1.0
+  resolution: "d3-color@npm:3.1.0"
+  checksum: 4931fbfda5d7c4b5cfa283a13c91a954f86e3b69d75ce588d06cde6c3628cebfc3af2069ccf225e982e8987c612aa7948b3932163ce15eb3c11cd7c003f3ee3b
+  languageName: node
+  linkType: hard
+
+"d3-contour@npm:4":
+  version: 4.0.0
+  resolution: "d3-contour@npm:4.0.0"
+  dependencies:
+    d3-array: ^3.2.0
+  checksum: 1f9b9e56d0966d98a4c740b6af32b4fa2d14424159644adc24f4eb0ab023afbd414938f63f95032a66407fb701f4966efe40875e2cc0460fb653a943d3fc86b0
+  languageName: node
+  linkType: hard
+
+"d3-delaunay@npm:6":
+  version: 6.0.2
+  resolution: "d3-delaunay@npm:6.0.2"
+  dependencies:
+    delaunator: 5
+  checksum: 80b18686dd7a5919a570000061f1515d106b7c7e3cba9da55706c312fc8f6de58a72674f2ea4eadc6694611f2df59f82c8b9d304845dd8b7903ee1f303aa5865
+  languageName: node
+  linkType: hard
+
+"d3-dispatch@npm:1 - 3, d3-dispatch@npm:3":
+  version: 3.0.1
+  resolution: "d3-dispatch@npm:3.0.1"
+  checksum: fdfd4a230f46463e28e5b22a45dd76d03be9345b605e1b5dc7d18bd7ebf504e6c00ae123fd6d03e23d9e2711e01f0e14ea89cd0632545b9f0c00b924ba4be223
+  languageName: node
+  linkType: hard
+
+"d3-drag@npm:2 - 3, d3-drag@npm:3":
+  version: 3.0.0
+  resolution: "d3-drag@npm:3.0.0"
+  dependencies:
+    d3-dispatch: 1 - 3
+    d3-selection: 3
+  checksum: d297231e60ecd633b0d076a63b4052b436ddeb48b5a3a11ff68c7e41a6774565473a6b064c5e9256e88eca6439a917ab9cea76032c52d944ddbf4fd289e31111
+  languageName: node
+  linkType: hard
+
+"d3-dsv@npm:1 - 3, d3-dsv@npm:3":
+  version: 3.0.1
+  resolution: "d3-dsv@npm:3.0.1"
+  dependencies:
+    commander: 7
+    iconv-lite: 0.6
+    rw: 1
+  bin:
+    csv2json: bin/dsv2json.js
+    csv2tsv: bin/dsv2dsv.js
+    dsv2dsv: bin/dsv2dsv.js
+    dsv2json: bin/dsv2json.js
+    json2csv: bin/json2dsv.js
+    json2dsv: bin/json2dsv.js
+    json2tsv: bin/json2dsv.js
+    tsv2csv: bin/dsv2dsv.js
+    tsv2json: bin/dsv2json.js
+  checksum: 5fc0723647269d5dccd181d74f2265920ab368a2868b0b4f55ffa2fecdfb7814390ea28622cd61ee5d9594ab262879509059544e9f815c54fe76fbfb4ffa4c8a
+  languageName: node
+  linkType: hard
+
+"d3-ease@npm:1 - 3, d3-ease@npm:3":
+  version: 3.0.1
+  resolution: "d3-ease@npm:3.0.1"
+  checksum: 06e2ee5326d1e3545eab4e2c0f84046a123dcd3b612e68858219aa034da1160333d9ce3da20a1d3486d98cb5c2a06f7d233eee1bc19ce42d1533458bd85dedcd
+  languageName: node
+  linkType: hard
+
+"d3-fetch@npm:3":
+  version: 3.0.1
+  resolution: "d3-fetch@npm:3.0.1"
+  dependencies:
+    d3-dsv: 1 - 3
+  checksum: 382dcea06549ef82c8d0b719e5dc1d96286352579e3b51b20f71437f5800323315b09cf7dcfd4e1f60a41e1204deb01758470cea257d2285a7abd9dcec806984
+  languageName: node
+  linkType: hard
+
+"d3-force@npm:3":
+  version: 3.0.0
+  resolution: "d3-force@npm:3.0.0"
+  dependencies:
+    d3-dispatch: 1 - 3
+    d3-quadtree: 1 - 3
+    d3-timer: 1 - 3
+  checksum: 6c7e96438cab62fa32aeadb0ade3297b62b51f81b1b38b0a60a5ec9fd627d74090c1189654d92df2250775f31b06812342f089f1d5947de9960a635ee3581def
+  languageName: node
+  linkType: hard
+
+"d3-format@npm:1 - 3, d3-format@npm:3":
+  version: 3.1.0
+  resolution: "d3-format@npm:3.1.0"
+  checksum: f345ec3b8ad3cab19bff5dead395bd9f5590628eb97a389b1dd89f0b204c7c4fc1d9520f13231c2c7cf14b7c9a8cf10f8ef15bde2befbab41454a569bd706ca2
+  languageName: node
+  linkType: hard
+
+"d3-geo@npm:3":
+  version: 3.0.1
+  resolution: "d3-geo@npm:3.0.1"
+  dependencies:
+    d3-array: 2.5.0 - 3
+  checksum: e0f7e6a2f0d4c26efe08a7aa2c40b9a1a5a037220c6aaa51fb527035597e6e8841222b433e5681f9b5588b5b6f9a1c2d7f032a76ccbac3a17b0c1cbfffd05c1b
+  languageName: node
+  linkType: hard
+
+"d3-hierarchy@npm:3":
+  version: 3.1.2
+  resolution: "d3-hierarchy@npm:3.1.2"
+  checksum: 0fd946a8c5fd4686d43d3e11bbfc2037a145fda29d2261ccd0e36f70b66af6d7638e2c0c7112124d63fc3d3127197a00a6aecf676bd5bd392a94d7235a214263
+  languageName: node
+  linkType: hard
+
+"d3-interpolate@npm:1 - 3, d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:3":
+  version: 3.0.1
+  resolution: "d3-interpolate@npm:3.0.1"
+  dependencies:
+    d3-color: 1 - 3
+  checksum: a42ba314e295e95e5365eff0f604834e67e4a3b3c7102458781c477bd67e9b24b6bb9d8e41ff5521050a3f2c7c0c4bbbb6e187fd586daa3980943095b267e78b
+  languageName: node
+  linkType: hard
+
+"d3-path@npm:1 - 3, d3-path@npm:3":
+  version: 3.0.1
+  resolution: "d3-path@npm:3.0.1"
+  checksum: 6347c7055e0af330acadbe7f02144963eecabff560a791ecfeaffb45662e4d38eedabc6109dc481478f136b41d03707d3a43321ca9a115962888c99732ceb41a
+  languageName: node
+  linkType: hard
+
+"d3-polygon@npm:3":
+  version: 3.0.1
+  resolution: "d3-polygon@npm:3.0.1"
+  checksum: 0b85c532517895544683849768a2c377cee3801ef8ccf3fa9693c8871dd21a0c1a2a0fc75ff54192f0ba2c562b0da2bc27f5bf959dfafc7fa23573b574865d2c
+  languageName: node
+  linkType: hard
+
+"d3-quadtree@npm:1 - 3, d3-quadtree@npm:3":
+  version: 3.0.1
+  resolution: "d3-quadtree@npm:3.0.1"
+  checksum: 5469d462763811475f34a7294d984f3eb100515b0585ca5b249656f6b1a6e99b20056a2d2e463cc9944b888896d2b1d07859c50f9c0cf23438df9cd2e3146066
+  languageName: node
+  linkType: hard
+
+"d3-random@npm:3":
+  version: 3.0.1
+  resolution: "d3-random@npm:3.0.1"
+  checksum: a70ad8d1cabe399ebeb2e482703121ac8946a3b336830b518da6848b9fdd48a111990fc041dc716f16885a72176ffa2898f2a250ca3d363ecdba5ef92b18e131
+  languageName: node
+  linkType: hard
+
+"d3-scale-chromatic@npm:3":
+  version: 3.0.0
+  resolution: "d3-scale-chromatic@npm:3.0.0"
+  dependencies:
+    d3-color: 1 - 3
+    d3-interpolate: 1 - 3
+  checksum: a8ce4cb0267a17b28ebbb929f5e3071d985908a9c13b6fcaa2a198e1e018f275804d691c5794b970df0049725b7944f32297b31603d235af6414004f0c7f82c0
+  languageName: node
+  linkType: hard
+
+"d3-scale@npm:4":
+  version: 4.0.2
+  resolution: "d3-scale@npm:4.0.2"
+  dependencies:
+    d3-array: 2.10.0 - 3
+    d3-format: 1 - 3
+    d3-interpolate: 1.2.0 - 3
+    d3-time: 2.1.1 - 3
+    d3-time-format: 2 - 4
+  checksum: a9c770d283162c3bd11477c3d9d485d07f8db2071665f1a4ad23eec3e515e2cefbd369059ec677c9ac849877d1a765494e90e92051d4f21111aa56791c98729e
+  languageName: node
+  linkType: hard
+
+"d3-selection@npm:2 - 3, d3-selection@npm:3":
+  version: 3.0.0
+  resolution: "d3-selection@npm:3.0.0"
+  checksum: f4e60e133309115b99f5b36a79ae0a19d71ee6e2d5e3c7216ef3e75ebd2cb1e778c2ed2fa4c01bef35e0dcbd96c5428f5bd6ca2184fe2957ed582fde6841cbc5
+  languageName: node
+  linkType: hard
+
+"d3-shape@npm:3":
+  version: 3.1.0
+  resolution: "d3-shape@npm:3.1.0"
+  dependencies:
+    d3-path: 1 - 3
+  checksum: 3dffe31b56feaf0817954748c9823c0e1fb6ab888b83775e9d568176ffa369546064ae49403963aac70108272988f632452634851f1c8a92805134d0c40e6dba
+  languageName: node
+  linkType: hard
+
+"d3-time-format@npm:2 - 4, d3-time-format@npm:4":
+  version: 4.1.0
+  resolution: "d3-time-format@npm:4.1.0"
+  dependencies:
+    d3-time: 1 - 3
+  checksum: 7342bce28355378152bbd4db4e275405439cabba082d9cd01946d40581140481c8328456d91740b0fe513c51ec4a467f4471ffa390c7e0e30ea30e9ec98fcdf4
+  languageName: node
+  linkType: hard
+
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3":
+  version: 3.1.0
+  resolution: "d3-time@npm:3.1.0"
+  dependencies:
+    d3-array: 2 - 3
+  checksum: 613b435352a78d9f31b7f68540788186d8c331b63feca60ad21c88e9db1989fe888f97f242322ebd6365e45ec3fb206a4324cd4ca0dfffa1d9b5feb856ba00a7
+  languageName: node
+  linkType: hard
+
+"d3-timer@npm:1 - 3, d3-timer@npm:3":
+  version: 3.0.1
+  resolution: "d3-timer@npm:3.0.1"
+  checksum: 1cfddf86d7bca22f73f2c427f52dfa35c49f50d64e187eb788dcad6e927625c636aa18ae4edd44d084eb9d1f81d8ca4ec305dae7f733c15846a824575b789d73
+  languageName: node
+  linkType: hard
+
+"d3-transition@npm:2 - 3, d3-transition@npm:3":
+  version: 3.0.1
+  resolution: "d3-transition@npm:3.0.1"
+  dependencies:
+    d3-color: 1 - 3
+    d3-dispatch: 1 - 3
+    d3-ease: 1 - 3
+    d3-interpolate: 1 - 3
+    d3-timer: 1 - 3
+  peerDependencies:
+    d3-selection: 2 - 3
+  checksum: cb1e6e018c3abf0502fe9ff7b631ad058efb197b5e14b973a410d3935aead6e3c07c67d726cfab258e4936ef2667c2c3d1cd2037feb0765f0b4e1d3b8788c0ea
+  languageName: node
+  linkType: hard
+
+"d3-zoom@npm:3":
+  version: 3.0.0
+  resolution: "d3-zoom@npm:3.0.0"
+  dependencies:
+    d3-dispatch: 1 - 3
+    d3-drag: 2 - 3
+    d3-interpolate: 1 - 3
+    d3-selection: 2 - 3
+    d3-transition: 2 - 3
+  checksum: 8056e3527281cfd1ccbcbc458408f86973b0583e9dac00e51204026d1d36803ca437f970b5736f02fafed9f2b78f145f72a5dbc66397e02d4d95d4c594b8ff54
+  languageName: node
+  linkType: hard
+
+"d3@npm:^7.0.0, d3@npm:^7.7.0":
+  version: 7.7.0
+  resolution: "d3@npm:7.7.0"
+  dependencies:
+    d3-array: 3
+    d3-axis: 3
+    d3-brush: 3
+    d3-chord: 3
+    d3-color: 3
+    d3-contour: 4
+    d3-delaunay: 6
+    d3-dispatch: 3
+    d3-drag: 3
+    d3-dsv: 3
+    d3-ease: 3
+    d3-fetch: 3
+    d3-force: 3
+    d3-format: 3
+    d3-geo: 3
+    d3-hierarchy: 3
+    d3-interpolate: 3
+    d3-path: 3
+    d3-polygon: 3
+    d3-quadtree: 3
+    d3-random: 3
+    d3-scale: 4
+    d3-scale-chromatic: 3
+    d3-selection: 3
+    d3-shape: 3
+    d3-time: 3
+    d3-time-format: 4
+    d3-timer: 3
+    d3-transition: 3
+    d3-zoom: 3
+  checksum: ed1308674fe0eda2ee14218f3d8ead5025204367c1881acf794d7eb99b0940883108520c35e053d5b23707a4ce858a5af422eea299bc0d24ce7d7fe13e7f9f38
+  languageName: node
+  linkType: hard
+
+"dagre-d3-es@npm:7.0.6":
+  version: 7.0.6
+  resolution: "dagre-d3-es@npm:7.0.6"
+  dependencies:
+    d3: ^7.7.0
+    lodash-es: ^4.17.21
+  checksum: c3ef31eda7f616e53fdc77d5c92615cbb6b97f5c3d5d5dd344321a0c48fc34605ca57354aa9d64775537756bc48c889af9a69bf64889f929a7918e5ba3f0f4cb
+  languageName: node
+  linkType: hard
+
 "damerau-levenshtein@npm:^1.0.8":
   version: 1.0.8
   resolution: "damerau-levenshtein@npm:1.0.8"
@@ -9154,6 +9508,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"delaunator@npm:5":
+  version: 5.0.0
+  resolution: "delaunator@npm:5.0.0"
+  dependencies:
+    robust-predicates: ^3.0.0
+  checksum: d6764188442b7f7c6bcacebd96edc00e35f542a96f1af3ef600e586bfb9849a3682c489c0ab423440c90bc4c7cac77f28761babff76fa29e193e1cf50a95b860
+  languageName: node
+  linkType: hard
+
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
@@ -9249,6 +9612,7 @@ __metadata:
     "@docusaurus/module-type-aliases": ^2.2.0
     "@docusaurus/plugin-pwa": ^2.2.0
     "@docusaurus/preset-classic": ^2.2.0
+    "@docusaurus/theme-mermaid": ^2.2.0
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
     "@mdx-js/react": ^1.6.22
@@ -9426,6 +9790,13 @@ __metadata:
   dependencies:
     domelementtype: ^2.3.0
   checksum: 0f58f4a6af63e6f3a4320aa446d28b5790a009018707bce2859dcb1d21144c7876482b5188395a188dfa974238c019e0a1e610d2fc269a12b2c192ea2b0b131c
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:2.4.1":
+  version: 2.4.1
+  resolution: "dompurify@npm:2.4.1"
+  checksum: 1169177465b3cbb25a44322937fba549f6c4e1a91b83245d144471be26619c835cccf0f8e20aa78c25ac11a06efd17cc1b9db9cacadceb78a4c08a1029eafee5
   languageName: node
   linkType: hard
 
@@ -11772,7 +12143,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:0.6, iconv-lite@npm:^0.6.2":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -11969,6 +12340,13 @@ __metadata:
     has: ^1.0.3
     side-channel: ^1.0.4
   checksum: 1944f92e981e47aebc98a88ff0db579fd90543d937806104d0b96557b10c1f170c51fb777b97740a8b6ddeec585fca8c39ae99fd08a8e058dfc8ab70937238bf
+  languageName: node
+  linkType: hard
+
+"internmap@npm:1 - 2":
+  version: 2.0.3
+  resolution: "internmap@npm:2.0.3"
+  checksum: 7ca41ec6aba8f0072fc32fa8a023450a9f44503e2d8e403583c55714b25efd6390c38a87161ec456bf42d7bc83aab62eb28f5aef34876b1ac4e60693d5e1d241
   languageName: node
   linkType: hard
 
@@ -13233,6 +13611,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"khroma@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "khroma@npm:2.0.0"
+  checksum: 3be7ef681f41f6071464e21060731fa63e2915bcd0774b9f35e431aa664c0c0e0826825403360654935111d4309f6704e5dc27cd953614133dfbdee4c056c3a8
+  languageName: node
+  linkType: hard
+
 "kind-of@npm:^6.0.0, kind-of@npm:^6.0.2, kind-of@npm:^6.0.3":
   version: 6.0.3
   resolution: "kind-of@npm:6.0.3"
@@ -13451,6 +13836,13 @@ __metadata:
   dependencies:
     p-locate: ^5.0.0
   checksum: 72eb661788a0368c099a184c59d2fee760b3831c9c1c33955e8a19ae4a21b4116e53fa736dc086cdeb9fce9f7cc508f2f92d2d3aae516f133e16a2bb59a39f5a
+  languageName: node
+  linkType: hard
+
+"lodash-es@npm:^4.17.21":
+  version: 4.17.21
+  resolution: "lodash-es@npm:4.17.21"
+  checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
   languageName: node
   linkType: hard
 
@@ -13912,6 +14304,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mermaid@npm:^9.1.1":
+  version: 9.3.0
+  resolution: "mermaid@npm:9.3.0"
+  dependencies:
+    "@braintree/sanitize-url": ^6.0.0
+    d3: ^7.0.0
+    dagre-d3-es: 7.0.6
+    dompurify: 2.4.1
+    khroma: ^2.0.0
+    lodash-es: ^4.17.21
+    moment-mini: ^2.24.0
+    non-layered-tidy-tree-layout: ^2.0.2
+    stylis: ^4.1.2
+    uuid: ^9.0.0
+  checksum: 5b310deeac6180b7a1d602c67dc1bd7674a49fc6a6a4b3187f5f457a130b9b2d16ac9f7e1c96042ceeeaa18725df8fe0bfd91108a25cc2c181ac913ec5e9f5c4
+  languageName: node
+  linkType: hard
+
 "methods@npm:~1.1.2":
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
@@ -14141,6 +14551,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"moment-mini@npm:^2.24.0":
+  version: 2.29.4
+  resolution: "moment-mini@npm:2.29.4"
+  checksum: 5d386872d04202c36653442a65f0e06a4e33cf3b25cef4e9df17877a8e76e93f218a1dfd4ccc0946c228815a4e1e53d79ae340de82791ffce90007769eb85120
+  languageName: node
+  linkType: hard
+
 "mrmime@npm:^1.0.0":
   version: 1.0.0
   resolution: "mrmime@npm:1.0.0"
@@ -14350,6 +14767,13 @@ __metadata:
     underscore: ^1.9.1
     winston: ^3.3.3
   checksum: 1b50556f7cbf4d53fe39d27bcf02f283b07b43fbdff064a41869679b12f467081845981f2b53a92095ffc1f70c822f33f7f2651d74d0769e2fcb1837c04044a3
+  languageName: node
+  linkType: hard
+
+"non-layered-tidy-tree-layout@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "non-layered-tidy-tree-layout@npm:2.0.2"
+  checksum: 5defc1c459001b22816a4fb8b86259b9b76e7f3090df576122a41c760133ab2061934cacd6f176c98c2ae4fee3879b97941e8897e8882985cbfe830f155cd158
   languageName: node
   linkType: hard
 
@@ -16621,6 +17045,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"robust-predicates@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "robust-predicates@npm:3.0.1"
+  checksum: 45e9de2df4380da84a2a561d4fd54ea92194e878b93ed19d5e4bc90f4e834a13755e846c8516bab8360190309696f0564a0150386c52ef01f70f2b388449dac5
+  languageName: node
+  linkType: hard
+
 "rollup-plugin-terser@npm:^7.0.0":
   version: 7.0.2
   resolution: "rollup-plugin-terser@npm:7.0.2"
@@ -16683,6 +17114,13 @@ __metadata:
   dependencies:
     queue-microtask: ^1.2.2
   checksum: cb4f97ad25a75ebc11a8ef4e33bb962f8af8516bb2001082ceabd8902e15b98f4b84b4f8a9b222e5d57fc3bd1379c483886ed4619367a7680dad65316993021d
+  languageName: node
+  linkType: hard
+
+"rw@npm:1":
+  version: 1.3.3
+  resolution: "rw@npm:1.3.3"
+  checksum: c20d82421f5a71c86a13f76121b751553a99cd4a70ea27db86f9b23f33db941f3f06019c30f60d50c356d0bd674c8e74764ac146ea55e217c091bde6fba82aa3
   languageName: node
   linkType: hard
 
@@ -17716,7 +18154,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stylis@npm:4.1.3":
+"stylis@npm:4.1.3, stylis@npm:^4.1.2":
   version: 4.1.3
   resolution: "stylis@npm:4.1.3"
   checksum: d04dbffcb9bf2c5ca8d8dc09534203c75df3bf711d33973ea22038a99cc475412a350b661ebd99cbc01daa50d7eedcf0d130d121800eb7318759a197023442a6
@@ -18661,6 +19099,15 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "uuid@npm:9.0.0"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 8dd2c83c43ddc7e1c71e36b60aea40030a6505139af6bee0f382ebcd1a56f6cd3028f7f06ffb07f8cf6ced320b76aea275284b224b002b289f89fe89c389b028
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is a first attempt at migrating _some_ of the web service documentation, and improving it.

It's not perfect, but we have to start somewhere. Some of the old documentation was project documentation talking more about what we were thinking of implementing, and very difficult to follow. There was a lot of duplication.

There is still a lot of duplication but it is significantly better than it was.

Other docs will be moved over in different chunks. I can only do so many of these are a time.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/491"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

