### PR TITLE
Fix the test file path

### DIFF
--- a/general/development/tools/phpunit.md
+++ b/general/development/tools/phpunit.md
@@ -187,7 +187,7 @@ vendor/bin/phpunit my/tests/filename.php
 so, run this command in the CLI to see a real test in action:
 
 ```bash
-vendor/bin/phpunit cohort/tests/cohortlib_test.php
+vendor/bin/phpunit cohort/tests/lib_test.php
 ```
 
 You can also run a single test method inside a class:


### PR DESCRIPTION
Use an example that actually works in recent Moodle versions.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/653"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

