### PR TITLE
[repo] Bump lighthouse timeout

### DIFF
--- a/.github/workflows/lighthouse-report.yml
+++ b/.github/workflows/lighthouse-report.yml
@@ -18,11 +18,11 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3
 
       - name: Wait for the Netlify Preview
-        uses: andrewnicols/wait-for-netlify-preview@v1.0.6
+        uses: andrewnicols/wait-for-netlify-preview@v1
         id: netlify
         with:
           site_id: "3c056055-e1bd-4cfd-8a02-ed35ab7aedfa"
-          max_timeout: 600
+          max_timeout: 900
           netlify_secret: ${{ secrets.NETLIFY_SECRET }}
 
       - name: Audit URLs using Lighthouse


### PR DESCRIPTION
Now that we have more supported branches in docs, it takes longer to build them.