### PR TITLE
[docs] Migrate Themes overview

### DIFF
--- a/data/migratedPages.yml
+++ b/data/migratedPages.yml
@@ -1683,6 +1683,9 @@ Testing_instructions_guide:
 Testing_of_integrated_issues:
 - filePath: "/general/development/process/testing/integrated-issues.md"
   slug: "/general/development/process/testing/integrated-issues"
+Themes_overview:
+- filePath: "/docs/apis/plugintypes/theme/index.md"
+  slug: "/docs/apis/plugintypes/theme/"
 Time_API:
 - filePath: "/docs/apis/subsystems/time/index.md"
   slug: "/docs/apis/subsystems/time/"

--- a/docs/apis/plugintypes/theme/_examples/lang.md
+++ b/docs/apis/plugintypes/theme/_examples/lang.md
@@ -1,0 +1,15 @@
+<!-- markdownlint-disable first-line-heading -->
+<!-- cspell:ignore choosereadme, configtitle -->
+
+Each plugin must define a set of language strings with, at a minimum, an English translation. These are specified in the plugin's lang/en directory in a file named after the plugin.
+
+Language strings for the plugin. Required strings:
+
+- **`pluginname`** - name of plugin.
+- **`choosereadme`** - descriptive text displayed beneath the theme information dialog screenshot.
+- **`configtitle`** - settings text for this type of plugin.
+
+You will usually need to add your own strings for two main purposes:
+
+- Creating suitable form controls for users who are editing the theme settings; and
+- Displaying information about the theme.

--- a/docs/apis/plugintypes/theme/_examples/lang.php
+++ b/docs/apis/plugintypes/theme/_examples/lang.php
@@ -1,0 +1,3 @@
+$string['pluginname'] = 'Boost';
+$string['choosereadme'] = 'Boost is a modern, highly-customisable theme. This theme is intended to be used directly, or as a parent theme when creating new themes utilising Bootstrap 4.';
+$string['configtitle'] = 'Boost';

