### PR TITLE
[docs] Fix wrong function name for activitychooser

### DIFF
--- a/docs/apis/plugintypes/mod/activitymodule.md
+++ b/docs/apis/plugintypes/mod/activitymodule.md
@@ -62,7 +62,7 @@ The information about an activity will be accessible through the 'i' icon. Click
 
 ## Third party plugin developers
 
-Course module plugins can add items to the activity chooser by implementing the `{plugin}_get_content_items()` callback in their plugin lib (lib.php). This callback replaces the now deprecated `{plugin}_get_shortcuts()` method.
+Course module plugins can add items to the activity chooser by implementing the `{plugin}_get_course_content_items()` callback in their plugin lib (lib.php). This callback replaces the now deprecated `{plugin}_get_shortcuts()` method.
 
 In order for activity starring and recommendations to work, each content_item has an ID which is subject to some additional rules. Each ID:
 

--- a/versioned_docs/version-4.1/apis/plugintypes/mod/activitymodule.md
+++ b/versioned_docs/version-4.1/apis/plugintypes/mod/activitymodule.md
@@ -62,7 +62,7 @@ The information about an activity will be accessible through the 'i' icon. Click
 
 ## Third party plugin developers
 
-Course module plugins can add items to the activity chooser by implementing the `{plugin}_get_content_items()` callback in their plugin lib (lib.php). This callback replaces the now deprecated `{plugin}_get_shortcuts()` method.
+Course module plugins can add items to the activity chooser by implementing the `{plugin}_get_course_content_items()` callback in their plugin lib (lib.php). This callback replaces the now deprecated `{plugin}_get_shortcuts()` method.
 
 In order for activity starring and recommendations to work, each content_item has an ID which is subject to some additional rules. Each ID:
 

--- a/versioned_docs/version-4.2/apis/plugintypes/mod/activitymodule.md
+++ b/versioned_docs/version-4.2/apis/plugintypes/mod/activitymodule.md
@@ -62,7 +62,7 @@ The information about an activity will be accessible through the 'i' icon. Click
 
 ## Third party plugin developers
 
-Course module plugins can add items to the activity chooser by implementing the `{plugin}_get_content_items()` callback in their plugin lib (lib.php). This callback replaces the now deprecated `{plugin}_get_shortcuts()` method.
+Course module plugins can add items to the activity chooser by implementing the `{plugin}_get_course_content_items()` callback in their plugin lib (lib.php). This callback replaces the now deprecated `{plugin}_get_shortcuts()` method.
 
 In order for activity starring and recommendations to work, each content_item has an ID which is subject to some additional rules. Each ID:
 

--- a/versioned_docs/version-4.3/apis/plugintypes/mod/activitymodule.md
+++ b/versioned_docs/version-4.3/apis/plugintypes/mod/activitymodule.md
@@ -62,7 +62,7 @@ The information about an activity will be accessible through the 'i' icon. Click
 
 ## Third party plugin developers
 
-Course module plugins can add items to the activity chooser by implementing the `{plugin}_get_content_items()` callback in their plugin lib (lib.php). This callback replaces the now deprecated `{plugin}_get_shortcuts()` method.
+Course module plugins can add items to the activity chooser by implementing the `{plugin}_get_course_content_items()` callback in their plugin lib (lib.php). This callback replaces the now deprecated `{plugin}_get_shortcuts()` method.
 
 In order for activity starring and recommendations to work, each content_item has an ID which is subject to some additional rules. Each ID:
 


### PR DESCRIPTION
While reviewing https://tracker.moodle.org/browse/MDL-80434 I realised there was a mistake in the docs, because they were referring to **_get_content_items** instead of **_get_course_content_items** (which was the real method that replaced get_shortcuts()).