### PR TITLE
Document the use of @var also for class constants

### DIFF
--- a/general/development/policies/codingstyle/index.md
+++ b/general/development/policies/codingstyle/index.md
@@ -1609,7 +1609,7 @@ The description portion is optional, it can be left out if the function is simpl
 
 ##### `@var`
 
-The `@var` tag is used to document class properties.
+The `@var` tag is used to document both class properties and constants, don't use `@const` for the later.
 
 <ValidExample>
 


### PR DESCRIPTION
The use of `@const` is incorrect and we have to explicitly say it.

Following both the phpDocumentor guidelines and the phpdoc-tags draft proposal, `@var` should be used for both class properties and constants (and other things that are out from the scope of this change).

This is part of https://tracker.moodle.org/browse/MDL-77599