### PR TITLE
[repo] Prevent admonition overlapping custom components.

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -154,3 +154,8 @@ ul ol {
   /* Docusaurus overrides the style for nested ordered lists to roman-numerals, which is non-ideal. */
   list-style-type: auto;
 }
+
+.theme-admonition {
+    /* Prevent overlapping custom components, such as ProjectSummary */
+    clear: both;
+}


### PR DESCRIPTION
Basically tiny style fix to prevent this:
![image](https://github.com/moodle/devdocs/assets/329780/42d129c1-60aa-4204-9f55-6dc5dc96b401)
(https://moodledev.io/general/projects/api/amos)