### PR TITLE
Fix category page urls in app docs

### DIFF
--- a/general/app/development/_category_.yml
+++ b/general/app/development/_category_.yml
@@ -1,3 +1,0 @@
-label: Development
-link:
-  type: generated-index

--- a/general/app/development/index.md
+++ b/general/app/development/index.md
@@ -1,0 +1,9 @@
+---
+title: Development
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/general/app/development/link-handling/_category_.yml
+++ b/general/app/development/link-handling/_category_.yml
@@ -1,4 +1,0 @@
-label: Link handling
-link:
-  type: generated-index
-position: 4

--- a/general/app/development/link-handling/index.md
+++ b/general/app/development/link-handling/index.md
@@ -1,0 +1,10 @@
+---
+title: Link handling
+sidebar_position: 4
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/general/app/development/plugins-development-guide/examples/_category_.yml
+++ b/general/app/development/plugins-development-guide/examples/_category_.yml
@@ -1,3 +1,0 @@
-label: Examples
-link:
-  type: generated-index

--- a/general/app/development/plugins-development-guide/examples/index.md
+++ b/general/app/development/plugins-development-guide/examples/index.md
@@ -1,0 +1,9 @@
+---
+title: Examples
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/general/app/development/scripts/_category_.yml
+++ b/general/app/development/scripts/_category_.yml
@@ -1,4 +1,0 @@
-label: Scripts
-link:
-  type: generated-index
-position: 7

--- a/general/app/development/scripts/index.md
+++ b/general/app/development/scripts/index.md
@@ -1,0 +1,10 @@
+---
+title: Scripts
+sidebar_position: 7
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/general/app/development/testing/_category_.yml
+++ b/general/app/development/testing/_category_.yml
@@ -1,4 +1,0 @@
-label: Testing
-link:
-  type: generated-index
-position: 6

--- a/general/app/development/testing/index.md
+++ b/general/app/development/testing/index.md
@@ -1,0 +1,10 @@
+---
+title: Testing
+sidebar_position: 6
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/general/app/upgrading/_category_.yml
+++ b/general/app/upgrading/_category_.yml
@@ -1,3 +1,0 @@
-label: Upgrading your code
-link:
-  type: generated-index

--- a/general/app/upgrading/index.md
+++ b/general/app/upgrading/index.md
@@ -1,0 +1,9 @@
+---
+title: Upgrading your code
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/general/app_releases/v2/_category_.yml
+++ b/general/app_releases/v2/_category_.yml
@@ -1,2 +1,0 @@
-label: Moodle Mobile 2
-position: 3

--- a/general/app_releases/v2/index.md
+++ b/general/app_releases/v2/index.md
@@ -1,0 +1,10 @@
+---
+title: Moodle Mobile 2
+sidebar_position: 3
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="v2/v2.0" />

--- a/general/app_releases/v3/_category_.yml
+++ b/general/app_releases/v3/_category_.yml
@@ -1,2 +1,0 @@
-label: Moodle App 3
-position: 2

--- a/general/app_releases/v3/index.md
+++ b/general/app_releases/v3/index.md
@@ -1,0 +1,10 @@
+---
+title: Moodle App 3
+sidebar_position: 2
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="v3/v3.0.0" />

--- a/general/app_releases/v4/_category_.yml
+++ b/general/app_releases/v4/_category_.yml
@@ -1,2 +1,0 @@
-label: Moodle App 4
-position: 1

--- a/general/app_releases/v4/index.md
+++ b/general/app_releases/v4/index.md
@@ -1,0 +1,10 @@
+---
+title: Moodle App 4
+sidebar_position: 1
+---
+
+<!-- markdownlint-disable no-inline-html -->
+
+import { Redirect } from '@docusaurus/router';
+
+<Redirect to="v4/v4.0.0" />


### PR DESCRIPTION
Before this commit, some urls of parent pages did not match the child urls. This was not future-proof because urls could change if a category page is ever converted to a text page.