### PR TITLE
missing semi-colon in external apis

### DIFF
--- a/docs/apis/subsystems/external/functions.md
+++ b/docs/apis/subsystems/external/functions.md
@@ -108,7 +108,7 @@ class create_groups extends \core_external\external_api {
         require_capability('moodle/course:creategroups', $coursecontext);
 
         // Create the group using existing Moodle APIs.
-        $createdgroups = \local_groupmanager\util::create_groups($groups)
+        $createdgroups = \local_groupmanager\util::create_groups($groups);
 
         // Return a value as described in the returns function.
         return [

--- a/versioned_docs/version-4.1/apis/subsystems/external/functions.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/functions.md
@@ -89,7 +89,7 @@ class create_groups extends external_api {
         require_capability('moodle/course:creategroups', $coursecontext);
 
         // Create the group using existing Moodle APIs.
-        $createdgroups = \local_groupmanager\util::create_groups($groups)
+        $createdgroups = \local_groupmanager\util::create_groups($groups);
 
         // Return a value as described in the returns function.
         return [

--- a/versioned_docs/version-4.2/apis/subsystems/external/functions.md
+++ b/versioned_docs/version-4.2/apis/subsystems/external/functions.md
@@ -108,7 +108,7 @@ class create_groups extends \core_external\external_api {
         require_capability('moodle/course:creategroups', $coursecontext);
 
         // Create the group using existing Moodle APIs.
-        $createdgroups = \local_groupmanager\util::create_groups($groups)
+        $createdgroups = \local_groupmanager\util::create_groups($groups);
 
         // Return a value as described in the returns function.
         return [

--- a/versioned_docs/version-4.3/apis/subsystems/external/functions.md
+++ b/versioned_docs/version-4.3/apis/subsystems/external/functions.md
@@ -108,7 +108,7 @@ class create_groups extends \core_external\external_api {
         require_capability('moodle/course:creategroups', $coursecontext);
 
         // Create the group using existing Moodle APIs.
-        $createdgroups = \local_groupmanager\util::create_groups($groups)
+        $createdgroups = \local_groupmanager\util::create_groups($groups);
 
         // Return a value as described in the returns function.
         return [


### PR DESCRIPTION
Adding the missing PHP semi-colon on 4 examples of external API use.