### PR TITLE
Expanded DB identifier sizes (tables and columns - MDL-76459)

### DIFF
--- a/docs/apis/plugintypes/assign/feedback.md
+++ b/docs/apis/plugintypes/assign/feedback.md
@@ -30,10 +30,11 @@ Assignment Feedback plugins are located in the `/mod/assign/feedback` directory.
 
 :::important Plugin naming
 
-The plugin name should be no longer than 13 characters - this is because the database tables for a submission plugin must be prefixed with `assignfeedback_[pluginname]` (15 chars + X) and the table names can be no longer than 28 chars due to a limitation with Oracle.
+The plugin name should be no longer than 38 (13 before Moodle 4.3) characters - this is because the database tables for a submission plugin must be prefixed with `assignfeedback_[pluginname]` (15 chars + X) and the table names can be no longer than 53 (28 before Moodle 4.3) chars due to a limitation with PostgreSQL.
 
-If a plugin requires multiple database tables, the plugin name will need to be shorter to allow different table names to fit under the 28 character limit.
+If a plugin requires multiple database tables, the plugin name will need to be shorter to allow different table names to fit under the 53 character limit (28 before Moodle 4.3).
 
+Note: If your plugin is intended to work with versions of Moodle older than 4.3, then the plugin name must be 13 characters or shorter, and table names must be 28 characters or shorter.
 :::
 
 Each plugin is in a separate subdirectory and consists of a number of _mandatory files_ and any other files the developer is going to use.

--- a/docs/apis/plugintypes/assign/submission.md
+++ b/docs/apis/plugintypes/assign/submission.md
@@ -30,11 +30,11 @@ Assignment Feedback plugins are located in the `/mod/assign/submission` director
 
 :::important Plugin naming
 
-The plugin name should be no longer than 11 characters - this is because the database tables for a submission plugin must be prefixed with `assignsubmission_[pluginname]` (17 chars + X) and the table names can be no longer than 28 chars due to a limitation with Oracle.
+The plugin name should be no longer than 36 (11 before Moodle 4.3) characters - this is because the database tables for a submission plugin must be prefixed with `assignsubmission_[pluginname]` (17 chars + X) and the table names can be no longer than 53 (28 before Moodle 4.3) chars due to a limitation with PostgreSQL.
 
-If a plugin requires multiple database tables, the plugin name will need to be shorter to allow different table names to fit under the 28 character limit.
+If a plugin requires multiple database tables, the plugin name will need to be shorter to allow different table names to fit under the 53 character limit (28 before Moodle 4.3).
 
-:::
+Note: If your plugin is intended to work with versions of Moodle older than 4.3, then the plugin name must be 11 characters or shorter, and table names must be 28 characters or shorter.
 
 Each plugin is in a separate subdirectory and consists of a number of _mandatory files_ and any other files the developer is going to use.
 

--- a/docs/devupdate.md
+++ b/docs/devupdate.md
@@ -12,6 +12,18 @@ import TabItem from '@theme/TabItem';
 
 This page highlights the important changes that are coming in Moodle 4.3 for developers.
 
+## Database table and column names
+
+Starting with Moodle 4.3 the limits for both table and column names have been raised. Now table names can be up to 53 characters long (from previous 28 characters limit) and column names can be up to 63 characters long (from previous 30 characters limit).
+
+:::caution
+In order to achieve the above, the maximum length for the database prefix (`$CFG->prefix`) is now 10 characters. Installation or upgrade won't be possible with longer prefixes.
+:::
+
+:::caution
+If you are writing a plugin intended for older versions of Moodle then you must continue to use the lower limits of 28, and 30.
+:::
+
 ## Activity badge
 
 The new activity card design proposed for Moodle 4.3 differentiates badge information from other HTML content (displayed using the pre-existing `afterlink` feature).

--- a/general/development/tools/xmldb.md
+++ b/general/development/tools/xmldb.md
@@ -76,7 +76,11 @@ Apart from the [Database Structures guidelines](https://docs.moodle.org/dev/Data
 
 1. About names:
     1. All lowercase names (tables, indexes, keys and fields).
-    1. Table names and field names must use only a-z, 0-9 and _ chars. Max 28 characters.
+    1. Table names and field names must use only a-z, 0-9 and _ chars. Max 53 characters for tables and 63 characters for fields (28 and 30 before Moodle 4.3).
+
+     :::caution
+     If you are writing a plugin intended for older versions of Moodle then you must continue to use the lower limits of 28, and 30.
+     :::
     1. Key and index names under the XMLDB Files must be formed by concatenating the name of the fields present in the key/index with the '"-" (minus) character.
     1. Primary key always must be named "primary" (this is one exception to the previous convention).
     1. It's highly recommended to avoid [reserved words](https://docs.moodle.org/dev/XMLDB_reserved_words) completely. We know we have some of them now but they should be completely out for next releases.

--- a/general/releases/4.3.md
+++ b/general/releases/4.3.md
@@ -36,6 +36,8 @@ Moodle supports the following database servers. Again, version numbers are just 
 | [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 | Latest |
 | [Oracle Database](http://www.oracle.com/us/products/database/overview/index.html) | 19 | Latest |
 
+Note that, since Moodle 4.3, the maximum length for the database prefix (`$CFG->prefix`) is 10 characters. Installation or upgrade won't be possible with longer prefixes.
+
 ## Client requirements
 
 ### Browser support


### PR DESCRIPTION
Update all the references to the old 28 and 30 char long limits to the new 53 and 63 ones for Moodle 4.3 and up.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/728"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

