### PR TITLE
Add Font Awesome 6 to devupdate (blocked by MDL-76989)

### DIFF
--- a/docs/devupdate.md
+++ b/docs/devupdate.md
@@ -108,3 +108,27 @@ class quiz_archive_report extends quiz_archive_parent_class_alias {
 ```
 
 </CodeExample>
+
+## Font Awesome 6
+
+The Font Awesome third-party library has been upgraded from 4.7 to 6.3.0 in MDL-76989. The syntax has slightly changed. The free version included in Moodle only supports the solid and regular styles:
+
+```css title="Version 4's syntax"
+<i class="fa fa-star"></i>
+<i class="fa fa-star-o"></i>
+```
+
+```css title="Version 6's syntax"
+<i class="fa-regular fa-star"></i>
+<i class="fa-solid fa-star"></i>
+```
+
+Font Awesome 6 is backwards compatible (because a shim has been included too), so the old syntax still works.
+
+In the SCSS/CSS files some changes needs to be done to display the icons properly:
+
+- The attribute `content: $fa-var-xxx` needs to be converted to `content: fa-content($fa-var-xxx)`
+- The regular style is used by default. When the solid styled icon needs to be used, the following must be added: `@extend .fa-solid`. There are other ways to achieve the same. More information can be found in [this page](https://fontawesome.com/v6/docs/web/use-with/scss#a-more-manual-custom-css-approach).
+- `@include fa-icons()` is not required anymore (when it's used, the icons are not displayed properly).
+
+More information about the changes between 4 and 6, including any icons which have been renamed, can be found in https://fontawesome.com/docs/web/setup/upgrade/upgrade-from-v4


### PR DESCRIPTION
A reference to the devupdate page for Moodle 4.2 should be added to mention Font Awesome has been upgraded from 4.7 to 6.3.0 in [MDL-76989](https://tracker.moodle.org/browse/MDL-76989).

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/569"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

