### PR TITLE
[docs] Add developer_notes tracker label

### DIFF
--- a/general/development/tracker/labels.md
+++ b/general/development/tracker/labels.md
@@ -90,6 +90,9 @@ Used to identify all issues to be listed in the release notes (minor or major).
 - [`upgrade_notes`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20upgrade_notes)<br/>
 Issues that need to be mentioned in the user documentation [under 'Possible issues that may affect you in Moodle X.0' (major versions).
 
+- [`developer_notes`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20developer_notes)<br/>
+Issues that need to be mentioned in the [integration exposed forum](https://moodle.org/mod/forum/view.php?f=1153) and in the [Moodle developer update documentation](../../../docs/devupdate).
+
 - `lost_functionality`<br/>
 Used to identify issues describing functionality which was available in an earlier version but which is no longer available in the latest version.
 


### PR DESCRIPTION
Document the new **developer_notes** label

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/651"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

