### PR TITLE
[docs] api: Fix string-deprecation admonition closing tag.

### DIFF
--- a/general/projects/api/string-deprecation.md
+++ b/general/projects/api/string-deprecation.md
@@ -87,7 +87,7 @@ Use the `git-blame` tool on the corresponding `lang/en/deprecated.txt` and find 
 [git blame lang/en/deprecated.txt](https://github.com/moodle/moodle/blame/master/lang/en/deprecated.txt)<br/>
 [git blame mod/quiz/lang/en/deprecated.txt](https://github.com/moodle/moodle/blame/master/mod/quiz/lang/en/deprecated.txt)
 
-::::
+:::
 
 ## See also
 


### PR DESCRIPTION
Fixing broken layout (https://moodledev.io/general/projects/api/string-deprecation#what-to-do-if-you-get-a-debugging-message):
![image](https://github.com/moodle/devdocs/assets/329780/7efcd72f-6d96-4e8d-aa1d-b3ab3e7173a4)
