### PR TITLE
Update xmldb.md

### DIFF
--- a/general/development/tools/xmldb.md
+++ b/general/development/tools/xmldb.md
@@ -75,20 +75,20 @@ Choose the 'View PHP Code' option and then copy and paste the generated code.
 Apart from the [Database Structures guidelines](https://docs.moodle.org/dev/Database), some more conventions should be followed:
 
 1. About names:
-2. All lowercase names (tables, indexes, keys and fields).
-3. Table names and field names must use only a-z, 0-9 and _ chars. Max 28 characters.
-4. Key and index names under the XMLDB Files must be formed by concatenating the name of the fields present in the key/index with the '"-" (minus) character.
-5. Primary key always must be named "primary" (this is one exception to the previous convention).
-6. It's highly recommended to avoid [reserved words](https://docs.moodle.org/dev/XMLDB_reserved_words) completely. We know we have some of them now but they should be completely out for next releases.
-7. About NULLS
-8. Avoid to create all the fields as NOT NULL with the *silly* default value `*` (empty string). The underlying code used to create tables will handle it properly but the XMLDB structure must be REAL. Read more in the [Problems Page](https://docs.moodle.org/dev/XMLDB_Problems#NOT_NULL_fields_using_a_DEFAULT_*_clause).
-9. About FOREIGN KEYS
-10. Under the tables of every XMLDB file, you must define the existing **Foreign Keys** (FK) properly. This will allow everybody to know a bit better the structure, allow to evolve to a better constrained system in the future and will provide the underlying code with the needed info to create the proper indexes.
-11. Note that, if you define any field combination as FK you won't have to create any index on that fields, the code will do it automatically!
-12. Respect Convention 1.3
-13. About UNIQUE KEYS
-14. Declare any fields as UNIQUE KEY (UK) only if they are going to be used as target for one FK. Create unique indexes instead.
-15. Respect Convention 1.3
+    1. All lowercase names (tables, indexes, keys and fields).
+    1. Table names and field names must use only a-z, 0-9 and _ chars. Max 28 characters.
+    1. Key and index names under the XMLDB Files must be formed by concatenating the name of the fields present in the key/index with the '"-" (minus) character.
+    1. Primary key always must be named "primary" (this is one exception to the previous convention).
+    1. It's highly recommended to avoid [reserved words](https://docs.moodle.org/dev/XMLDB_reserved_words) completely. We know we have some of them now but they should be completely out for next releases.
+1. About NULLS
+    1. Avoid to create all the fields as NOT NULL with the *silly* default value `*` (empty string). The underlying code used to create tables will handle it properly but the XMLDB structure must be REAL. Read more in the [Problems Page](https://docs.moodle.org/dev/XMLDB_Problems#NOT_NULL_fields_using_a_DEFAULT_*_clause).
+1. About FOREIGN KEYS
+    1. Under the tables of every XMLDB file, you must define the existing **Foreign Keys** (FK) properly. This will allow everybody to know a bit better the structure, allow to evolve to a better constrained system in the future and will provide the underlying code with the needed info to create the proper indexes.
+    1. Note that, if you define any field combination as FK you won't have to create any index on that fields, the code will do it automatically!
+    1. Respect Convention 1.3
+1. About UNIQUE KEYS
+    1. Declare any fields as UNIQUE KEY (UK) only if they are going to be used as target for one FK. Create unique indexes instead.
+    1. Respect Convention 1.3
 
 ## See also
 


### PR DESCRIPTION
Ordering of the Conventions List as in https://docs.moodle.org/dev/XMLDB_defining_an_XML_structure. Note that the Github Markdown preview does not do accurately preview ordered lists second level numbers like they should appear see https://youtu.be/iBA-j6XaHNc?si=w1mE3--keCxcnxZR&t=333 I hope docusaurus then gets it right.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/710"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

