### PR TITLE
[Docs] Update assignment submit capability name

### DIFF
--- a/docs/apis/subsystems/enrol.md
+++ b/docs/apis/subsystems/enrol.md
@@ -99,7 +99,7 @@ function get_enrolled_users(
 Get all users who are able to submit an assignment:
 
 ```php
-$submissioncandidates = get_enrolled_users($modcontext, 'mod/assignment:submit');
+$submissioncandidates = get_enrolled_users($modcontext, 'mod/assign:submit');
 ```
 
   </div>


### PR DESCRIPTION
The mod/assignment:submit was replaced by mod/assign:submit.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/695"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

