### PR TITLE
Fix minor, but clutch errors in writing-a-service.md

### DIFF
--- a/docs/apis/subsystems/external/writing-a-service.md
+++ b/docs/apis/subsystems/external/writing-a-service.md
@@ -71,7 +71,7 @@ $functions = [
     // The name of your web service function, as discussed above.
     'local_groupmanager_create_groups' => [
         // The name of the namespaced class that the function is located in.
-        'classname'   => 'local_groupmanager\create_groups',
+        'classname'   => 'local_groupmanager\external\create_groups',
 
         // A brief, human-readable, description of the web service function.
         'description' => 'Creates new groups.',
@@ -137,9 +137,9 @@ Thus for the web service function `local_groupmanager_create_groups()`, we shoul
 
 This will be located in the file `local/groupmanager/classes/external/create_groups.php`. The class will contain:
 
-- `execute_groups(...)`
-- `execute_groups_parameters()`
-- `execute_groups_return()`
+- `execute(...)`
+- `execute_parameters()`
+- `execute_return()`
 
 ### Defining parameters
 


### PR DESCRIPTION
While trying to refactor a webservice which still depended on the old externallib approach I had some issues, because the docs have some errors - at least I think they are, because I could not get my webservice to work until I figured out what might be the issue by trial and error, so please review carefully.

While creating this PR I also realized that one error already had been fixed 20 days ago in the git repository. Unfortunately the moodledev.io website still shows the error.

https://github.com/moodle/devdocs/blob/38785ebc001af53def9bb6a52b17e8cf7954e90b/docs/apis/subsystems/external/writing-a-service.md?plain=1#L358

vs.

![grafik](https://user-images.githubusercontent.com/65113153/214692284-62f9832d-0e3b-4d8e-97e9-1bf970499ddb.png)

It would be nice, if this could be fixed soon, so noone else is losing some time stumbling over it.

Thank you very much for this really awesome documentation! Really fun to work with :-)

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/531"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

