### PR TITLE
[Docs] navigation: Add hint on version for adding node to primary navigation

### DIFF
--- a/docs/apis/core/navigation/index.md
+++ b/docs/apis/core/navigation/index.md
@@ -379,7 +379,7 @@ navigation_node::override_active_url(
 
 ### **Q.** How do I add a node to the "flat" navigation in the Boost theme?
 
-After creating a node and adding it to the navigation tree - you can set the property `showinflatnavigation` to true in order for this node to be displayed in the flat navigation.
+Adding a node to the "flat" navigation is only possible for Moodle versions before 4.0. After creating a node and adding it to the navigation tree - you can set the property `showinflatnavigation` to true in order for this node to be displayed in the flat navigation.
 
 ```php
 $node = navigation_node::create(...);


### PR DESCRIPTION
According to [](https://moodle.academy/mod/book/view.php?id=851&chapterid=697) and by trying the code myself I found that adding an item to the flat/primary navigation in the described way is only possible in Moodle versions < 4.0.