### PR TITLE
WIP/WIP/WIP: Try with new re-generated crawl/index

### DIFF
--- a/config/algolia.js
+++ b/config/algolia.js
@@ -22,7 +22,7 @@ module.exports = {
     // Public API key: it is safe to commit it
     apiKey: '11b0ce30d623418a6279455023c0faf8',
 
-    indexName: 'moodle',
+    indexName: 'moodle2',
 
     // Optional: see doc section below.
     // Contextual search is enabled by default.


### PR DESCRIPTION
WIP/WIP/WIP!

It seems to return way more accurate results than the current one that is really suboptimal.

Sure that more improvements can be done later (robots.txt, better tags handling...). But with this, at very least, the results in general are better.

OT, I've been unable to find from where the Public API key being currently used comes. It doesn't match any search api key in our account.

WIP/WIP/WIP

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/583"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

