### PR TITLE
[docs] - plugin checklist approval blockers

### DIFF
--- a/general/community/plugincontribution/checklist.md
+++ b/general/community/plugincontribution/checklist.md
@@ -199,6 +199,8 @@ Examples of issues that will prevent your plugin from being approved:
 
 1. There is no public and transparent issue tracker where the community members can leave feedback, report bugs and suggest improvements.
 1. Your SQL fails to work on PostgreSQL even when working on MySQL.
+1. [Namespace collisions](../../development/policies/codingstyle/frankenstyle.md).
+1. Compliance with [security guidelines](../../development/policies/security/index.md).
 1. It integrates with an external system and does not have the privacy API correctly implemented.
 1. It is an activity module and does not have the backup and restore API implemented.
 


### PR DESCRIPTION
adds some common approval blockers to the checklist - in particular the security guidelines and significant namespace collisions are typical blockers.

@mudrd8mz good to have a +1 from you (or a -1) :-)

first dev docs PR so let me know if I've got something wrong...

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/709"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

