### PR TITLE
Writing acceptance tests: do not repeat feature-level tags for scenario

### DIFF
--- a/general/development/tools/behat/writing.md
+++ b/general/development/tools/behat/writing.md
@@ -65,13 +65,18 @@ JavaScript tests are usually much slower than tests executed without JavaScript.
 Afterwards you can specify a scenario:
 
 ```gherkin
-@javascript
 Scenario: Description of your scenario, which you want to test.
     When I log in as "student1"
     And I am on "Course 1" course homepage
 ```
 
 Again you can define specific tags. Afterwards you write the steps, which should be executed during your test.
+
+:::tip
+
+Tags that are specified in your feature's header automatically apply to all scenarios defined in that feature, so it is not necessary to repeat them. In the above example, the scenario will use JavaScript, although it does not have the `@javascript` tag.
+
+:::
 
 ### Multiple Scenarios
 


### PR DESCRIPTION
Currently, the example repeats the `@javascript` tag in the scenario, even though it is already present in the feature's header. This is not necessary and would actually give a `duplicate-behat-tag` warning.

I suggest changing the example and adding a note that explains how tags defined at feature level will automatically apply to all scenarios of that feature.