### PR TITLE
[docs] Add SCSS deprecation page

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -173,7 +173,7 @@ Debugging_network_requests_in_the_Moodle_App:
 - filePath: "/general/app/development/network-debug.md"
   slug: "/general/app/development/network-debug"
 Deprecation:
-- filePath: "/general/development/policies/deprecation.md"
+- filePath: "/general/development/policies/deprecation/index.md"
   slug: "/general/development/policies/deprecation"
 Designing_usable_forms:
 - filePath: "/general/development/policies/designing-usable-forms.md"

--- a/general/development/policies/codingstyle/index.md
+++ b/general/development/policies/codingstyle/index.md
@@ -2028,7 +2028,7 @@ If you have a big task that is nearly done, apart a few TODOs, and you really wa
 
 There is a nice "to-do checker" reporting tool, restricted to admins and available via web @ [`lib/tests/other/todochecker.php`](https://github.com/moodle/moodle/blob/master/lib/tests/other/todochecker.php).
 
-Finally, don't forget to add any MDL-12345 used by your TODOs (and @todos too, unless part of the [deprecation process](../deprecation.md), those are handled apart) to the "Review TODOs Epic": MDL-47779 (requires login to see the issues)
+Finally, don't forget to add any MDL-12345 used by your TODOs (and @todos too, unless part of the [deprecation process](../deprecation/index.md), those are handled apart) to the "Review TODOs Epic": MDL-47779 (requires login to see the issues)
 
 ### CVS keywords
 

--- a/general/development/policies/deprecation/index.md
+++ b/general/development/policies/deprecation/index.md
@@ -38,7 +38,7 @@ Both steps should always happen as earlier as possible in the 6-months period be
 
 ### Step 1. Immediate action
 
-Deprecation affects only the current master version, in other words, the deprecation only becomes effective after the next [major release](../../releases.md).
+Deprecation affects only the current master version, in other words, the deprecation only becomes effective after the next [major release](../../../releases.md).
 
 - If the function is not a member of a class (in other words, it is an independent function), it should be moved, with its PHPDoc and all comments, to `lib/deprecatedlib.php`, which is included everywhere. If the function is a class member, it will need to be deprecated in its current location.
   - Deprecated behat step definitions should be moved to `lib/tests/behat/behat_deprecated.php`, including a call to `behat_deprecated::deprecated_message()` proposing an alternative to the deprecated method.
@@ -54,7 +54,7 @@ Deprecation affects only the current master version, in other words, the depreca
  ```
 
 - If the deprecated function has been replaced with a new function, ideally the new function should be called from the deprecated function, so that the new functionality is used. This will make maintenance easier moving forward.
-- A `@deprecated` tag should be added to the PHPDoc for the function description so that IDEs describing the function will note that it is deprecated, documenting which version it was deprecated in and the MDL issue associated with it. See the guidelines in [Coding style](./codingstyle/index.md#deprecated-and-todo).
+- A `@deprecated` tag should be added to the PHPDoc for the function description so that IDEs describing the function will note that it is deprecated, documenting which version it was deprecated in and the MDL issue associated with it. See the guidelines in [Coding style](../codingstyle/index.md#deprecated-and-todo).
 - If the function is an external function, then an additional deprecation-specific method needs to be created and set to return true. See the [adding a web service to a plugin](/docs/apis/subsystems/external/writing-a-service#deprecation) docs on that process. You should continue to add the `@deprecated since x.x` tag to the docs of all three of the relevant external methods (parameters, main method, returns) to make it clear to IDEs that the function is deprecated.
 - There will need to be an issue associated with the initial part of the deprecation. A second issue needs to be created to finish the job. The first issue will be linked to second issue. The second issue needs to be a sub-task of an appropriate [deprecation META](https://tracker.moodle.org/issues/?jql=%28summary%20~%20%22meta%22%20or%20type%20%3D%20Epic%29%20AND%20summary%20~%20%22together%20deprecated%22%20order%20by%20created&runQuery=true&clear=true).
 
@@ -229,8 +229,8 @@ Named parameter arguments are available from PHP 8.0 onwards.
 
 ## See also...
 
-- [String deprecation](../../projects/api/string-deprecation.md)
+- [String deprecation](../../../projects/api/string-deprecation.md)
 - [External functions deprecation](/docs/apis/subsystems/external/writing-a-service#deprecation)
 - [Capabilities deprecation](/docs/apis/subsystems/access#deprecating-a-capability)
-- [Process](../process.md)
-- [Release process](../process/release/index.md)
+- [Process](../../process.md)
+- [Release process](../../process/release/index.md)

--- a/general/development/policies/deprecation/index.md
+++ b/general/development/policies/deprecation/index.md
@@ -232,5 +232,6 @@ Named parameter arguments are available from PHP 8.0 onwards.
 - [String deprecation](../../../projects/api/string-deprecation.md)
 - [External functions deprecation](/docs/apis/subsystems/external/writing-a-service#deprecation)
 - [Capabilities deprecation](/docs/apis/subsystems/access#deprecating-a-capability)
+- [SCSS deprecation](./scss-deprecation.md)
 - [Process](../../process.md)
 - [Release process](../../process/release/index.md)

--- a/general/development/policies/deprecation/scss-deprecation.md
+++ b/general/development/policies/deprecation/scss-deprecation.md
@@ -1,0 +1,120 @@
+---
+title: SCSS Deprecation
+tags:
+  - Processes
+  - Core development
+  - Deprecation
+  - SCSS
+---
+import { Since } from '@site/src/components';
+
+<Since versions={["4.4"]} issueNumber={"MDL-78334"} />
+
+Since Moodle 4.4, it's possible to deprecate SCSS styles and classes. This allows us to safely remove SCSS and will help us keep the code cleaner and more organized.
+
+The most common scenarios where this functionality can be used is when specific SCSS code is not being used anywhere, when the name of a class is changed or a class should not be used in the future.
+
+:::info When should SCSS be removed?
+
+There are situations where deprecation does not make sense. For example when a whole functionality is being removed, or a very specific SCSS class is no longer used by the code. If it is very unlikely that the SCSS class is used by any other code, it can simply be removed without the full deprecation process.
+
+:::
+
+## How it works
+
+A new SCSS file called `deprecated.scss` has been added to the `theme/boost/scss/moodle` folder. All the deprecated SCSS code should be added to this file.
+
+In this file a new mixin called `deprecated-styles` has been also added. This mixin will add a red backgound to the deprecated styles and also a `:before` pseudo-element with the text "Deprecated style in use". It is important to note that `deprecated-styles` mixin will only affect sites with `themedesignermode` setting enabled or behat test running sites.
+
+:::tip
+
+If all the styles depending on the same parent are deprecated, is strongly recommended to deprecate the parent selector.
+
+:::
+
+## How to deprecate SCSS code
+
+To deprecate SCSS code, follow these steps:
+
+1. Remove the SCSS code that is no longer in use from the original file.
+2. Add the removed SCSS code to the `deprecated.scss` file under the comment for the current version `// Deprecated since Moodle X.Y.`
+3. Add the `deprecated-styles` mixin to the removed SCSS code.
+4. Add a comment to the removed SCSS code explaining why it has been deprecated.
+
+:::note
+
+If there is no section for the current version in the `deprecated.scss` file, it should be added. See [Final deprecation](#final-deprecation).
+
+:::
+
+**Example 1: Helper class has been removed**
+
+```scss title="theme/boost/scss/moodle/deprecated.scss"
+// The class ".foo" is deprecated. Use ".bar" instead.
+.foo {
+  @include deprecated-styles();
+
+  color: $pink;
+  @include border-right-radius(0);
+  border: $border-width solid $border-color;
+  table {
+    margin: 1rem;
+  }
+  table > tbody {
+    padding: .5rem;
+  }
+}
+```
+
+**Example 2: SCSS code is no longer in use**
+
+```scss title="theme/boost/scss/moodle/deprecated.scss"
+// The following styles are deprecated because they are no longer in use.
+// Deprecating the parent selector that contains all the deprecated styles.
+.path-course-view li.activity .foo {
+  @include deprecated-styles();
+}
+.path-course-view li.activity .foo > a {
+  text-decoration: none;
+  color: $secondary;
+}
+.path-course-view li.activity .foo > a:hover {
+  color: $primary;
+}
+```
+
+## Final deprecation
+
+When adding SCSS code to the `deprecated.scss` file, it is important to add it under the comment with the version when the code was deprecated. If that comment still doesn't exist, it should be added:
+
+```scss title="theme/boost/scss/moodle/deprecated.scss"
+//
+// Deprecated since Moodle X.Y.
+//
+```
+
+And alongside with that, a new issue should be created in the tracker to remove the deprecated SCSS code with the title `Remove strings deprecated in X.Y` and in the epic `X.[Y+4]` deprecations.
+
+After 4 major versions, the deprecated SCSS code will be removed from the `deprecated.scss` file.
+
+## Check deprecated styles in Behat tests
+
+Is is possible to check if deprecated styles are being used while running Behat tests. To do so, add the `--scss-deprecations` flag to the Behat init command.
+
+```bash
+php admin/tool/behat/cli/init.php --scss-deprecations
+```
+
+Then, when running Behat tests, the following message will be displayed:
+
+```bash
+Run optional tests:
+[...]
+- SCSS deprecations: Yes
+```
+
+If deprecated styles are being used, the test will fail with the following message:
+
+```bash
+Deprecated style in use (Exception)
+```

--- a/general/development/process.md
+++ b/general/development/process.md
@@ -319,7 +319,7 @@ Decisions will be posted on the issue and that issue will be closed, allowing an
 
 - [Detailed workflow](./process/_files/workflow.jpg)
 - [Release process](./process/release)
-- [Deprecation](./policies/deprecation.md)
+- [Deprecation](./policies/deprecation/index.md)
 - [Integration dashboard](http://tracker.moodle.org/secure/Dashboard.jspa?selectPageId=11350)
 Walks-though of the process for contributors:
 - By Dan Poltawski, Integrator: http://www.slideshare.net/poltawski/how-to-guarantee-your-change-is-integrated-to-moodle-core, https://www.youtube.com/watch?v=836WtnM2YpM

--- a/general/development/process/peer-review/index.md
+++ b/general/development/process/peer-review/index.md
@@ -45,7 +45,7 @@ To allow the community of Moodle developers to work together, conventions should
 - Variables are named correctly (all lower case, no camel-case, no underscores).
 - Functions are named correctly (all lower case, no camel-case, underscores allowed).
 - PHP DocBlocks have been updated and adhere to coding style guide.
-- Where functions are being removed, the [deprecation policy](../../policies/deprecation.md) is followed.
+- Where functions are being removed, the [deprecation policy](../../policies/deprecation/index.md) is followed.
 - The code doesn't use deprecated functions.
 - $_GET, $_POST, $_REQUEST, $_COOKIE, and $_SESSION are never used.
 
@@ -182,7 +182,7 @@ Ensure that:
 
 - The PHPdoc comments on all classes, methods and fields are useful. (Comments that just repeat the function name are not helpful! Add value.)
 - Where an API has been changed significantly, the relevant upgrade.txt file has been updated with information.
-- Where something has been deprecated, that the comments don't just say "do NOT use this any more!!!" but actually follow the [deprecation policy](../../policies/deprecation.md).
+- Where something has been deprecated, that the comments don't just say "do NOT use this any more!!!" but actually follow the [deprecation policy](../../policies/deprecation/index.md).
 - Appropriate [labels](../../tracker/labels.md) have been added when there has been a function change, particularly
   - docs_required (any functional change, usually paired with `ui_change`),
   - dev_docs_required (any change to APIs, usually paired with `api_change`),

--- a/general/development/process/release/index.md
+++ b/general/development/process/release/index.md
@@ -190,4 +190,4 @@ Usually on Monday
 
 ## See also
 
-- [Deprecation process](../../policies/deprecation.md)
+- [Deprecation process](../../policies/deprecation/index.md)


### PR DESCRIPTION
- Convert the current "Deprecation" page into a subsection, moving `deprecation.md` to `/deprecation/index.md`
- Add a new "SCSS deprecation" page under this new "Deprecation" subsection