### PR TITLE
[docs] Update devupdate redirect

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1253,7 +1253,7 @@ Moodle_4.0.2_release_notes:
   slug: "/general/releases/4.0/4.0.2"
 Moodle_4.0_developer_update:
 - filePath: "/docs/devupdate.md"
-  slug: "/docs/devupdate"
+  slug: "/docs/4.1/devupdate"
 Moodle_4.0_release_notes:
 - filePath: "/general/releases/4.0.md"
   slug: "/general/releases/4.0"


### PR DESCRIPTION
Jake points out that the 4.0 developer update docs on the legacy docs points to the 4.2 devupdate notes.

This change fixes that now that we've branched the docs.

Note: We did not start to branch the docs until 4.1 so the 4.0 devupdate notes are listed under 4.1 sadly. 

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/658"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

