### PR TITLE
Declare PHP 8.2 supported

### DIFF
--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -49,6 +49,12 @@ You must be logged in to tracker to see issues in Epics.
 
 ## PHP supported versions
 
+### PHP 8.2
+
+<Since versions={["4.2.3", "4.3"]} issueNumber="MDL-76405" />
+
+PHP 8.2 **can be used with** Moodle 4.2.3, Moodle 4.3 and later releases. See MDL-76405 for details.
+
 ### PHP 8.1
 
 <Since versions={["4.1.2", "4.2"]} issueNumber="MDL-73016" />
@@ -92,10 +98,6 @@ PHP 7.1 **can be used with** Moodle 3.2 and later releases. It is also the **min
 PHP 7.0 **can be used with** Moodle 3.0.1, Moodle 3.1 and later releases. It is also the **minimum** supported version for Moodle 3.4. See [Moodle and PHP 7.0 details](https://docs.moodle.org/dev/Moodle_and_PHP_7.0_details) and [MDL-50565](https://tracker.moodle.org/browse/MDL-50565) for details.
 
 ## PHP versions under development
-
-### PHP 8.2
-
-PHP 8.2 support **is currently being implemented** for Moodle 4.2.x, 4.3.0 and later releases. Hence it's still **incomplete and only for development purposes**. See MDL-76405 for details.
 
 ### PHP 8.3
 

--- a/general/releases/4.2.md
+++ b/general/releases/4.2.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 3.11.8 or later.
-- PHP version: minimum PHP 8.0.0 *Note: minimum PHP version has increased since Moodle 4.1*. PHP 8.1.x is supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.0.0 *Note: minimum PHP version has increased since Moodle 4.1*. PHP 8.2.x is supported too (since Moodle 4.2.3). See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP extension **exif** is recommended.
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).

--- a/general/releases/4.3.md
+++ b/general/releases/4.3.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 3.11.8 or later.
-- PHP version: minimum PHP 8.0.0 *Note: minimum PHP version has increased since Moodle 4.1*. PHP 8.1.x is supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.0.0 *Note: minimum PHP version has increased since Moodle 4.1*. PHP 8.2.x is supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
 - PHP variants: Only 64-bit versions of PHP are supported. *Note: Changed since 4.1*.


### PR DESCRIPTION
- Do it in the PHP policy page: By MDL-76405, since 4.2.3
- Update 4.2 release notes.
- Update 4.3 release notes.

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/734"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

