### PR TITLE
Peer review checklist improvements

### DIFF
--- a/general/development/process/peer-review/index.md
+++ b/general/development/process/peer-review/index.md
@@ -235,34 +235,15 @@ Ensure that:
 
 ### Accessibility
 
-We aim for Moodle to be accessible to everyone, especially to people with disabilities. When peer-reviewing a patch that introduces changes on the frontend, it would be good to do a quick accessibility check on the page or on the UI elements affected by the patch.
+Moodle should be accessible to everyone. When reviewing any changes that affects the frontend, ensure that these points have been considered:
 
-Checking accessibility requires a bit of practice and knowledge, if you want to perform a systematic accessibility check, you can follow the [Accessibility checklist](./accessibility-checklist.md).
+- Automated tools: Does it pass automated accessibility checks? (e.g. via [axe DevTools](https://www.deque.com/axe/devtools/) or [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/))
+- Colours: Do the text have sufficient colour contrast against the background? If the patch introduces elements that convey information through colours, are there alternative means to convey this information to users with visual impairments?
+- HTML validity: Does the patch generate a page with valid HTML? (e.g. checked via [Nu HTML validator](https://validator.w3.org/nu/#textarea))
+- Keyboard navigation: Can you successfully navigate through the interface via keyboard?
+- Screen reader: When using a screen reader (e.g. [ChromeVox](https://support.google.com/chromebook/answer/7031755?hl=en), [NVDA](https://www.nvaccess.org/), [JAWS](https://www.freedomscientific.com/products/software/jaws/), etc), are the UI components being properly and clearly announced?
 
-Even if you don't have much experience with accessibility, there are some quick checks that can be done to check for accessibility:
-
-- **Automated tools**.
-  - Does it pass automated accessibility checks? (e.g. via [axe DevTools](https://www.deque.com/axe/devtools/) or [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/))
-- **Colours**:
-  - Do the text have sufficient colour contrast against the background?
-  - If the patch introduces elements that convey information through colours, are there alternative means to convey this information to users with visual impairments?
-- **HTML validity**
-  - Does the patch generate a page with valid HTML? (e.g. checked via [Nu HTML validator](https://validator.w3.org/nu/#textarea))
-- **Keyboard navigation**
-  - Can you successfully navigate through the interface via keyboard?
-- **Screen reader'**
-  - When using a screen reader (e.g. [ChromeVox](https://support.google.com/chromebook/answer/7031755?hl=en), [NVDA](https://www.nvaccess.org/), [JAWS](https://www.freedomscientific.com/products/software/jaws/), etc), are the UI components being properly and clearly announced?
-
-:::important
-Although these checks are optional, we encourage everyone to keep accessibility in mind when doing peer reviews.
-:::
-
-During peer reviews, please mark this category with either of the following (whichever's applicable):
-
-- **Y** - When accessibility has been checked and no accessibility issues were found.
-- **N** - When accessibility has been checked but accessibility issues were found.
-- **N/A** - When an accessibility check is not applicable for the patch.
-- **S** - To indicate that an accessibility check might be needed but has been skipped by the peer reviewer.
+But, remember that what you are doing here is part of a peer review. If you want to perform a systematic accessibility check, you can follow the [Accessibility checklist](./accessibility-checklist.md).
 
 ### Overall completeness and correctness
 

--- a/general/development/process/peer-review/index.md
+++ b/general/development/process/peer-review/index.md
@@ -29,10 +29,10 @@ These are points to consider while peer-reviewing issues. Further explanation be
 [] Documentation
 [] Git
 [] Third party code
-[] Sanity check
 [] Icons
 [] The Moodle mobile app / web services
 [] Accessibility (Optional)
+[] Sanity check
 ```
 
 Acceptable check-marks are Y (for yes), N (for no) or - (for not applicable). All N check-marks should be accompanied by an explanation of the problem that still needs to be addressed.
@@ -213,17 +213,6 @@ Does the change contain [third party code](../../../community/plugincontribution
 - Does not duplicate the functionality of any existing api or third party library in core.
 - Any modifications to third party code are recorded in readme_moodle.txt
 
-### Sanity check
-
-Ensure that:
-
-- The code seems to solve the described problem completely within its reported scope (and further issues have been created to resolve remaining parts or further refactoring);
-- The code makes sense in relation to the broader codebase (look at the whole function, not just the altered code); and
-- The developer has searched for and fixed other areas that may also have been affected by the same problem.
-- Verify that the related component maintainers, if known, have participated and are aware of the issue (as assignee, or existing comments...). If they have not, please perform a friendly @mention to make them aware about the issue. A list of component leads is available here: https://docs.moodle.org/dev/Component_Leads
-- If any version numbers have been changed in [version.php](https://docs.moodle.org/dev/version.php) files, then the changes follow [the rule for updating version numbers in core](https://docs.moodle.org/dev/Moodle_versions#How_to_increment_version_numbers_in_core).
-- There are comments on tracker explaining why current approach was taken and why other options (especially large issues). If not comment asking them to explain
-
 ### Icons
 
 Are new icons being introduced? If so, ensure that:
@@ -274,6 +263,17 @@ During peer reviews, please mark this category with either of the following (whi
 - **N** - When accessibility has been checked but accessibility issues were found.
 - **N/A** - When an accessibility check is not applicable for the patch.
 - **S** - To indicate that an accessibility check might be needed but has been skipped by the peer reviewer.
+
+### Sanity check
+
+Ensure that:
+
+- The code seems to solve the described problem completely within its reported scope (and further issues have been created to resolve remaining parts or further refactoring);
+- The code makes sense in relation to the broader codebase (look at the whole function, not just the altered code); and
+- The developer has searched for and fixed other areas that may also have been affected by the same problem.
+- Verify that the related component maintainers, if known, have participated and are aware of the issue (as assignee, or existing comments...). If they have not, please perform a friendly @mention to make them aware about the issue. A list of component leads is available here: https://docs.moodle.org/dev/Component_Leads
+- If any version numbers have been changed in [version.php](https://docs.moodle.org/dev/version.php) files, then the changes follow [the rule for updating version numbers in core](https://docs.moodle.org/dev/Moodle_versions#How_to_increment_version_numbers_in_core).
+- There are comments on tracker explaining why current approach was taken and why other options (especially large issues). If not comment asking them to explain
 
 ## Process
 

--- a/general/development/process/peer-review/index.md
+++ b/general/development/process/peer-review/index.md
@@ -32,7 +32,7 @@ These are points to consider while peer-reviewing issues. Further explanation be
 [] Icons
 [] The Moodle mobile app / web services
 [] Accessibility (Optional)
-[] Sanity check
+[] Overall completeness and correctness
 ```
 
 Acceptable check-marks are Y (for yes), N (for no) or - (for not applicable). All N check-marks should be accompanied by an explanation of the problem that still needs to be addressed.
@@ -264,16 +264,16 @@ During peer reviews, please mark this category with either of the following (whi
 - **N/A** - When an accessibility check is not applicable for the patch.
 - **S** - To indicate that an accessibility check might be needed but has been skipped by the peer reviewer.
 
-### Sanity check
+### Overall completeness and correctness
 
 Ensure that:
 
-- The code seems to solve the described problem completely within its reported scope (and further issues have been created to resolve remaining parts or further refactoring);
-- The code makes sense in relation to the broader codebase (look at the whole function, not just the altered code); and
+- The code seems to solve the described problem completely within its reported scope (and further issues have been created to resolve remaining parts or further refactoring).
+- The code makes sense in relation to the broader codebase (look at the whole function, not just the altered code).
 - The developer has searched for and fixed other areas that may also have been affected by the same problem.
-- Verify that the related component maintainers, if known, have participated and are aware of the issue (as assignee, or existing comments...). If they have not, please perform a friendly @mention to make them aware about the issue. A list of component leads is available here: https://docs.moodle.org/dev/Component_Leads
+- Verify that the related component maintainers, if known, have participated and are aware of the issue (as assignee, or existing comments...). If they have not, please perform a friendly @mention to make them aware about the issue. A list of component leads is available here: https://docs.moodle.org/dev/Component_Leads.
 - If any version numbers have been changed in [version.php](https://docs.moodle.org/dev/version.php) files, then the changes follow [the rule for updating version numbers in core](https://docs.moodle.org/dev/Moodle_versions#How_to_increment_version_numbers_in_core).
-- There are comments on tracker explaining why current approach was taken and why other options (especially large issues). If not comment asking them to explain
+- There are comments on tracker explaining why current approach was taken and why other options (especially large issues). If not comment asking them to explain.
 
 ## Process
 


### PR DESCRIPTION
Here are three proposed changes to the Peer review checklist, as three separate commits.

It might have been a mistake to send them as a single pull request, because while I think the first two should be uncontentious, the third one might need more discussion. If you want me to separate them out, just ask (or you can do it yourself).

The three changes are:

1. Move the overall checklist item to the end.
2. Rename it to 'Overall completeness and correctness' to more clearly name what it is for and because the Moodle content guideliness specifically [tell us to avoid the phrase 'sanity check'](https://moodledev.io/general/contentguidelines/styleguide/voice/contentprinciples#words-and-phrases-to-avoid).
3. Change the Accessibility check so that it is no longer 'optional'. That sent such a misleading signal about how much Moodle values accessibility, which is in reality a lot. (The reason it was 'options' is that people defined such a high bar for what was supposed to be a 'Peer review', so we felt it was unreasonable for it to be required. While accessiblity is importnat, and requires specialist knowledge, are other things like Security, Privacy and Performance. So, I think the Accessibility part of the peer review checklist should be brought into line - but I realise this might need discussion.

Obviously, if this gets merged, someone will need to update the Tracker comment template.