### PR TITLE
[repo] Adjust /docs to include next version

### DIFF
--- a/.markdownlint/fix-renamed-links.js
+++ b/.markdownlint/fix-renamed-links.js
@@ -123,6 +123,14 @@ const isRelativeLinkPossible = (link, file) => {
     const linkFolder = link.split('/')[1];
     const fileFolder = file.split('/')[1];
 
+    if (linkFolder === 'docs' && fileFolder === 'docs') {
+        if (link.match(/^\/docs\/\d\.\d\//)) {
+            // This is a versioned link.
+            // We don't want to normalise these.
+            return false;
+        }
+    }
+
     // In Docusaurus, different root folders contain different plugin instances.
     // Docusaurus does not support relative links between different plugins.
     return linkFolder === fileFolder;
@@ -164,7 +172,11 @@ const getOptimisedLink = (mappings, file, currentLink, forceRelative) => {
     const updatedLink = mappings[normalisedCurrentLink] ? mappings[normalisedCurrentLink] : normalisedCurrentLink;
     const relativeLinkPossible = isRelativeLinkPossible(updatedLink, normalisedCurrentFile);
     const forceRelativeLink = shouldForceRelativeForLink(currentLink, forceRelative);
+    const isRelativeLink = currentLink.startsWith('./') || currentLink.startsWith('../');
 
+    if (isRelativeLink && !relativeLinkPossible) {
+        return updatedLink;
+    }
     if (updatedLink === normalisedCurrentLink && !forceRelativeLink) {
         // There is no rename for this file.
         // Configuration is set to _not_ force a relative link for this section.

--- a/config/navbar.js
+++ b/config/navbar.js
@@ -15,6 +15,7 @@
  * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
  */
 const VersionsArchived = require('../versionsArchived.json');
+const nextVersionData = require('../nextVersion.js');
 
 const ArchivedVersionsDropdownItems = Object.entries(VersionsArchived).splice(
     0,
@@ -31,7 +32,7 @@ const navbar = {
     },
     items: [
         {
-            to: '/docs',
+            to: nextVersionData.nextVersionRoot,
             label: 'Guides',
             position: 'left',
         },

--- a/docs/devupdate.md
+++ b/docs/devupdate.md
@@ -595,6 +595,6 @@ Here you can find all the functionality that has been deprecated in PHPUnit 9.x 
 
 ## Previous versions
 
-- [Moodle 4.3 developer update](./4.3/devupdate)
-- [Moodle 4.2 developer update](./4.2/devupdate)
-- [Moodle 4.1&4.0 developer update](./4.1/devupdate)
+- [Moodle 4.3 developer update](/docs/4.3/devupdate)
+- [Moodle 4.2 developer update](/docs/4.2/devupdate)
+- [Moodle 4.1&4.0 developer update](/docs/4.1/devupdate)

--- a/docs/guides/bs5migration/index.md
+++ b/docs/guides/bs5migration/index.md
@@ -23,7 +23,7 @@ See more about Bootstrap 5 breaking changes in the [official documentation](http
 To achieve a smoother process and facilitate the moment of the update, the migration has been divided into different steps:
 
 1. **PopperJS upgrade**: This is the first step in the migration process, as Bootstrap 5 requires PopperJS version 2. This step is about upgrading the current PopperJS version to version 2. Because we still need PopperJS version 1 for Bootstrap 4 both versions will co-exist until all usages are migrated to v2.
-2. **SCSS Deprecation process**: A SCSS deprecation process will be needed for the cleanup after BS5 upgrade. More details about it in [SCSS deprecation](../../general/development/policies/deprecation/scss-deprecation).
+2. **SCSS Deprecation process**: A SCSS deprecation process will be needed for the cleanup after BS5 upgrade. More details about it in [SCSS deprecation](/general/development/policies/deprecation/scss-deprecation).
 3. **Refactoring BS4 features dropped in BS5**: This step is about refactoring the current Bootstrap 4 features that will be deprecated or dropped in its version 5 and they can be replaced with current codebase.
 4. **Create a BS5 "bridge"**: Some simple breaking changes could be also addressed in advance creating a BS5 "bridge". With small additions to this "bridge", we can refactor in advance the occurrences in the codebase for some dropped features in BS5.
 5. **BS5 upgrade**: Upgrade the current Bootstrap 4 version to version 5.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,6 +19,9 @@ import { config as dotEnvConfig } from 'dotenv';
 import Versions from './versions.json';
 import MoodleBannerRemark from './src/remark/moodleBanner.js';
 import TrackerLinksRemark from './src/remark/trackerLinks.js';
+import UnversionedDocsLinksRemark from './src/remark/unversionedDocsLinks.js';
+
+// eslint-disable global-require
 
 dotEnvConfig();
 
@@ -29,29 +32,25 @@ const versionConfig = Object.fromEntries(Versions.map((version) => [version, {
 versionConfig.current = {
     label: 'main',
     banner: 'none',
+    path: '4.4',
 };
 
 // Share the remarkPlugins between all presets.
 const remarkPlugins = [
     MoodleBannerRemark,
     TrackerLinksRemark,
+    UnversionedDocsLinksRemark,
 ];
 
 const isDeployPreview = !!process.env.NETLIFY && process.env.CONTEXT === 'deploy-preview';
 
 const getBaseUrl = () => {
-    if (process.env.NETLIFY) {
-        // Netlify hosts on '/', always.
-        return '/';
-    }
-
     if (typeof process.env.BASEURL !== 'undefined') {
         // Respect the env.
         return process.env.BASEURL;
     }
 
-    // Default is currently '/devdocs'.
-    return '/devdocs/';
+    return '/';
 };
 
 /** @type {import('@docusaurus/types').Config} */

--- a/general/development/tracker/labels.md
+++ b/general/development/tracker/labels.md
@@ -91,7 +91,7 @@ Used to identify all issues to be listed in the release notes (minor or major).
 Issues that need to be mentioned in the user documentation [under 'Possible issues that may affect you in Moodle X.0' (major versions).
 
 - [`developer_notes`](https://tracker.moodle.org/issues/?jql=labels%20%3D%20developer_notes)<br/>
-Issues that need to be mentioned in the [integration exposed forum](https://moodle.org/mod/forum/view.php?f=1153) and in the [Moodle developer update documentation](../../../docs/devupdate).
+Issues that need to be mentioned in the [integration exposed forum](https://moodle.org/mod/forum/view.php?f=1153) and in the [Moodle developer update documentation](/docs/devupdate).
 
 - `lost_functionality`<br/>
 Used to identify issues describing functionality which was available in an earlier version but which is no longer available in the latest version.

--- a/nextVersion.js
+++ b/nextVersion.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Moodle Pty Ltd.
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const nextVersion = '4.4';
+const nextLTSVersion = '4.5';
+const nextVersionRoot = `/docs/${nextVersion}`;
+
+module.exports = {
+    nextVersion,
+    nextLTSVersion,
+    nextVersionRoot,
+};

--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -19,6 +19,7 @@ import React from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.css';
 import Link from '@docusaurus/Link';
+import NextVersionData from '@site/nextVersion';
 
 /* eslint-disable global-require */
 
@@ -48,7 +49,7 @@ const FeatureList = [
         linkText: 'View standards',
     },
     {
-        link: '/docs/apis',
+        link: `${NextVersionData.nextVersionRoot}/apis`,
         title: 'API guides',
         Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
         description: (

--- a/src/remark/unversionedDocsLinks.js
+++ b/src/remark/unversionedDocsLinks.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Moodle Pty Ltd.
+ *
+ * Moodle is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Moodle is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { SKIP, CONTINUE, visit } from 'unist-util-visit';
+import { nextVersionRoot } from '../../nextVersion.js';
+
+/**
+ * Update any /docs/* link to point to /docs/:nextVersion.
+ *
+ * @param {Tree} node
+ * @param {Number} index
+ * @param {Tree} parent
+ * @returns {Number|String} The next index to process, or 'skip' to skip this node.
+ */
+const updateLink = (node) => {
+    if (!node.url) {
+        return SKIP;
+    }
+
+    if (!node.url.startsWith('/docs/')) {
+        return SKIP;
+    }
+
+    if (node.url.match(/\/docs\/\d\.\d/)) {
+        return SKIP;
+    }
+
+    // Get the current version.
+    node.url = node.url.replace(/^\/docs\//, `${nextVersionRoot}/`);
+
+    return CONTINUE;
+};
+
+const plugin = () => async (ast) => {
+    // Visit all nodes on the AST which are of type 'link' and apply the updateLink function on them.
+    // The visit function's third parameter is a Visitor function.
+    // See the docs at https://github.com/syntax-tree/unist-util-visit-parents
+    // Note: It has a mixed return type.
+    // - If the Visitor function returns 'skip', then the visit function will skip this node and continue.
+    // - If the Visitor function returns a Number, then the visit function will continue from that index.
+    visit(ast, 'link', (node, index, parent) => updateLink(node, index, parent));
+};
+
+export default plugin;

--- a/static/_redirects
+++ b/static/_redirects
@@ -59,3 +59,7 @@
 # Issue 415
 # Redirect /roadmap to /general/community/roadmap
 /roadmap/* /general/community/roadmap/:splat
+
+# Issue #955
+# Redirect /docs/* to /docs/4.4/:splat
+/docs/* /docs/4.4/:splat

--- a/static/_redirects
+++ b/static/_redirects
@@ -34,16 +34,28 @@
 # Issue #386
 # Redirect /releases to /general/releases
 /releases /general/releases
+
+# Issue 415
+# Redirect /roadmap to /general/community/roadmap
+/roadmap /general/community/roadmap
+
+# Issue #393
+# Redirect /docs/apis/plugintypes/tinymce to /docs/apis/plugintypes/tiny/legacy
+/docs/apis/plugintypes/tinymce /docs/apis/plugintypes/tiny/legacy
+
+# MOBILE-4270
+/general/app/development/release-process /general/development/process-moodleapp/release
+
+
+
+############################################################################
+# Splats should go later for performance
+############################################################################
+
+# Issue #386
+# Redirect /releases to /general/releases
 /releases/* /general/releases/:splat
 
 # Issue 415
 # Redirect /roadmap to /general/community/roadmap
-/roadmap to /general/community/roadmap
-/roadmap/* to /general/community/roadmap/:splat
-
-# Issue #393
-# Redirect /docs/apis/plugintypes/tinymce to /docs/apis/plugintypes/tiny/legacy
-/docs/apis/plugintypes/tinymce to /docs/apis/plugintypes/tiny/legacy
-
-# MOBILE-4270
-/general/app/development/release-process /general/development/process-moodleapp/release
+/roadmap/* /general/community/roadmap/:splat


### PR DESCRIPTION
This commit changes the unversioned docs at /docs/ to instead be at /docs/[nextVersionNumber].

It includes a redirect for /docs/* (where an existing page is not found) and it adds helpers to specify the version number in URLs and other locations.

Fixes #955