### PR TITLE
[docs] Academy developer pathway link

### DIFF
--- a/general/community/contribute.md
+++ b/general/community/contribute.md
@@ -10,7 +10,7 @@ sidebar_position: 3
 If you want to contribute to Moodle, you can start looking at the following:
 
 - **Found a bug?** [Report an issue](../development/tracker.md#reporting-an-issue) in our bug tracker.
-- **Want to learn and extend your Moodle development skills**? Sign up to free self-paced courses in our [Moodle Academy Developer Learning Pathway](https://learn.moodle.org/).
+- **Want to learn and extend your Moodle development skills**? Sign up to free self-paced courses in our [Moodle Academy Developer Learning Pathway](https://moodle.academy/course/index.php?categoryid=4).
 - **Ready to help coding**? Check the [getting started](../development/gettingstarted.md) page.
 - **Share your plugins** in the [Plugins directory](https://moodle.org/plugins).
 - **Adopt an existing plugin**. Look at the [list of plugins seeking a new maintainer](https://moodle.org/plugins/browse.php?list=set&id=61) and read the [Plugins adoption programme](https://moodle.org/mod/forum/discuss.php?d=260354).


### PR DESCRIPTION
Change the Moodle academy developer pathway link

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/598"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

