### PR TITLE
Add global definition of $CFG

### DIFF
--- a/docs/apis/subsystems/external/testing.md
+++ b/docs/apis/subsystems/external/testing.md
@@ -54,6 +54,7 @@ namespace mod_kitchen\external;
 
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 
 class get_fruit_test extends externallib_advanced_testcase {

--- a/versioned_docs/version-4.1/apis/subsystems/external/testing.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/testing.md
@@ -54,6 +54,7 @@ namespace mod_kitchen\external;
 
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 
 class get_fruit_test extends externallib_advanced_testcase {

--- a/versioned_docs/version-4.2/apis/subsystems/external/testing.md
+++ b/versioned_docs/version-4.2/apis/subsystems/external/testing.md
@@ -54,6 +54,7 @@ namespace mod_kitchen\external;
 
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 
 class get_fruit_test extends externallib_advanced_testcase {

--- a/versioned_docs/version-4.3/apis/subsystems/external/testing.md
+++ b/versioned_docs/version-4.3/apis/subsystems/external/testing.md
@@ -54,6 +54,7 @@ namespace mod_kitchen\external;
 
 defined('MOODLE_INTERNAL') || die();
 
+global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
 
 class get_fruit_test extends externallib_advanced_testcase {


### PR DESCRIPTION
Test class files do not seem to have access to global variables, so there is the need of declaring `global $CFG;` for this example to work.

Another possibility would be to use a relative path for the require_once statement. Not sure what is the better option in this case.