### PR TITLE
Declare php81 supported

### DIFF
--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -20,7 +20,7 @@ New PHP versions are [released every year](https://www.php.net/supported-version
 We always follow this agreed policy regarding PHP and Moodle supported versions:
 
 1. A LTS will always **require the previous LTS** (or later) for upgrading.
-2. The **maximum PHP version** supported for a branch will be the max one achieved along the life of the branch. Usually with .0 releases but may happen later (we added support for php74 with 3.8.3, or support for php80 with 3.11.8, for example).
+2. The **maximum PHP version** supported for a branch will be the max one achieved along the life of the branch. Usually with .0 releases but may happen later (we added support for php80 with 3.11.8, or support for php81 with 4.1.2, for example).
 3. The **minimum PHP** version supported for a branch will be **the lower of**:
     - The [minimum version supported in any way by php](https://www.php.net/supported-versions.php) the day of the Moodle release (so we provide slow, progressive increments).
     - The maximum PHP version supported by the previous LTS branch (so we guarantee jumping between LTS is possible without upgrading PHP at the same time).
@@ -31,7 +31,7 @@ We always follow this agreed policy regarding PHP and Moodle supported versions:
 {panel:title=Policy: PHP & Moodle supported versions|borderStyle=dashed|borderColor=#cccccc|titleBGColor=#f7d6c1|bgColor=#ffffce}
 Since Moodle 3.5 (MDL-59159), these rules apply to decide Minimum PHP and Moodle versions supported:
  # A LTS will always require the previous LTS (or later) for upgrading.
- # The maximum PHP version supported for a branch will be the max one achieved along the life of the branch. Usually with .0 releases but may happen later (we added support for php70 with 3.0.1, or support for php73 with 3.6.4, for example).
+ # The maximum PHP version supported for a branch will be the max one achieved along the life of the branch. Usually with .0 releases but may happen later (we added support for php80 with 3.11.8, or support for php81 with 4.1.2, for example).
  # The minimum PHP version supported for a branch will be *the lower of*:
  -- The [minimum version supported in any way by php|http://php.net/supported-versions.php] the day of the Moodle release (so we provide slow, progressive increments).
  -- The maximum PHP version supported by the previous LTS branch (so we guarantee jumping between LTS is possible without upgrading PHP at the same time).{panel}
@@ -48,6 +48,12 @@ You must be logged in to tracker to see issues in Epics.
 :::
 
 ## PHP supported versions
+
+### PHP 8.1
+
+<Since versions={["4.1.2", "4.2"]} issueNumber="MDL-73016" />
+
+PHP 8.1 **can be used with** Moodle 4.1.2, Moodle 4.2 and later releases. See [MDL-73016](https://tracker.moodle.org/browse/MDL-73016) for details.
 
 ### PHP 8.0
 
@@ -86,10 +92,6 @@ PHP 7.1 **can be used with** Moodle 3.2 and later releases. It is also the **min
 PHP 7.0 **can be used with** Moodle 3.0.1, Moodle 3.1 and later releases. It is also the **minimum** supported version for Moodle 3.4. See [Moodle and PHP 7.0 details](https://docs.moodle.org/dev/Moodle_and_PHP_7.0_details) and [MDL-50565](https://tracker.moodle.org/browse/MDL-50565) for details.
 
 ## PHP versions under development
-
-### PHP 8.1
-
-PHP 8.1 support **is being implemented** for Moodle 4.1 and later releases. Hence it's still **incomplete and only for development purposes**.  See [MDL-73016](https://tracker.moodle.org/browse/MDL-73016) for details.
 
 ### PHP 8.2
 

--- a/general/releases/4.1.md
+++ b/general/releases/4.1.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 3.9 or later.
-- PHP version: minimum PHP 7.4.0 *Note: minimum PHP version has increased since Moodle 4.0*. PHP 8.0.x is supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 7.4.0 *Note: minimum PHP version has increased since Moodle 4.0*. PHP 8.0.x and 8.1.x are supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is recommended. It will be required in Moodle 4.2. For further details, see [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP extension **exif** is recommended.
 - PHP setting **max_input_vars** is recommended to be >= 5000 for PHP 7.x installations. It's a requirement for PHP 8.x installations. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).


### PR DESCRIPTION
- Do it in PHP policy page: By MDL-73016, since 4.1.2
- Update 4.1 release notes.
- Also updated a few old examples to actual ones.

(requires [MDL-73016](https://tracker.moodle.org/browse/MDL-73016) to be closed and rolled)

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/566"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

