### PR TITLE
[docs] repository plugins: typo fix

### DIFF
--- a/docs/apis/plugintypes/repository/_examples/lib.php
+++ b/docs/apis/plugintypes/repository/_examples/lib.php
@@ -12,7 +12,7 @@ class repository_pluginname extends repository {
      *
      * @param string $encodedpath
      * @param string $page
-     * @return array the list of files, including meta infomation
+     * @return array the list of files, including meta information
      */
     public function get_listing($encodedpath = '', $page = '') {
         // This methods

--- a/versioned_docs/version-4.1/apis/plugintypes/repository/_examples/lib.php
+++ b/versioned_docs/version-4.1/apis/plugintypes/repository/_examples/lib.php
@@ -12,7 +12,7 @@ class repository_pluginname extends repository {
      *
      * @param string $encodedpath
      * @param string $page
-     * @return array the list of files, including meta infomation
+     * @return array the list of files, including meta information
      */
     public function get_listing($encodedpath = '', $page = '') {
         // This methods

--- a/versioned_docs/version-4.1/apis/plugintypes/repository/index.md
+++ b/versioned_docs/version-4.1/apis/plugintypes/repository/index.md
@@ -457,7 +457,7 @@ This function will return a list of files to be displayed to the user, the list 
  *
  * @param string $encodedpath
  * @param string $page
- * @return array the list of files, including meta infomation
+ * @return array the list of files, including meta information
  */
 public function get_listing($encodedpath = '', $page = '') {
     // This methods

--- a/versioned_docs/version-4.2/apis/plugintypes/repository/_examples/lib.php
+++ b/versioned_docs/version-4.2/apis/plugintypes/repository/_examples/lib.php
@@ -12,7 +12,7 @@ class repository_pluginname extends repository {
      *
      * @param string $encodedpath
      * @param string $page
-     * @return array the list of files, including meta infomation
+     * @return array the list of files, including meta information
      */
     public function get_listing($encodedpath = '', $page = '') {
         // This methods

--- a/versioned_docs/version-4.2/apis/plugintypes/repository/index.md
+++ b/versioned_docs/version-4.2/apis/plugintypes/repository/index.md
@@ -457,7 +457,7 @@ This function will return a list of files to be displayed to the user, the list 
  *
  * @param string $encodedpath
  * @param string $page
- * @return array the list of files, including meta infomation
+ * @return array the list of files, including meta information
  */
 public function get_listing($encodedpath = '', $page = '') {
     // This methods


### PR DESCRIPTION
I'm just working on a new plugin and found this tiny typo in the docs

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/737"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

