### PR TITLE
changes to index page info for next meeting and change to the agenda

### DIFF
--- a/general/community/meetings/202305.md
+++ b/general/community/meetings/202305.md
@@ -16,4 +16,4 @@ Meeting recording TBA
 ### Agenda
 
 1. Quiz and Question bank 4.x by Tim Hunt and team
-2. Moodle HQ update: UX and tracker - who does it work? (TBC)
+2. Moodle HQ update (speaker TBC)

--- a/general/community/meetings/index.md
+++ b/general/community/meetings/index.md
@@ -12,7 +12,7 @@ sidebar_label: Meetings
 Developer meetings are open to anyone interested in Moodle development.
 
 :::important
-Our next Developer meeting is on 28 March 2023 at 08:00UTC.
+Our next Developer meeting is on 23 May 2023 at 08:00UTC.
 
 If there are any topics that you would like to present or discuss at a developer meeting, please contact [Aurelie Soulier](https://moodle.org/user/profile.php?id=5177207).
 


### PR DESCRIPTION
changes to index page info for next meeting and change to the agenda

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/613"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

