### PR TITLE
[docs] Fix links to TinyMCE documentation

### DIFF
--- a/docs/apis/plugintypes/tiny/index.md
+++ b/docs/apis/plugintypes/tiny/index.md
@@ -289,8 +289,8 @@ Most plugins will make use of one or more of the following commands, but others 
 - [addIcon](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.editor.ui.registry/#addIcon)
 - [addButton](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.editor.ui.registry/#addButton)
 - [addToggleButton](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.editor.ui.registry/#addToggleButton)
-- [addMenuItem](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.editor.ui.registry/#addmenuItem)
-- [addToggleMenuItem](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.editor.ui.registry/#addmenuItem)
+- [addMenuItem](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.editor.ui.registry/#addMenuItem)
+- [addToggleMenuItem](https://www.tiny.cloud/docs/tinymce/6/apis/tinymce.editor.ui.registry/#addToggleMenuItem)
 
 Plugins may use any parts of the TinyMCE API that they need.
 


### PR DESCRIPTION
A minor change to fix anchors in links to TinyMCE documentation.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/645"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

