### PR TITLE
[docs] Fix the developers meeting link for August

### DIFF
--- a/general/community/meetings/202308.md
+++ b/general/community/meetings/202308.md
@@ -7,9 +7,9 @@ tags:
 
 ### Details
 
-Date and time: 15 August 2023 at 07:00 UTC ([Check this time in your location](https://www.timeanddate.com/worldclock/fixedtime.html?msg=Moodle+Developer+meeting+-+August+2023&iso=20230815T07&p1=1440&ah=1)).
+15 August 2023 at 07:00 UTC.
 
-[Meeting recording TBA](https://recordings.rna1.blindsidenetworks.com/moodlehq/e9b35f3e7056aa2378e3076420f2f69ba6e0cd9e-1692082373539/capture/)]
+[Meeting recording](https://moodle.org/mod/bigbluebuttonbn/bbb_view.php?action=play&bn=1&rid=25&rtype=video)
 
 ### Agenda
 


### PR DESCRIPTION
The current link is not following the expected format so it's failing if the user is not logged in. I've replaced it to make it consistent with previous meetings.