### PR TITLE
[docs] corrected custom fields types

### DIFF
--- a/docs/apis/core/customfields/index.md
+++ b/docs/apis/core/customfields/index.md
@@ -1,6 +1,8 @@
 ---
 title: Custom fields API
-tags: []
+tags:
+  - customfield
+  - Custom field
 ---
 
 import { Since } from '@site/src/components';

--- a/docs/apis/core/customfields/index.md
+++ b/docs/apis/core/customfields/index.md
@@ -54,7 +54,7 @@ handler::setup_edit_page() // Sets page context/url/breadcrumb for the customfie
 
 ### Add custom fields to the instance edit form
 
-Custom fields are added to the **instances**. For example, course custom fields are added to the courses, so `courseid` is the `instanceid`. In the example of [mod_surveybuilder](https://github.com/marinaglancy/moodle-mod_surveybuilder) we use `$USER->id` as the `instanceid` (which means that in this example one user can fill the survey in one module only once). In each case of using custom fields there should be a clear concept of an **instance**. `Instanceid` is required to save the data but it may be empty when we render the instance edit form (for example, the course is not yet created).
+Custom fields are added to the **instances**. For example, course custom fields are added to the courses, so `courseid` is the `instanceid`. In the example of [`mod_surveybuilder`](https://github.com/marinaglancy/moodle-mod_surveybuilder) we use `$USER->id` as the `instanceid` (which means that in this example one user can fill the survey in one module only once). In each case of using custom fields there should be a clear concept of an **instance**. `Instanceid` is required to save the data but it may be empty when we render the instance edit form (for example, the course is not yet created).
 
 Developer must add custom field callbacks to the instance edit form. If the instance is "made up" (like in `mod_surveybuilder`), a new form has to be created with `id` field in it that will refer to the `instanceid`.
 

--- a/docs/apis/plugintypes/customfield/index.md
+++ b/docs/apis/plugintypes/customfield/index.md
@@ -6,7 +6,7 @@ tags:
   - Custom field
 ---
 
-Custom fields allow you to create field types to be used for custom fields. Instances of these field types can be added to the respective areas that implement [Custom fields API](/docs/apis/core/customfields). Currently in Moodle core only courses implement this API, however custom fields are also used in addon plugins for other areas. For example, if you want to display radio buttons on the course edit page, then you can add an instance of a radio custom field plugin to the Course custom fields configuration.
+Custom fields allow you to create field types to be used for custom fields. Instances of these field types can be added to the respective areas that implement [Custom fields API](../../core/customfields/index.md). Currently in Moodle core only courses implement this API, however custom fields are also used in addon plugins for other areas. For example, if you want to display radio buttons on the course edit page, then you can add an instance of a radio custom field plugin to the Course custom fields configuration.
 
 import {
     Lang,
@@ -125,5 +125,5 @@ The `instance_form_definition()` function adds any required field elements that 
 
 ## See Also
 
-- [Custom files API](/docs/apis/core/customfields)
+- [Custom files API](../../core/customfields/index.md)
 - [User Profile Fields](https://docs.moodle.org/dev/User_profile_fields)

--- a/docs/apis/plugintypes/customfield/index.md
+++ b/docs/apis/plugintypes/customfield/index.md
@@ -1,12 +1,12 @@
 ---
-title: Course Custom fields
+title: Custom fields
 tags:
-  - core_course
+  - customfield
   - Course
   - Custom field
 ---
 
-Course custom fields allow you to create field types to be used for course custom fields. Instances of these field types can be added to a course. for example, if you want to display radio buttons on the course edit page, then you can create a radio custom course field plugin.
+Custom fields allow you to create field types to be used for custom fields. Instances of these field types can be added to the respective areas that implement [Custom fields API](/docs/apis/core/customfields). Currently in Moodle core only courses implement this API, however custom fields are also used in addon plugins for other areas. For example, if you want to display radio buttons on the course edit page, then you can add an instance of a radio custom field plugin to the Course custom fields configuration.
 
 import {
     Lang,
@@ -16,7 +16,7 @@ import DataController from './_files/data_controller';
 
 ## File structure
 
-Course custom field plugins are located in the `/customfield/field` directory. A plugin should not include any custom files outside of it's own plugin folder.
+Custom field plugins are located in the `/customfield/field` directory. A plugin should not include any custom files outside of it's own plugin folder.
 
 Each plugin is in a separate subdirectory and consists of a number of _mandatory files_ and any other files the developer is going to use.
 
@@ -44,10 +44,10 @@ customfield/field/checkbox
 
 </details>
 
-A course custom field plugin requires two _controller_ classes:
+A custom field plugin requires two _controller_ classes:
 
 - a _field_ controller, which describes the field itself; and
-- a _data_ controller, which describes with interface within the context of the course page.
+- a _data_ controller, which describes with interface within the context of the instance (i.e. course).
 
 ### Field Controller
 
@@ -121,8 +121,9 @@ The `datafield()` function returns an enumerated string and describes which data
 
 #### instance_form_definition()
 
-The `instance_form_definition()` function adds any required field elements that are displayed on the course editing page.
+The `instance_form_definition()` function adds any required field elements that are displayed on the instance editing page (i.e. on the course settings page).
 
 ## See Also
 
+- [Custom files API](/docs/apis/core/customfields)
 - [User Profile Fields](https://docs.moodle.org/dev/User_profile_fields)

--- a/docs/apis/plugintypes/index.md
+++ b/docs/apis/plugintypes/index.md
@@ -55,7 +55,7 @@ The underscore character is not supported in activity modules for legacy reasons
 | [Assignment submission plugins](./assign/submission.md) | assignsubmission | /mod/assign/submission | Different forms of assignment submissions | 2.3+ |
 | [Assignment feedback plugins](./assign/feedback.md) | assignfeedback | /mod/assign/feedback | Different forms of assignment feedbacks | 2.3+ |
 | [Book tools](./mod_book/index.md) | booktool | /mod/book/tool | Small information-displays or tools that can be moved around pages | 2.1+ |
-| [Course Custom fields](./customfield/index.md) | customfield | /customfield/field | Custom field types, used in Custom course fields | 3.7+ |
+| [Custom fields](./customfield/index.md) | customfield | /customfield/field | Custom field types, used in Custom course fields | 3.7+ |
 | [Database fields](./mod_data/fields.md) | datafield | /mod/data/field | Different types of data that may be added to the Database activity module | 1.6+ |
 | [Database presets](./mod_data/presets.md) | datapreset | /mod/data/preset | Pre-defined templates for the Database activity module | 1.6+ |
 | [LTI sources](https://docs.moodle.org/dev/External_tool_source) | ltisource | /mod/lti/source | LTI providers can be added to external tools easily through the external tools interface see [Documentation on External Tools](https://docs.moodle.org/en/External_tool). This type of plugin is specific to LTI providers that need a plugin that can register custom handlers to process LTI messages | 2.7+ |


### PR DESCRIPTION
We use custom fields in Workplace for programs, certifications, appointments and certificates. It was strange to see that this plugin type is called "COURSE custom field" in the docs

<a href="https://gitpod.io/#https://github.com/moodle/devdocs/pull/740"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

