### PR TITLE
Activity language pack filename

### DIFF
--- a/docs/apis/plugintypes/mod/index.mdx
+++ b/docs/apis/plugintypes/mod/index.mdx
@@ -235,7 +235,7 @@ also _required_:
   pluginname="[modname]"
 />
 
-### `/lang/en/mod_[modname].php` - Language string definitions
+### `/lang/en/[modname].php` - Language string definitions
 
 <Lang
   plugintype="mod"


### PR DESCRIPTION
Activity language packs are named lang/XX/[modname].php (not mod_[modname].php).

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/648"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

