### PR TITLE
[docs] Upgrade H5P core and editor libraries to moodle-1.23

### DIFF
--- a/general/community/credits/thirdpartylibs.md
+++ b/general/community/credits/thirdpartylibs.md
@@ -256,7 +256,7 @@ Copyright © 2000 Herman Veluwenkamp (hermanV AT mindless DOT com)
 
 The general H5P library used to display H5P content.
 
-**Version**: moodle-1.22.4<br/>
+**Version**: moodle-1.23<br/>
 **License**: GPL-3.0
 
 Copyright © Joubel
@@ -271,7 +271,7 @@ Copyright © Joubel
 
 The general H5P library used to edit H5P content.
 
-**Version**: moodle-1.22.4<br/>
+**Version**: moodle-1.23<br/>
 **License**: GPL-3.0
 
 Copyright © Joubel


### PR DESCRIPTION
This PR should be merged once https://tracker.moodle.org/browse/MDL-76691 will be integrated (this is the issue to upgrade both H5P libraries, core and editor) :-)

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/495"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

