### PR TITLE
MDL-75794: Improve behat steps deprecation process documentation

### DIFF
--- a/general/development/policies/deprecation/index.md
+++ b/general/development/policies/deprecation/index.md
@@ -41,7 +41,7 @@ Both steps should always happen as earlier as possible in the 6-months period be
 Deprecation affects only the current master version, in other words, the deprecation only becomes effective after the next [major release](../../../releases.md).
 
 - If the function is not a member of a class (in other words, it is an independent function), it should be moved, with its PHPDoc and all comments, to `lib/deprecatedlib.php`, which is included everywhere. If the function is a class member, it will need to be deprecated in its current location.
-  - Deprecated behat step definitions should be moved to `lib/tests/behat/behat_deprecated.php`, including a call to `behat_deprecated::deprecated_message()` proposing an alternative to the deprecated method.
+  - Deprecated behat step definitions should be moved to `lib/tests/behat/behat_deprecated.php`. Steps that are part of a component should be moved to `$COMPONENT_DIRECTORY/tests/behat/behat_<COMPONENT>_deprecated.php` instead. Deprecated function should call to `behat_deprecated::deprecated_message()` proposing an alternative to the deprecated method.
 - If an entire class is being deprecated, the following actions should be done:
   - Add @deprecated tag on class level PHPDoc block
   - Add @deprecated tag on the PHPDoc block of all public methods


### PR DESCRIPTION
Thanks to Paul Holden's review I realized that dev docs don't mention deprecated behat steps should be moved to component directory instead of lib/tests/behat/behat_deprecated.php.
I discussed with Júlia the added information. I hope that's OK.

Thanks both for your help :-)

Amaia