### PR TITLE
[docs] templates: Clarify availability of globals object

### DIFF
--- a/docs/guides/templates/index.md
+++ b/docs/guides/templates/index.md
@@ -645,6 +645,7 @@ In PHP you have access to the `$CFG` object to allow access to properties. Musta
 ```
 
 The properties available on the `globals.config` object are the same as normally exposed for JavaScript; these are gathered from `get_config_for_javascript()` function in `lib/outputrequirementslib.php`.
+This object is only available when using client-side Mustache rendering in JavaScript; it is not added to templates rendered with the PHP Mustache engine.
 
 ## Core templates
 


### PR DESCRIPTION
Add a line to clarify that the `globals` object is only added to template context when one uses the JS Mustache engine -- it is not available for templates using the PHP mustache engine.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/719"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

