### PR TITLE
Declare PHP 8.3 supported

### DIFF
--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -49,6 +49,12 @@ You must be logged in to tracker to see issues in Epics.
 
 ## PHP supported versions
 
+### PHP 8.3
+
+<Since versions={["4.4"]} issueNumber="MDL-76426" />
+
+PHP 8.3 **can be used with** Moodle 4.4 and later releases. See MDL-76426 for details.
+
 ### PHP 8.2
 
 <Since versions={["4.2.3", "4.3"]} issueNumber="MDL-76405" />
@@ -99,9 +105,9 @@ PHP 7.0 **can be used with** Moodle 3.0.1, Moodle 3.1 and later releases. It is 
 
 ## PHP versions under development
 
-### PHP 8.3
+### PHP 8.4
 
-PHP 8.3 support **is currently being implemented** for Moodle 4.4 and later releases. Hence it's still **incomplete and only for development purposes**. See MDL-76426 for details.
+PHP 8.4 support **is currently being implemented** for Moodle 5.0 and later releases. Hence it's still **incomplete and only for development purposes**. See MDL-80117 for details.
 
 ## See also
 


### PR DESCRIPTION
- Do it in the PHP policy page: By MDL-76426, since 4.4
- Update 4.4 release notes (not needed in this case, it's already showing the correct PHP 8.3 information).

Note: Creating this as draft, we need:
- #952 implemented (4.4 release page available).
- This PR modified to ensure that the 4.4 release page has correct information.
- [MDL-76426](https://tracker.moodle.org/browse/MDL-76426) completed.

See #734 for the PHP 8.2 sister PR of this.