### PR TITLE
Make ProjectSummary more visually appealing.

### DIFF
--- a/src/components/ProjectSummary/index.tsx
+++ b/src/components/ProjectSummary/index.tsx
@@ -50,52 +50,54 @@ export default function ProjectSummary(props: ProjectSummaryProps): ReactNode {
 
     function GetProjectSummary(projectData: ProjectSummaryData): ReactNode {
         return (
-            <table className={styles.projecttable}>
-                <tbody>
-                    <tr>
-                        <th>Owners</th>
-                        <td>{getOwners(projectData)}</td>
-                    </tr>
-                    <tr>
-                        <th>Status</th>
-                        <td>{getStatus(projectData)}</td>
-                    </tr>
-                    {projectData.discussionLinks?.length > 0
-                        && (
-                            <tr>
-                                <th>Links</th>
-                                <td>
-                                    {projectData.discussionLinks.map(({ link, title }) => (
-                                        <div key={title}>
-                                            <Link
-                                                to={link}
-                                            >
-                                                {title}
-                                            </Link>
-                                        </div>
-                                    ))}
-                                </td>
-                            </tr>
-                        )}
-                    {projectData.issueLinks?.length > 0
-                        && (
-                            <tr>
-                                <th>Issues</th>
-                                <td>
-                                    {projectData.issueLinks.map(({ link, title }) => (
-                                        <div key={title}>
-                                            <Link
-                                                to={link}
-                                            >
-                                                {title}
-                                            </Link>
-                                        </div>
-                                    ))}
-                                </td>
-                            </tr>
-                        )}
-                </tbody>
-            </table>
+            <div className={styles.projectsummary}>
+                <table>
+                    <tbody>
+                        <tr>
+                            <th>Owners</th>
+                            <td>{getOwners(projectData)}</td>
+                        </tr>
+                        <tr>
+                            <th>Status</th>
+                            <td>{getStatus(projectData)}</td>
+                        </tr>
+                        {projectData.discussionLinks?.length > 0
+                            && (
+                                <tr>
+                                    <th>Links</th>
+                                    <td>
+                                        {projectData.discussionLinks.map(({ link, title }) => (
+                                            <div key={title}>
+                                                <Link
+                                                    to={link}
+                                                >
+                                                    {title}
+                                                </Link>
+                                            </div>
+                                        ))}
+                                    </td>
+                                </tr>
+                            )}
+                        {projectData.issueLinks?.length > 0
+                            && (
+                                <tr>
+                                    <th>Issues</th>
+                                    <td>
+                                        {projectData.issueLinks.map(({ link, title }) => (
+                                            <div key={title}>
+                                                <Link
+                                                    to={link}
+                                                >
+                                                    {title}
+                                                </Link>
+                                            </div>
+                                        ))}
+                                    </td>
+                                </tr>
+                            )}
+                    </tbody>
+                </table>
+            </div>
         );
     }
 

--- a/src/components/ProjectSummary/styles.module.css
+++ b/src/components/ProjectSummary/styles.module.css
@@ -1,4 +1,6 @@
-.projecttable {
+.projectsummary {
   float: right;
   clear: both;
+  font-family: monospace;
+  padding-left: 1rem;
 }


### PR DESCRIPTION
I suggest to wrap ProjectSummary in div container with some minor style change, so it looks a little more "technical" and has space from the left side.

Before:
![image](https://github.com/moodle/devdocs/assets/329780/f0adb353-edf3-40f8-90e7-9c3ce5df8869)

After:
![VirtualBox_Debian_20_10_2023_20_30_56](https://github.com/moodle/devdocs/assets/329780/c9059c11-db84-48ed-9eca-ab51f780574b)

(feel free to reject, spotted that parapgraph text touches the table while reading docs and thought would be good to improve slightly)
