### PR TITLE
Lower case the @javascript tags

### DIFF
--- a/general/development/tools/behat/browsers/index.md
+++ b/general/development/tools/behat/browsers/index.md
@@ -70,7 +70,7 @@ Not all the drivers can execute all of Moodle's step definitions; we tagged the 
 Note that, to skip some tag, you must prepend it with the <tt>~</tt> (logical NOT) character. Examples:
 
 - Run all tests but `@_alert</tt> ones: <tt>--tags '~@_alert'`
-- Run all chrome tests but `@skip_chrome_zerosize` ones: `--tags '@JavaScript&&~@skip_chrome_zerosize'`
+- Run all chrome tests but `@skip_chrome_zerosize` ones: `--tags '@javascript&&~@skip_chrome_zerosize'`
 
 ## Working combinations of OS+Browser+selenium
 

--- a/general/development/tools/behat/running.md
+++ b/general/development/tools/behat/running.md
@@ -420,7 +420,7 @@ Running parallel (headless) runs on different selenium servers avoid random focu
 
 With the `--tags` or the `-name` Behat options you can filter which tests are going to run or which ones are going to be skipped. There are a few tags that you might be interested in:
 
-- `@JavaScript`: All the tests that runs in a browser using JavaScript; they require Selenium or the browser's own automation layer, as per [Run tests without Selenium](./running.md#run-tests-without-selenium-chromedriver-geckodriver) to be running, otherwise an exception will be thrown.
+- `@javascript`: All the tests that runs in a browser using JavaScript; they require Selenium or the browser's own automation layer, as per [Run tests without Selenium](./running.md#run-tests-without-selenium-chromedriver-geckodriver) to be running, otherwise an exception will be thrown.
 - `@_file_upload`: All the tests that involves file uploading or any OS feature that is not 100% part of the browser. They should only be executed when Selenium is running in the same machine where the tests are running.
 - `@_alert`: All the tests that involves JavaScript dialogs (alerts, confirms...) are using a feature that is OS-dependant and out of the browser scope, so they should be tag appropriately as not all browsers manage them properly.
 - `@_switch_window`: All the tests that are using the `I switch to "NAME" window` step should be tagged as not all browsers manage them properly.
@@ -586,7 +586,7 @@ If you would prefer not to use the `moodle-browser-config` tool but still wish t
 $CFG->behat_profiles = [
         'chrome' => [
             'browser' => 'chrome',
-            'tags' => '@JavaScript',
+            'tags' => '@javascript',
         ],
 ];
 ```

--- a/general/development/tools/behat/writing.md
+++ b/general/development/tools/behat/writing.md
@@ -59,7 +59,7 @@ Feature: Here comes a description of your user story.
 ```
 
 The tags on top of the feature description can be used to select specific test cases when running the tests.
-The '@JavaScript' tag should only be used, if JavaScript is needed to execute your test. This is dependent on the step you will use in your definition.
+The `@javascript` tag should only be used, if JavaScript is needed to execute your test. This is dependent on the step you will use in your definition.
 JavaScript tests are usually much slower than tests executed without JavaScript.
 
 Afterwards you can specify a scenario:


### PR DESCRIPTION
Found them when looking for some info. Surely cause by some bulk search and replace (I imagine).

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/610"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

