### PR TITLE
[docs] php83 target has been agreed to be exclusively 4.4.x (MDL-76441)

### DIFF
--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -101,7 +101,7 @@ PHP 7.0 **can be used with** Moodle 3.0.1, Moodle 3.1 and later releases. It is 
 
 ### PHP 8.3
 
-PHP 8.3 support **is currently being implemented**. We hope to make this available for Moodle 4.4 but this has not yet been confirmed and is subject to change. See MDL-76426 for details.
+PHP 8.3 support **is currently being implemented** for Moodle 4.4 and later releases. Hence it's still **incomplete and only for development purposes**. See MDL-76426 for details.
 
 ## See also
 


### PR DESCRIPTION
Raised as part of [MDL-76441](https://tracker.moodle.org/browse/MDL-76441), part of the php83 epic.