### PR TITLE
[docs] security: update security measure of logging

### DIFF
--- a/general/development/policies/security/index.md
+++ b/general/development/policies/security/index.md
@@ -199,7 +199,7 @@ We recommend that you follow the [Output functions](/docs/apis/subsystems/output
 
 ### Log every request
 
-- Every script should call `add_to_log`.
+- Every script should log an [event](https://docs.moodle.org/dev/Events_API)
 
 ### Other good practice
 


### PR DESCRIPTION
Since `add_to_log()` was [deprecated](https://github.com/moodle/moodle/blob/MOODLE_402_STABLE/lib/deprecatedlib.php#L38), I changed the sentence to refer to the Events API.



<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/657"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

