### PR TITLE
[docs] Update WS docs for MDL-76583

### DIFF
--- a/docs/apis/subsystems/external/functions.md
+++ b/docs/apis/subsystems/external/functions.md
@@ -28,14 +28,32 @@ For a component named `local_groupmanager` located in `local/groupmanager` which
 
 :::
 
+import { Since } from '@site/src/components';
+
 A service definition:
 
-- _must_ `require_once` the `lib/externallib.php` file
-- _must_ extend the `external_api` class
+- _must_ extend the `\core_external\external_api` class
 - _must_ declare an `execute_parameters` function to describe the expected parameters of the function
 - _must_ declare an `execute` function which is called with the functions and performs the expected actions
 - _must_ declare an `execute_returns` function to describe the values returned by the function
 - _may_ declare an `execute_is_deprecated` function to declare a function as deprecated
+
+<Since version="4.2" issueNumber="MDL-76583" />
+
+:::caution Writing plugins supporting Multiple Moodle versions
+
+The External API subsystem was restructured in Moodle 4.2 and moved from classes within a manually-required file, to autoloaded and namespaced classes.
+
+If you are developing a plugin whose codebase is used or tested in multiple Moodle versions, including older versions of Moodle, then you:
+
+- _must_ `require_once` the `lib/externallib.php` file
+- _must_ extend the `external_api` class instead of `\core_external\external_api`
+
+This will allow your plugin to continue working without deprecation notices or failures.
+
+Please note that deprecation notices will be added to this pathway from Moodle 4.6 onwards.
+
+:::
 
 ### An example definition
 
@@ -44,11 +62,12 @@ A service definition:
 
 namespace local_groupmanager\external;
 
-defined('MOODLE_INTERNAL') || die;
+use external_function_parameters;
+use external_multiple_structure;
+use external_single_structure;
+use external_value;
 
