### PR TITLE
Update for 4.0 LMS accessibility accreditation

### DIFF
--- a/general/development/policies/accessibility.md
+++ b/general/development/policies/accessibility.md
@@ -26,14 +26,14 @@ Accreditations expire after one year, but this does not mean that the accreditat
 |---------|-------------------------------------------|----------------------------------------------------------|
 | v3.10   | 10 November 2020                          | [MDL-67688](https://tracker.moodle.org/browse/MDL-67688) |
 | v3.11   | 8 November 2021                           | [MDL-72657](https://tracker.moodle.org/browse/MDL-72657) |
-| v4.0    | _In progress_                             | [MDL-74624](https://tracker.moodle.org/browse/MDL-74624) |
-| v4.1    | _Pending_                                 |                                                          |
+| v4.0    | 3 May 2023                                | [MDL-74624](https://tracker.moodle.org/browse/MDL-74624) |
+| v4.1, v4.2 | _Pending_                              | [MDL-78185](https://tracker.moodle.org/browse/MDL-78185) |
 
 **[Moodle App](https://www.webkeyit.com/accessibility-services/accessibility-accreditations/moodle-mobile-app)**
 
 - WCAG 2.1 Level AA accreditation issued on 30 June 2021
 
-An overview of Moodle's conformance with the [WCAG 2.1](https://www.w3.org/TR/WCAG21/) guidelines can be found in our [accessibility conformance report](https://docs.moodle.org/311/en/VPAT#Moodle%20accessibility%20conformance%20report).
+An overview of Moodle's conformance with the [WCAG 2.1](https://www.w3.org/TR/WCAG21/) guidelines can be found in our [accessibility conformance report](https://docs.moodle.org/en/VPAT#Moodle%20accessibility%20conformance%20report).
 
 :::
 


### PR DESCRIPTION
- Updated the table to reflect that 4.0 has finally been given the WCAG 2.1 Level AA accreditation since 3 May 2023.
- Updated the section for 4.2 and 4.1 accreditation with the epic issue. Note that the next audit will be done for Moodle 4.2 which will also cover key new features and improvements from 4.1. That's why they are being grouped together.
- Remove the version from the VPAT URL so it will point to the latest VPAT for the latest accredited Moodle version.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/620"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