--- a/docs/apis/plugintypes/theme/fonts.md
+++ b/docs/apis/plugintypes/theme/fonts.md
@@ -1,0 +1,77 @@
+---
+title: Fonts
+tags:
+  - Plugins
+  - Theme
+  - Fonts
+sidebar_position: 3
+---
+
+<Since version="2.6" />
+
+CSS3 standard introduced the possibility to specify custom fonts, see [CSS web fonts tutorial](http://www.w3schools.com/css/css3_fonts.asp).
+
+Moodle includes support for plugin or theme fonts. It is very similar to theme images and pix subdirectories.
+
+## Font file locations
+
+Depending on where you intend to use the font put it into one of the following locations:
+
+- `/lib/fonts/` Fonts used in core.
+- `/plugindir/fonts/` Fonts used by plugin.
+- `/theme/sometheme/fonts/` Theme specific fonts.
+
+You can also override core and plugin fonts in theme:
+
+- `/theme/sometheme/fonts_core/` Overridden core fonts.
+- `/theme/sometheme/fonts_plugins/plugintype_pluginname/` Overridden fonts of some plugin.
+
+:::important
+
+- Subdirectories are not allowed.
+- Use only lowercase alphanumeric characters and underscore in font file names.
+- WOFF (Web Open Font Format), TTF (True Type Fonts), OTF (OpenType Fonts), SVG (Scalable Vector Graphic) and EOT (Embedded OpenType) fonts are supported, but it's recommended to use WOFF fonts.
+
+:::
+
+### CSS placeholders
+
+```css title="Use a font in a plugin"
+@font-face {
+    font-family: ThreeDumb;
+    src: url([[font:mod_book|3dumb.woff]]);
+}
+```
+
+The placeholder references file `/mod/book/fonts/3dumb.woff`, the new font face could be for example used for book headings:
+
+```css
+.path-mod-book .book_chapter_title {
+    font-family: ThreeDumb;
+}
+```
+
+If you want to use some font in theme only, you can for example:
+
+```css title="Use a font in theme only"
+@font-face {
+    font-family: goodDogFont;
+    src: url([[font:theme|good_dog.woff]]);
+}
+
+a {font-family:goodDogFont;}
+```
+
+The font would be stored in `/theme/yourtheme/fonts/good_dog.woff` file.
+
+Based on previous example, if you want to use some font stored in `/lib/fonts/` directory, you have to replace `font:theme` by `font:core`.
+
+### More free fonts
+
+Please respect all licenses for font redistribution, you can get some nice free fonts from [http://www.fontsquirrel.com](http://www.fontsquirrel.com) for example.
+
+:::warning
+
+This is not intended for forcing of something like Comic Sans on all your visitors ;-)
+
+:::

--- a/docs/apis/plugintypes/theme/images.md
+++ b/docs/apis/plugintypes/theme/images.md
@@ -1,0 +1,106 @@
+---
+title: Images and icons in themes
+tags:
+  - Plugins
+  - Theme
+  - Images
+  - Icons
+sidebar_position: 2
+sidebar_label: Images and icons
+---
+
+One of the theme features is the ability to override any of the standard images within Moodle when your theme is in use. At this point, let's explore how to utilize your own images within your theme and how to override the images being used by Moodle.
+So first up a bit about images within Moodle:
+
+1. Images you want to use within your theme **must** to be located within your theme's `pix` directory.
+1. You can use sub directories within the `pix` directory of your theme.
+1. Images used by Moodle's core are located within the `pix` directory of Moodle.
+1. All plugins should store their images within their own `pix` directory.
+
+The following section assumes that there are two image files in the `pix` directory of a theme named `yourthemename`:
+
+- `/theme/yourthemename/pix/imageone.svg`
+- `/theme/yourthemename/pix/subdir/imagetwo.png`
+
+The first image is an SVG, and the second a PNG located in a subdirectory.
+
+## Use images in templates
+
+The following example illustrates how to make use of these images within your layout file so they can be inserted in your layout template.
+
+```php title="theme/yourtheme/layout/somelayout.php"
+$templatecontext = [
+    $imageone => $OUTPUT->pix_url('imageone', 'theme'),
+    $imagetwo => $OUTPUT->pix_url('subdir/imagetwo', 'theme'),
+];
+
+echo $OUTPUT->render_from_template('theme_yourtheme/somelayout', $templatecontext);
+```
+
+:::note
+
+A method of Moodle's output library is utilized to generate the URL to the image. It's not too important how that function works, but it is important that it's used, as it's what allows images within Moodle to be overridden.
+
+:::
+
+:::danger Important
+
+**DO NOT** include the image file extension. Moodle will work it out automatically and it will not work if you do include it.
+
+:::
+
+```handlebars title="theme/yourtheme/templates/somelayout.mustache"
+<img src="{{{imageone}}}" alt="Please give your image alt text or set the role to presentation" width="50" height="50">
+<img src="{{{imagetwo}}}" alt="Please give your image alt text or set the role to presentation" width="50" height="50">
+```
+
+## Use images in CSS
+
+The following is how you would use the images from within CSS/SCSS as background images.
+
+```css
+.divone {
+    background-image: url([[pix:theme|imageone]]);
+}
+
+.divtwo {
+    background-image: url([[pix:theme|subdir/imagetwo]]);
+}
+```
+
+A placeholder is used within the CSS  to allow use of a pix icon. During the CSS/SCSS compilation, these placeholders are converted into a URL which the browser can fetch and serve.
+
+:::note
+
+Notice that the image file extension included. The reason for this leads us into the next topic, how to override images.
+
+:::
+
+## Override images
+
+From within a theme you can **very** easily override any standard image within Moodle by simply adding the replacement image to the theme's pix directory in the same sub directory structure as it is in Moodle.
+So, for instance, if there is a need to override the following images:
+
+1. `/pix/moodlelogo.png`
+1. `/pix/i/user.svg`
+1. `/mod/chat/pix/monologo.svg`
+
+Simply add the replacement images to the theme in the following locations:
+
+1. `/theme/themename/pix_core/moodlelogo.png`
+1. `/theme/themename/pix_core/i/user.svg`
+1. `/theme/themename/pix_plugins/mod/chat/monologo.svg`
+
+:::note
+
+A `pix_core` directory has been created in the theme to store the replacement images. For a specific activity module like chat, the directory `pix_plugins/mod/chat` is needed. This directory is `pix_plugins` and then the plugin type (`mod`) and then the plugin name (`chat`).
+
+:::
+
+Another noteworthy aspect is that Moodle not only searches for replacements of the same image type (svg, png, jpg, gif, and so on) but also replacements in any image format. This is why the image file extension was never specified when working with our images above.
+This means that the following would also work:
+
+1. `/theme/themename/pix_core/moodlelogo.svg`
+1. `/theme/themename/pix_core/i/user.jpg`
+
+For a more detailed description of how this all works see the page on [Using images in a theme](https://docs.moodle.org/dev/Using_images_in_a_theme).

--- a/docs/apis/plugintypes/theme/index.md
+++ b/docs/apis/plugintypes/theme/index.md
@@ -1,0 +1,512 @@
+---
+title: Theme plugins
+tags:
+  - Plugins
+  - Theme
+---
+
+A Moodle theme allows users to customize the appearance and functionality of their Moodle site, from overall design to specific activities. Users can create their own themes or modify existing ones, leveraging CSS and JavaScript for customization. The theme architecture ensures smooth fallbacks for minimal changes, fostering flexibility and ease of use.
+
+## File structure
+
+import {
+    Lang,
+    Lib,
+    VersionPHP,
+} from '../../_files';
+
+Theme plugins are located in the `/theme` directory.
+
+Each plugin is in a separate subdirectory and consists of a number of _mandatory files_ and any other files the developer is going to use.
+
+<details>
+  <summary>View an example directory layout for a `theme_example` plugin.</summary>
+
+```console
+ theme/example
+ |-- amd
+ |   └-- src
+ |-- classes
+ |   └-- output
+ |-- fonts
+ |-- fonts_core
+ |-- fonts_plugins
+ |   └-- plugintype
+ |        └-- pluginname
+ |-- lang
+ |   └-- en
+ |       └-- theme_example.php
+ |-- layout
+ |-- pix
+ |   └-- favicon.ico
+ |   └-- screenshot.png
+ |-- pix_plugins
+ |   └-- plugintype
+ |        └-- pluginname
+ |-- style
+ |-- scss
+ |-- templates
+ |-- config.php
+ |-- settings.php
+ └-- version.php
+```
+
+</details>
+
+Some of the important files for the Theme plugintype are described below. See the [common plugin files](../commonfiles) documentation for details of other files which may be useful in your plugin.
+
+:::tip Override icons and templates
+
+You can customize icons in base themes:
+
+1. Without altering core code by placing them in `$CFG->dataroot/pix` and `$CFG->dataroot/pix_plugins`. If a theme extends a base theme and includes its own icons, those will take precedence.
+1. Adding custom icons to a theme by placing them in the theme's `pix_core` and `pix_plugins` directories, as described in the [Override images section](./theme/images#override-images).
+
+:::
+
+Similarly, mustache templates in base themes can be overridden without impacting core code by placing them in `templates/[componentname]/[templatename].mustache`.
+
+### config.php
+
+All theme options are set within the `config.php` file for the theme.
+
+<details>
+  <summary>View basic theme config.php</summary>
+  <div>
+
+```php
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Boost config.
+ *
+ * @package   theme_boost
+ * @copyright 2016 Frédéric Massart
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/lib.php');
+
+$THEME->name = 'boost';
+$THEME->sheets = [];
+$THEME->editor_sheets = [];
+$THEME->editor_scss = ['editor'];
+$THEME->usefallback = true;
+$THEME->scss = function($theme) {
+    return theme_boost_get_main_scss_content($theme);
+};
+
+$THEME->layouts = [
+    // Most backwards compatible layout without the blocks.
+    'base' => array(
+        'file' => 'drawers.php',
+        'regions' => array(),
+    ),
+    // Standard layout with blocks.
+    'standard' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // Main course page.
+    'course' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+        'options' => array('langmenu' => true),
+    ),
+    'coursecategory' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // Part of course, typical for modules - default page layout if $cm specified in require_login().
+    'incourse' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // The site home page.
+    'frontpage' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+        'options' => array('nonavbar' => true),
+    ),
+    // Server administration scripts.
+    'admin' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // My courses page.
+    'mycourses' => array(
+        'file' => 'drawers.php',
+        'regions' => ['side-pre'],
+        'defaultregion' => 'side-pre',
+        'options' => array('nonavbar' => true),
+    ),
+    // My dashboard page.
+    'mydashboard' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+        'options' => array('nonavbar' => true, 'langmenu' => true),
+    ),
+    // My public page.
+    'mypublic' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    'login' => array(
+        'file' => 'login.php',
+        'regions' => array(),
+        'options' => array('langmenu' => true),
+    ),
+
+    // Pages that appear in pop-up windows - no navigation, no blocks, no header and bare activity header.
+    'popup' => array(
+        'file' => 'columns1.php',
+        'regions' => array(),
+        'options' => array(
+            'nofooter' => true,
+            'nonavbar' => true,
+            'activityheader' => [
+                'notitle' => true,
+                'nocompletion' => true,
+                'nodescription' => true
+            ]
+        )
+    ),
+    // No blocks and minimal footer - used for legacy frame layouts only!
+    'frametop' => array(
+        'file' => 'columns1.php',
+        'regions' => array(),
+        'options' => array(
+            'nofooter' => true,
+            'nocoursefooter' => true,
+            'activityheader' => [
+                'nocompletion' => true
+            ]
+        ),
+    ),
+    // Embeded pages, like iframe/object embeded in moodleform - it needs as much space as possible.
+    'embedded' => array(
+        'file' => 'embedded.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // Used during upgrade and install, and for the 'This site is undergoing maintenance' message.
+    // This must not have any blocks, links, or API calls that would lead to database or cache interaction.
+    // Please be extremely careful if you are modifying this layout.
+    'maintenance' => array(
+        'file' => 'maintenance.php',
+        'regions' => array(),
+    ),
+    // Should display the content and basic headers only.
+    'print' => array(
+        'file' => 'columns1.php',
+        'regions' => array(),
+        'options' => array('nofooter' => true, 'nonavbar' => false, 'noactivityheader' => true),
+    ),
+    // The pagelayout used when a redirection is occuring.
+    'redirect' => array(
+        'file' => 'embedded.php',
+        'regions' => array(),
+    ),
+    // The pagelayout used for reports.
+    'report' => array(
+        'file' => 'drawers.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre',
+    ),
+    // The pagelayout used for safebrowser and securewindow.
+    'secure' => array(
+        'file' => 'secure.php',
+        'regions' => array('side-pre'),
+        'defaultregion' => 'side-pre'
+    )
+];
+
+$THEME->parents = [];
+$THEME->enable_dock = false;
+$THEME->extrascsscallback = 'theme_boost_get_extra_scss';
+$THEME->prescsscallback = 'theme_boost_get_pre_scss';
+$THEME->precompiledcsscallback = 'theme_boost_get_precompiled_css';
+$THEME->yuicssmodules = [];
+$THEME->rendererfactory = 'theme_overridden_renderer_factory';
+$THEME->requiredblocks = '';
+$THEME->addblockposition = BLOCK_ADDBLOCK_POSITION_FLATNAV;
+$THEME->iconsystem = \core\output\icon_system::FONTAWESOME;
+$THEME->haseditswitch = true;
+$THEME->usescourseindex = true;
+// By default, all boost theme do not need their titles displayed.
+$THEME->activityheaderconfig = [
+    'notitle' => true
+];
+```
+
+  </div>
+</details>
+
+Everything is added to `$THEME`. This is the theme's configuration object, it is created by Moodle using default settings and is then updated by whatever settings are added to it.
+
+- `$THEME->name`. The theme's name should simply be whatever the theme's name is, most likely whatever the theme directory is named.
+- `$THEME->sheets`. An array containing the names of the CSS stylesheets to include for this theme. Boost uses SCSS instead of CSS so it doesn't list any files here.
+
+:::note
+
+It is just the name of the stylesheet and does not contain the directory or the file extension. Moodle assumes that the theme's stylesheets will be located in the `{theme}/style` directory of the theme and have .css as an extension.
+
+:::
+
+- `$THEME->editorsheets`. An array containing the names of the CSS stylesheets to include for text editor content area. Boost does not list any stylesheets here so text editors will use plain text styles.
+- `$THEME->layouts`. Any of the different layout types can be mapped. For more information see the [layouts section](./theme/layout).
+- `$THEME->parents`. Defines the themes that the theme will extend. Boost has no parents, but if a theme is extending boost, it should be listed it here like:
+
+```php
+$THEME->parents = ['boost'];
+```
+
+- `$THEME->enable_dock`. Boost does not support docking blocks.
+- `$THEME->csstreepostprocessor`. Boost uses a function to post process the CSS. This is an advanced feature and is used in boost to automatically apply vendor prefixes to CSS styles.
+- `$THEME->rendererfactory`. Almost all themes need this setting to be set to `theme_overridden_renderer_factory` or the theme will not be able to customise any core renderers.
+- `$THEME->undeletableblocktypes`. This is a comma separated list of block types that cannot be deleted in this theme. If you don't define this, the admin and settings blocks will be undeletable by default. Because Boost provides alternate ways to navigate it does not require any blocks.
+
+:::tip
+
+When you first begin writing themes, make sure you take a look at the configuration files of the other themes that get shipped with Moodle. You will get a good picture of how everything works, and what is going on in a theme, simply by reading it and taking notice of what it is including or excluding.
+
+:::
+
+Have a look at the following theme options for a complete list of theme options which include lesser used specialised or advanced settings:
+
+<details>
+  <summary>Complete theme options</summary>
+  <div>
+
+#### `$THEME->blockrtlmanipulations`
+
+Allows the theme to manipulate how the blocks are displayed in a *right-to-left* language. Not recommended CSS is automatically flipped for RTL.
+
+#### `$THEME->csspostprocess`
+
+Allows the user to provide the name of a function that all CSS should be passed to before being delivered.
+
+#### `$THEME->csstreepostprocessor`
+
+<Since version="3.2" />
+
+Allows the user to provide the name of a function that can perform manipulations on an in-memory representation of the CSS tree. Some useful manipulations are available such as the `theme_boost\autoprefixer` which will automatically add vendor prefixes to all CSS that requires them.
+
+#### `$THEME->doctype`
+
+The doctype of the served documents.
+
+#### `$THEME->editor_sheets`
+
+An array of stylesheets to include just within the body of the text editors like Tiny. This is required if you want content to resemble its final appearance in the page, while it is being edited in the text editor.
+
+#### `$THEME->enablecourseajax`
+
+If set to false the course AJAX features will be disabled.
+
+#### `$THEME->enable_dock`
+
+If set to true the side dock is enabled for blocks.
+
+#### `$THEME->prescsscallback`
+
+<Since version="3.2" />
+
+The name of a function that will return some SCSS code to inject at the beginning of the SCSS file specified in `$THEME->scss`.
+
+#### `$THEME->extrascsscallback`
+
+<Since version="3.2" />
+
+The name of a function that will return some SCSS code to inject at the end of the SCSS file specified in `$THEME->scss`.
+
+#### `$THEME->hidefromselector`
+
+Used to hide a theme from the theme selector (unless theme designer mode is on). Accepts true or false.
+
+#### `$THEME->javascripts`
+
+<DeprecatedSince version=" " />
+
+An array containing the names of JavaScript files located in `/javascript/` to include in the theme.
+
+:::danger Deprecated
+
+The `$THEME->javascripts` setting should no longer be used. Please use AMD [JavaScript Modules](../../../guides/javascript/modules.md) instead.
+
+:::
+
+#### `$THEME->javascripts_footer`
+
+<DeprecatedSince version=" " />
+
+As above but will be included in the page footer.
+
+:::danger Deprecated
+
+The `$THEME->javascripts_footer` setting should no longer be used. Please use AMD [JavaScript Modules](../../../guides/javascript/modules.md) instead.
+
+:::
+
+#### `$THEME->layouts`
+
+An array setting the layouts for the theme.
+
+#### `$THEME->scss`
+
+<Since version="3.2" />
+
+The name of a SCSS file in the theme's `scss/` folder to compile on the fly. Sheets with the same name will be ignored. This can also be a function which returns SCSS, in which case all import paths will be relative to the scss folder in this theme or any of it's parents.
+
+#### `$THEME->name`
+
+Name of the theme. Most likely the name of the directory in which this file resides.
+
+#### `$THEME->parents`
+
+An array of themes to inherit from. If the theme you inherit from inherits from a parent as well, you need to indicate the grandparent here too.
+
+#### `$THEME->parents_exclude_javascripts`
+
+An array of JavaScript files NOT to inherit from the themes parents.
+
+#### `$THEME->parents_exclude_sheets`
+
+An array of stylesheets NOT to inherit from the themes parents.
+
+#### `$THEME->plugins_exclude_sheets`
+
+An array of plugin sheets to ignore and NOT include.
+
+#### `$THEME->renderfactory`
+
+Sets a custom render factory to use with the theme, used when working with custom renderers. You most likely want this set to `theme_overridden_renderer_factory`.
+
+#### `$THEME->sheets`
+
+An array of stylesheets to include for this theme. Should be located in the theme's style directory. Not required if using SCSS.
+
+#### `$THEME->yuicssmodules`
+
+Old setting to define a list of YUI CSS modules to be included. These files interfere with existing styles and it is recommended to set this to an empty string to prevent any files being included.
+
+:::danger Attention
+
+This setting should probably be set to `''` to prevent and YUI CSS being included.
+
+:::
+
+#### `$THEME->undeletableblocktypes`
+
+An array of block types that must exist on all pages in this theme or this theme will be unusable. If a block type listed here is missing when a page is loaded. It will be auto-created (but only shown for themes that require it).
+
+#### `$THEME->addblockposition`
+
+Either `BLOCK_ADDBLOCK_POSITION_FLATNAV`, `BLOCK_ADDBLOCK_POSITION_DEFAULT` or `BLOCK_ADDBLOCK_POSITION_CUSTOM`. Defines where to put the "Add a block" controls when editing is enabled.
+
+  </div>
+</details>
+
+<!-- cspell:ignore themename -->
+
+### lang/en/themename.php
+
+import langExample from '!!raw-loader!./_examples/lang.php';
+import langDescription from './_examples/lang.md';
+
+<Lang
+    plugintype="theme"
+    pluginname="boost"
+    example={langExample}
+    description={langDescription}
+/>
+
+### version.php
+
+<VersionPHP
+    plugintype="theme"
+/>
+
+## Insights
+
+### Getting your theme to appear correctly in theme selector
+
+If you follow the examples on this page to the letter, when you go to the `Theme Selector` page you may be discouraged to find that your theme does not appear like the other themes do. In fact, instead of your theme's name, you will see something along the lines of `[pluginname](https://docs.moodle.org/dev/pluginname)`.
+
+To correct this, you must add the `theme/THEMENAME/lang/en/theme_THEMENAME.php` file, where `THEMENAME` is the name of the theme folder. Inside that file, add the string `$string[]('pluginname') = 'THEMENAME';`. Make `THEMENAME` the name of your theme, however you want it displayed in the Theme selector.
+
+Also, make sure to change your [`config.php`](#configphp) file and [`version.php`](#versionphp) file to reflect the correct name:
+
+```php title="config.php"
+
+$THEME->name = 'NAME';
+
+```
+
+```php title="version.php"
+
+$plugin->component = 'THEMENAME'; // Full name of the plugin (used for diagnostics)
+
+```
+
+The `screenshot` for the theme should be about `500 x 400 px`.
+
+### Required theme `divs`
+
+Some parts of Moodle may rely on particular `divs`, for example the div with id `page-header`. Consequently all themes must include at least the `divs` (with the same ids) that are present in the `boost` theme.
+
+Missing out these elements may result in unexpected behaviour within specific modules or other plugins.
+
+## Caching
+
+When Moodle is not running in theme designer mode it will look for a cached version of the compiled CSS for the current theme to serve to the browser requesting the page. If the cached file doesn't yet exist then the CSS will be built and cached during the page request.
+
+The cached CSS is located on disk in Moodle's local cache:
+
+```
+ <moodledata>/localcache/theme/<global_theme_revision>/<theme_name>/css/all_<theme subrevision>.css
+```
+
+The cache path consists of a global theme revision (`themerev` config value) and a per theme sub-revision (`themesubrev` plugin config value). If either of those are incremented it will change the path to the cache file and cause a new file to be generated.
+
+Individual theme's CSS cache can be built by using the admin CLI script:
+
+```bash
+  php admin/cli/build_theme_css.php --themes boost
+```
+
+The script will only increment the theme sub-revision of the theme(s) being built which means existing theme cache's remain untouched.
+
+## See also
+
+<!-- cspell:ignore HRDNZ -->
+
+- MoodleAcademy courses. For instance:
+  - [Moodle Page Layout and Site Navigation](https://moodle.academy/course/view.php?id=110)
+  - [Accessible Development Practices](https://moodle.academy/course/view.php?id=54)
+
+- MoodleBites Theme Design. Completely online courses [Level 1](https://www.moodlebites.com/mod/page/view.php?id=3208) and [Level 2](https://www.moodlebites.com/mod/page/view.php?id=3210) are designed to assist Moodle administrators, designers, and developers get up-to-speed with Moodle Theme design, and are run by [HRDNZ](https://www.hrdnz.com) (Certified Moodle Partner since 2006).

--- a/docs/apis/plugintypes/theme/layout.md
+++ b/docs/apis/plugintypes/theme/layout.md
@@ -1,0 +1,330 @@
+---
+title: Layout
+tags:
+  - Plugins
+  - Theme
+  - Layout
+sidebar_position: 1
+---
+
+All themes are required to define the layouts they wish to be responsible for as well as create; however, many layout files are required by those layouts. If the theme is overriding another theme then it is a case of deciding which layouts this new theme should override. If the theme is a completely fresh start then you will need to define a layout for each of the different possibilities.
+
+:::tip
+
+Note that a new theme that will base itself on another theme (overriding it) does not need to define any layouts or use any layout files if there are no changes that it wishes to make to the layouts of the existing theme.
+
+:::
+
+Layouts are defined in [`config.php`](../theme#configphp) within `$THEME->layouts`.
+
+The following is an example of one such layout definition:
+<details>
+  <summary>View example of one layout definition in config.php</summary>
+  <div>
+
+```php
+$THEME->layouts = [
+    // Standard layout with blocks, this is recommended for most pages with general information
+    'standard' => [
+        'theme' => 'boost',
+        'file' => 'columns2.php',
+        'regions' => ['side-pre'],
+        'defaultregion' => 'side-pre',
+    ],
+],
+```
+
+  </div>
+</details>
+
+The first thing Moodle looks at is the name of the layout, in this case it is `standard` (the array key in PHP), it then looks at the settings for the layout, this is the theme, file, regions, and default region. There are also a couple of other options that can be set by a layout:
+
+- `theme` [ *Optional* ]. Is the theme the layout file exists in. That's right: you can make use of layouts from other installed themes.
+- `file` [ *Required* ]. Is the name of the layout file this layout wants to use.
+- `regions` [ *Required* ]. Is the different block regions (places you can put blocks) within the theme.
+- `defaultregion` [ *Required if regions is non-empty, otherwise optional* ]. Is the default location when adding new blocks.
+- `options` [ *Optional* ]. An array of layout specific options described in detail below.
+
+The **theme** is optional. Normally the layout file is looked for in the current theme, or, if it is not there, in the parent theme. However, you can use a layout file from any other theme by giving the theme name here.
+
+You can define whatever regions you like. You just need to pick a name for each one. Most themes just use one or both of `side_pre` and `side_post`, which is like 'left side' and 'right side', except in right to left languages, when they are reversed. If you say in [`config.php`](../theme#configphp) that your the layout provides regions called `fred` and `barney`, then you must call `$OUTPUT->blocks_for_region('fred')` and `$OUTPUT->blocks_for_region('barney')` somewhere in the layout file.
+
+The final setting **options** is a special case that only needs to be set if you want to make use of it. This setting allows the theme designer to specify special options that they would like to create that can be later accessed within the layout file. This allows the theme to make design decisions during the definition and react upon those decisions in what ever layout file is being used.
+
+One such place this has been used is within the boost theme. If you take a look first at `theme/boost/config.php` you will notice that several layouts specify options `langmenu` and `nonavbar` which can both be set to either true or false. The layout options can then be used on the `layout .php` files, mustache templates and renderers.
+
+```php
+<?php
+$hasnavbar = (empty($PAGE->layout_options['nonavbar']) && $PAGE->has_navbar());
+$hasfooter = (empty($PAGE->layout_options['nofooter']));
+```
+
+## Layout files
+
+Layout files are used to provide a different layout of the elements of the page for different types of pages in Moodle.
+
+In the [`config.php`](../theme#configphp) for a theme there is a list of **layouts** which map a page type to a specific PHP page in the layout folder for the theme.
+
+<details>
+  <summary>View example of layout definition for popup</summary>
+  <div>
+
+```php title="theme/boost/config.php"
+    'popup' => [
+        'file' => 'columns1.php',
+        'regions' => [],
+        'options' => ['nofooter' => true, 'nonavbar' => true],
+    ],
+```
+
+This example means every page that has pagetype `popup` will be displayed with the `theme/themename/layout/columns1.php` file, it will have no block regions and there are some options that will be available to the page in the global variable `$PAGE->layout_options`.
+
+  </div>
+</details>
+
+:::tip
+
+It is possible to implement a layout file directly in PHP by echoing the HTML for the page, or mixing PHP tags with HTML, but a better way to create a layout file is to gather all the information required for the layout into a context and render it with a mustache template.
+
+Using templates for layout files makes a lot of sense because they are easier to read and maintain than mixing PHP and HTML in the same file.
+
+[Read about mustache templates](../../../guides/templates/index.md)
+
+:::
+
+<details>
+  <summary>View example of a layout file using a template</summary>
+  <div>
+
+```php title="theme/boost/layout/columns1.php"
+<?php
+
+$bodyattributes = $OUTPUT->body_attributes([]);
+
+$templatecontext = [
+    'sitename' => format_string($SITE->shortname, true, ['context' => context_course::instance(SITEID), "escape" => false]),
+    'output' => $OUTPUT,
+    'bodyattributes' => $bodyattributes
+];
+
+echo $OUTPUT->render_from_template('theme_boost/columns1', $templatecontext);
+```
+
+This example puts some variables into a `templatecontext` and then calls `render_from_template` to render the mustache template for this layout. The template is located at `theme/boost/templates/columns1.mustache`.
+It is possible to put PHP classes in the context for the mustache template and any public properties or methods which accept no arguments will be available to the template. `$OUTPUT` has several useful public methods which accept no arguments and is a valuable class when creating a layout template in mustache.
+
+  </div>
+</details>
+
+<details>
+  <summary>View example of the mustache template for the previous layout</summary>
+  <div>
+
+```handlebars title="theme/boost/templates/columns1.mustache"
+{{{ output.doctype }}}
+<html {{{ output.htmlattributes }}}>
+<head>
+    <title>{{{ output.page_title }}}</title>
+    <link rel="shortcut icon" href="{{{ output.favicon }}}" />
+    {{{ output.standard_head_html }}}
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+
+<body {{{ bodyattributes }}}>
+
+<div id="page-wrapper">
+
+    {{{ output.standard_top_of_body_html }}}
+
+    <div id="page" class="container-fluid">
+        <div id="page-content" class="row">
+            <div id="region-main-box" class="col-xs-12">
+                <section id="region-main">
+                    <div class="card card-block">
+                    {{{ output.course_content_header }}}
+                    {{{ output.main_content }}}
+                    {{{ output.course_content_footer }}}
+                    </div>
+                </section>
+            </div>
+        </div>
+    </div>
+</div>
+{{{ output.standard_end_of_body_html }}}
+</body>
+</html>
+{{#js}}
+require(['theme_boost/loader']);
+{{/js}}
+```
+
+Explaining each line of this template will answer a lot of questions. This example contains only the very minimal required functions to generate a valid layout. You should consider all of the sections below as required in every layout file (although any of the HTML tags can and should be altered).
+
+- Calling a function on `$OUTPUT` in `PHP`. Because there is a public method on the output class named `doctype` which accepts no arguments, mustache will call it and return the output. A function to generate the `doctype` tag is called because calling this function returns the correct HTML for the document type for this theme AND it sets a different content type header (including the charset) depending on the doc type for the theme. Setting a correct charset in every page is important to prevent a class of XSS attacks.
+
+```handlebars
+{{{ output.doctype }}}
+```
+
+- The root tag, the HTML tag, has been reintroduced. A set of default attributes for the page has been included by invoking the `htmlattributes` function of the output class. This encompasses the appropriate language attribute for the entire page and potentially an XML namespace for XHTML documents.
+
+```handlebars
+<html {{{ output.htmlattributes }}}>
+```
+
+- The head section of the document has been initiated, and the title for the page has been set. Note that the title is already escaped by the output class, so triple mustache tags `{{{` are being used to prevent double escaping.
+
+```handlebars
+<head>
+    <title>{{{ output.page_title }}}</title>
+```
+
+- A function is called to obtain the URL to the favicon. The favicon resides in the theme pix directory and is served through the `theme/image.php` file, which adds special caching headers for images.
+
+```handlebars
+    <link rel="shortcut icon" href="{{{ output.favicon }}}" />
+```
+
+- The standard head HTML function handles a significant amount of necessary setup for our page. It internally creates the block regions, generates meta tags including keywords for SEO, initializes common JavaScript modules, generates links to the style sheets, and injects any additional HTML set by the `$CFG->additionalhtmlhead` setting.
+
+```handlebars
+    {{{ output.standard_head_html }}}
+```
+
+- This `viewport` meta tag is recommended by bootstrap for "proper viewport rendering and touch zooming".
+
+```handlebars
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+```
+
+- The body attributes include the language direction and standard classes for the page.
+
+```handlebars
+<body {{{ bodyattributes }}}>
+
+```
+
+- In the Boost theme, a `page-wrapper` div is utilized to prevent content from disappearing under the fixed header.
+
+```handlebars
+<div id="page-wrapper">
+```
+
+- The `standard_top_of_body_html` should be included in every layout and includes skip links for accessibility as well as initialising JQuery, YUI and own static JavaScript files.
+
+```handlebars
+    {{{ output.standard_top_of_body_html }}}
+```
+
+- This is standard HTML tags defining the content region for this page. The classes come from Bootstrap 4.
+
+```handlebars
+    <div id="page" class="container-fluid">
+        <div id="page-content" class="row">
+            <div id="region-main-box" class="col-xs-12">
+                <section id="region-main">
+                    <div class="card card-block">
+```
+
+- The course content header allows Moodle plugins to inject things in the top of the page. This is used for "notifications" for example (which are the alert boxes you see after submitting a form).
+
+```handlebars
+                    {{{ output.course_content_header }}}
+```
+
+- The main content function returns the real content for the page.
+
+```handlebars
+                    {{{ output.main_content }}}
+```
+
+- The course content footer is used mainly by course formats to insert things after the main content.
+
+```handlebars
+                    {{{ output.course_content_footer }}}
+```
+
+- Close all the open tags.
+
+```handlebars
+</div>
+                </section>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+- This function will add all of the JavaScript that was required while rendering the page. JavaScript is added at the end of the document so that it does not block rendering the page.
+
+```handlebars
+{{{ output.standard_end_of_body_html }}}
+```
+
+- Finish the HTML for the page.
+
+```handlebars
+</body>
+</html>
+```
+
+- The final section is required for Bootstrap 4 themes and loads all the Bootstrap 4 JavaScript dependencies.
+
+```handlebars
+{{#js}}
+require(['theme_boost/loader']);
+{{/js}}
+```
+
+  </div>
+</details>
+
+If we had block regions in this layout we would need to insert them in the template. The way we would do this is by getting the HTML for the block region in our layout PHP file, adding it to the context and then including it in our template.
+
+```php title="theme/boost/layout/columns2.php"
+$blockshtml = $OUTPUT->blocks('side-pre');
+$hasblocks = strpos($blockshtml, 'data-block=') !== false;
+...
+$templatecontext = [
+...
+    'sidepreblocks' => $blockshtml,
+    'hasblocks' => $hasblocks,
+...
+];
+echo $OUTPUT->render_from_template('theme_boost/columns2', $templatecontext);
+```
+
+```handlebars title="theme/boost/templates/columns2.mustache"
+    {{#hasblocks}}
+    <section data-region="blocks-column" class="hidden-print">
+        {{{ sidepreblocks }}}
+    </section>
+    {{/hasblocks}}
+```
+
+When writing layout files, consider the variations in layouts and how the HTML utilized in each may differ. It is often unnecessary to create a distinct layout file for every layout; instead, existing layout files can often be reused across multiple layouts. Additionally, employing layout options can further minimize the need for creating additional layout files.
+
+It's important to note again that when customizing an existing theme, the creation of layouts or layout files may not be necessary.
+
+## Layout types
+
+- `base`. Most backwards compatible layout without the blocks. This is the layout used by default.
+- `standard`. Standard layout with blocks. This is recommended for most pages with general information.
+- `course`. Main course page.
+- `coursecategory`. Use for browsing through course categories.
+- `incourse`. Default layout while browsing a course, typical for modules.
+- `frontpage`. The site home page.
+- `admin`. Administration pages and scripts.
+- `mycourses`. My courses page.
+- `mydashboard`. My dashboard page.
+- `mypublic`. My public page.
+- `login`. The login page.
+- `popup`. Pages that appear in pop-up windows (no navigation, no blocks, no header).
+- `frametop`. Used for legacy frame layouts only. No blocks and minimal footer.
+- `embedded`. Used for embedded pages, like iframe/object embedded in moodleform. It needs as much space as possible.
+- `maintenance`. Used during upgrade and install. This must not have any blocks, and it is a good idea if it does not have links to other places. For example there should not be a home link in the footer.
+- `print`. Used when the page is being displayed specifically for printing.
+- `redirect`. Used when a redirection is occurring.
+- `report`. Used for reports.
+- `secure`. Used for `safebrowser` and `securewindow`.

--- a/docs/apis/plugintypes/theme/styles.md
+++ b/docs/apis/plugintypes/theme/styles.md
@@ -1,0 +1,136 @@
+---
+title: Styles
+tags:
+  - Plugins
+  - Theme
+  - Styles
+sidebar_position: 4
+---
+
+Let's begin by exploring the various locations within Moodle from which CSS can be included:
+
+- `\theme\themename\style\*.css`. This is the default location for all of the stylesheets that are used by a theme and the place which should be used by a theme designer if this theme is using CSS. Alternative to CSS is SCSS which is more powerful, flexible and easier to maintain.<br/>
+New theme developers should note that the order in which CSS files are found and included creates a hierarchy.  This order ensures that the rules, within a theme's style sheets, take precedence over identical rules in other files that may have been introduced before.  This can both extend another files definitions (see parent array in the config file) and also ensures that the current theme's CSS rules/definitions have the last say.<br/>
+There are other locations that can be used (although very rarely) to include CSS in a page. A developer of a php file can manually specify a stylesheet from anywhere within Moodle, like the database. Usually, if code is doing this, it is because there is a non-theme config or plugin setting that contains information requires special CSS information.  As a theme designer you should be aware of, but not have to worry about, these locations of CSS files.  Here are some examples:
+- `{pluginpath}\styles.css` (for instance, `\block\blockname\styles.css` or `\mod\modname\styles.css`). Every plugin can have its own styles.css file. This file should only contain the required CSS rules for the module and should not add anything to the look of the plugin such as colours, font sizes, or margins other than those that are truly required.<br />Theme specific styles for a plugin should be located within the themes styles directory.
+- `{pluginpath}\styles_themename.css`. This should only ever be used by plugin developers. It allows them to write CSS that is designed for a specific theme without having to make changes to that theme. You will notice that this is never used within Moodle and is designed to be used only by contributed code.
+
+:::tip
+
+As theme designers, only the first method of introducing CSS will be used: adding rules to a stylesheet file located in the theme's style directory.
+
+:::
+
+## CSS pre-processors
+
+Browsers understand CSS well, but it is hard to write and maintain. The language does not support inheritance and reuse. [Support for variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_variables) exists in more modern browsers only.  This is why CSS pre-processors were invented. Moodle supports SASS, which is recommended by far.
+
+:::info Information
+
+To use SASS, define `$THEME->scss = 'filename';` in your themes `config.php`. Moodle will then use one of it's in-built CSS pre-processor to compile the CSS the first time it is loaded (or every time if `themedesignermode` is enabled in `$CFG`).
+
+For more information see: [SASS (wikipedia)](https://en.wikipedia.org/wiki/Sass_(stylesheet_language))
+
+:::
+
+## Core CSS organisation
+
+None of the themes provided in the standard install by Moodle use CSS stylesheets directly. Instead they use either SCSS to generate the style sheets. They all list one main SCSS file named `moodle` or scss folders and this file uses imports to load all other required files.
+
+:::note
+
+As a theme designer, it is entirely up to you how you create and organize your CSS and the rules you create.
+
+:::
+
+## How to write effective CSS rules within Moodle
+
+:::warning Important
+
+Writing good CSS rules is incredibly important.
+
+:::
+
+Due to performance requirements and browser limitations, all of the CSS files are combined into a single CSS file that gets included every time. This means that rules need to be written in such a way as to minimise the chances of a collision leading to unwanted styles being applied. Whilst writing good CSS is something most designers strive for we have implemented several new body classes and prompt developers to use appropriate classnames.
+
+### \<body\> CSS id and classes
+
+The `ID` tag that gets applied to the body will always be a representation of the URI. For example if you are looking at a forum posting and the URI is `/mod/forum/view.php` then the body tags `ID` will be `#page-mod-forum-view`.
+
+As well as the body's ID attribute the URI is also exploded to form several CSS classes that get added to the body tag, so in the above example `/mod/forum/view` you would end up with the following classes being added to the body tag: `.path-mod` and `.path-mod-forum`.
+
+:::note
+
+`.path-mod-forum-view` is not added as a class, this is intentionally left out to lessen confusion and duplication as rules can relate directly to the page by using the ID and do not require the final class.
+
+:::
+
+The body ID and body classes described above will form the bread and butter for many of the CSS rules you will need to write for your theme, however there are also several other very handy classes that get added to the body tag that will be beneficial to you once you start your journey down the rabbit hole that is theming. Some of the more interesting classes are listed below.
+
+- If JavaScript is enabled then `jsenabled` will be added as a class to the body tag allowing you to style based on JavaScript being enabled or not.
+- Either `dir-rtl` or `dir-ltr` will be added to the body as a class depending on the direction of the language pack. This allows you to determine your text-alignment based on language if required:
+  - `rtl` = right to left
+  - `ltr` = left to right.
+- A class will be added to represent the language pack currently in use, by default `en_utf8` is used by Moodle and will result in the class `lang-en_utf8` being added to the body tag.
+- The `wwwroot` for Moodle will also be converted to a class and added to the body tag allowing you to stylise your theme based on the URL through which it was reached. For example, `http://sam.moodle.local/moodle/` will become `.sam-moodle-local—moodle`.
+- If the current user is not logged then `.notloggedin` will be added to the body tag.
+- The course format type will be added such as `format-weeks`.
+- The course id, context id and category id are all added as in `course-11 context-616 cmid-202 category-1`.
+- The `pagelayout` is added as `pagelayout-incourse`.
+
+:::info What does all of this look like in practise?
+
+Using the above example `/mod/forum/view.php` this will be the body tag:
+
+```html
+<body
+    id="page-mod-forum-view"
+    class="format-weeks forumtype-social
+        path-mod path-mod-forum safari dir-ltr lang-en yui-skin-sam yui3-skin-sam
+        sam-moodle-local—moodle
+        pagelayout-incourse
+        course-11 context-616 cmid-202 category-1
+        jsenabled" >
+```
+
+:::
+
+### Writing your rules
+
+By following the [CSS coding style](https://docs.moodle.org/dev/CSS_coding_style) and CSS best-practices and understanding the [cascading order](http://htmlhelp.com/reference/css/structure.html#cascade) of CSS a theme developer will reduce collisions and lines of CSS that is written. CSS classes have been placed where it is believed anyone may want to apply their own styles.
+
+When starting to write rules make sure that you have a good understanding of where you want those rules to be applied, it is a good idea to make the most of the body classes mentioned above.
+
+- If you want to write a rule for a specific page make use of the body tag's ID:
+
+```css
+    #page-mod-forum-view .forumpost {
+    border: 1px solid blue;
+}
+```
+
+- If you want to write a rule that will be applied all throughout the forum:
+
+```css
+.path-mod-forum .forumpost {
+    border: 1px solid blue;
+}
+```
+
+The other very important thing to take into consideration is the structure leading up to the tag you want to style. Browsers apply conflicting styles with priority on the more specific selectors. It can be very beneficial to keep this in mind and write full selectors that rely on the structure of the tags leading to the tag you wish to style.
+
+By making use of body id's and classes and writing selectors to take into account the leading structure you can greatly minimise the chance of a collision both with Moodle now and in the future.
+
+:::tip
+
+It is also important to **write as FEW rules as possible**. CSS is extremely hard to maintain and lots of CSS is bad for client side performance.
+
+:::
+
+Themes based on the Bootstrap CSS framework can achieve most things without writing a single additional CSS rule. Please read [Bootstrap 4](https://getbootstrap.com/docs/4.0/getting-started/introduction/ the Bootstrap documentation) and learn how to use Bootstrap well to avoid adding unnecessary CSS rules for things already provided by the framework.
+
+## Compiling SCSS on the fly
+
+<Since version="3.2" />
+
+You can provide a SCSS file that will be compiled (and cached) on the fly. The purpose of this feature is to dynamically allow the customisation of SCSS variables. See the [dedicated page on SCSS](https://docs.moodle.org/dev/SCSS).


### PR DESCRIPTION
For now, I'll start migrating the content in https://docs.moodle.org/dev/Themes_overview and then I'll improve the content, adding information from other pages in the Theme section, like https://docs.moodle.org/dev/Using_images_in_a_theme#Image_locations_within_Moodle