-require_once("{$CFG->libdir}/externallib.php");
-
-class create_groups extends external_api {
+class create_groups extends \core_external\external_api {
     public static function execute_parameters(): external_function_parameters {
         return new external_function_parameters([
             'groups' => new external_multiple_structure(

--- a/docs/apis/subsystems/external/security.md
+++ b/docs/apis/subsystems/external/security.md
@@ -19,7 +19,7 @@ Before working with any data provided by a user you **must** validate the parame
 
 To do so you should call the `validate_parameters()` function, passing in the reference to your `execute_parameters()` function, and the complete list of parameters for the function. The function will return the validated and cleaned parameters.
 
-The `validate_parameters()` function is defined on the `external_api` class, and can be called as follows:
+The `validate_parameters()` function is defined on the `\core_external\external_api` class, and can be called as follows:
 
 ```php title="local/groupmanager/classes/external/create_groups.php"
 public static function execute(array $groups): array {
@@ -42,7 +42,7 @@ For example, if you are working with data belonging to a specific activity, you 
 
 If your function operates on multiple contexts (like a list of courses), you must validate each context right before generating any response data related to that context.
 
-The `validate_context()` function is defined on the `external_api` class, and can be called as follows:
+The `validate_context()` function is defined on the `\core_external\external_api` class, and can be called as follows:
 
 ```php title="local/groupmanager/classes/external/create_groups.php"
 public static function execute(array $groups): array {

--- a/docs/apis/subsystems/external/testing.md
+++ b/docs/apis/subsystems/external/testing.md
@@ -83,7 +83,7 @@ class get_fruit_test extends externallib_advanced_testcase {
 
         // We need to execute the return values cleaning process to simulate
         // the web service server.
-        $returnvalue = external_api::clean_returnvalue(
+        $returnvalue = \core_external\external_api::clean_returnvalue(
             get_fruit::execute_returns(),
             $returnvalue
         );

--- a/docs/devupdate.md
+++ b/docs/devupdate.md
@@ -1,0 +1,49 @@
+---
+title: Moodle 4.2 developer update
+tags:
+- Core development
+---
+
+This page highlights the important changes that are coming in Moodle 4.2 for developers.
+
+## External API
+
+The `external_api` class, and all related classes have been moved from `lib/externallib.php` to namespaced classes within the [`core_external` subsystem](./apis/subsystems/external/index.md).
+
+:::note Delayed deprecation
+
+The old class locations have been aliased for backwards compatibility and will emit a deprecation notice in a _future_ release.
+
+If you are writing a Moodle plugin which has a single codebase shared with older versions of Moodle, you should continue to use the old API locations at this time.
+
+:::
+
+The following parts of the external API have been moved to the `core_external` subsystem.
+
+### Renamed External API classes
+
+| Old class name                 | New class name                               |
+| ---                            | ---                                          |
+| `external_api`                 | `core_external\external_api`                 |
+| `external_description`         | `core_external\external_description`         |
+| `external_files`               | `core_external\files`                        |
+| `external_format_value`        | `core_external\external_format_value`        |
+| `external_function_parameters` | `core_external\external_function_parameters` |
+| `external_multiple_structure`  | `core_external\external_multiple_structure`  |
+| `external_settings`            | `core_external\external_settings`            |
+| `external_single_structure`    | `core_external\external_single_structure`    |
+| `external_util`                | `core_external\util`                         |
+| `external_value`               | `core_external\external_value`               |
+| `external_warnings`            | `core_external\external_warnings`            |
+| `restricted_context_exception` | `core_external\restricted_context_exception` |
+
+### Renamed External API functions
+
+| Old function name                            | New function name                                       |
+| ---                                          | ---                                                     |
+| `external_format_string()`                   | `core_external\util::format_string()`                   |
+| `external_format_text()`                     | `core_external\util::format_text()`                     |
+| `external_create_service_token()`            | `core_external\util::generate_token()`                  |
+| `external_generate_token()`                  | `core_external\util::generate_token()`                  |
+| `external_generate_token_for_current_user()` | `core_external\util::generate_token_for_current_user()` |
+| `external_log_token_request()`               | `core_external\util::log_token_request()`               |

--- a/general/development/policies/component-communication/index.md
+++ b/general/development/policies/component-communication/index.md
@@ -82,11 +82,23 @@ External functions are functions defined in Moodle using the External API. These
 
 Calling external functions from another component in Moodle is no different to calling the php functions directly. This is allowed and encouraged.
 
-One thing to think about when calling external functions from php though is that they are designed to be able to be called from a webservice, and so they will re-do all of the security checks and setup of the page theme and language that you have probably already done in your php page. To make sure this doesn't cause side-effects (like changing the theme halfway through a page), always use the wrapper in `external_api::call_external_function()` instead of calling the external function directly.
+One thing to think about when calling external functions from php though is that they are designed to be able to be called from a webservice, and so they will re-do all of the security checks and setup of the page theme and language that you have probably already done in your php page. To make sure this doesn't cause side-effects (like changing the theme halfway through a page), always use the wrapper in `\core_external\external_api::call_external_function()` instead of calling the external function directly.
 
 Additional rules for calling external functions:
 
-- Always use the `external_api::call_external_function()` wrapper when calling from php.
+- Always use the `\core_external\external_api::call_external_function()` wrapper when calling from php.
+
+import { Since } from '@site/src/components';
+
+:::note
+
+<Since version="4.2" issueNumber="MDL-76583" />
+
+The `external_api` class was renamed in Moodle 4.2 and can now be found under `\core_external\external_api`.
+
+Please note that if you are writing a non-core plugin which is available in older versions of Moodle, then you should continue to use the `external_api` class which will be maintained for backwards compatibility until Moodle 4.6
+
+:::
 
 ### JavaScript Modules (AMD)
 
@@ -194,7 +206,7 @@ The component API defines all the things this plugin can do. Every function in t
 
 ### External API
 
-The external API is a single class that wraps each function in the Component API. By exposing all the functions in the Component API we allow people to build new interfaces and apps that we have never even thought about without requiring changes to our plugin. Covering each external function with a unit test ensures that all our parameters and return types are correctly specified. Note: External API functions can be called directly from other dependant plugins or sub-plugins in Moodle - but you must use the external_api::call_external_function to do so or you will introduce problems with theme, language and context.
+The external API is a single class that wraps each function in the Component API. By exposing all the functions in the Component API we allow people to build new interfaces and apps that we have never even thought about without requiring changes to our plugin. Covering each external function with a unit test ensures that all our parameters and return types are correctly specified. Note: External API functions can be called directly from other dependant plugins or sub-plugins in Moodle - but you must use the `\core_external\external_api::call_external_function` to do so or you will introduce problems with theme, language and context.
 
 ### Webservice API
 

--- a/sidebars/docs.js
+++ b/sidebars/docs.js
@@ -50,13 +50,11 @@ const sidebars = {
             },
         },
 
-        /*
         {
             label: 'Developer update',
             type: 'doc',
             id: 'devupdate',
         },
-*/
 
         {
             label: 'Moodle App',


### PR DESCRIPTION
- Document the move of `external_api` and friends to the `core_external` subsystem
- Note that pluginland plugins do not need to perform the migration at this time if they do not wish to
- Add a new devupdate page summarising breaking changes in Moodle 4.2

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/506"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

