### PR TITLE
[docs] Fix plugins update page sidebar title and position

### DIFF
--- a/general/community/plugincontribution/pluginsdirectory/updates.md
+++ b/general/community/plugincontribution/pluginsdirectory/updates.md
@@ -1,4 +1,14 @@
-# 07/11/2023
+---
+title: Plugins directory updates
+sidebar_position: 1
+sidebar_label: Updates
+tags:
+  - Guidelines for contributors
+  - Plugins
+  - Plugin documentation
+---
+
+## 07/11/2023
 
 Different improvements in the main page:
 


### PR DESCRIPTION
The Plugins directory updates page was recently created, but the Update link was not properly positioned in the sidebar and the title was not set. This patch sets the title and locates the Update link in the first position within the group.