### PR TITLE
Update functions.md

### DIFF
--- a/docs/apis/subsystems/external/functions.md
+++ b/docs/apis/subsystems/external/functions.md
@@ -117,12 +117,12 @@ class create_groups extends \core_external\external_api {
     }
 
     public static function execute_returns(): external_single_structure {
-        return new external_single_structure(
+        return new external_single_structure([
             'groups' => new external_multiple_structure([
                 'id' => new external_value(PARAM_INT, 'Id of the created user'),
                 'name' => new external_value(PARAM_RAW, 'The name of the group'),
             ])
-        );
+        ]);
     }
 }
 ```


### PR DESCRIPTION
Corrected example code for use of `external_single_structure`. It takes an array as parameter.