### PR TITLE
PHP 8.0 is now required for Moodle 4.2

### DIFF
--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -53,7 +53,7 @@ You must be logged in to tracker to see issues in Epics.
 
 <Since versions={["3.11.8", "4.0.2"]} issueNumber="MDL-70745" />
 
-PHP 8.0 **can be used with** Moodle 3.11.8, Moodle 4.0.2 and later releases. See [MDL-70745](https://tracker.moodle.org/browse/MDL-70745) for details.
+PHP 8.0 **can be used with** Moodle 3.11.8, Moodle 4.0.2 and later releases. It is also the **minimum** supported version for Moodle 4.2. See [MDL-70745](https://tracker.moodle.org/browse/MDL-70745) for details.
 
 ### PHP 7.4
 


### PR DESCRIPTION
Just add that bit of information now that it has been agreed:

https://tracker.moodle.org/browse/MDL-74905

(Moodle 4.2 requirements issue)

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/530"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

