### PR TITLE
reorder testing credits list showing recent release first

### DIFF
--- a/general/community/credits/testing.md
+++ b/general/community/credits/testing.md
@@ -10,117 +10,117 @@ tags:
 
 The following people have helped with [Quality Assurance (QA) testing](../../development/process/testing/qa):
 
-## Moodle 2.0 QA Cycle 1
+## Moodle 4.4 QA
 
-Andrea Bicciolo, Ashley Blakeston, Anthony Borrow, Stephen Bourget, Mónico Briseño Cortés, Chris Collman, Mary Cooch, Emanuel Delgado, Debra Dotson, Buddy Ethridge, Teresa Gibbison, Amy Groshek, Elena Ivanova, Matt Jenner, Brent Lee, Nicolas Martignoni, Colin Matheson, Mark McCall, Chad Outten, Joseph Rézeau, Michael Spall, Joseph Thibault, Jon Witts
-
-## Moodle 2.0 QA Cycle 2
-
-Jes Ackland-Snow, Andrea Bicciolo, Ashley Blakeston, Anthony Borrow, Mónico Briseño Cortés, James Brisland, Alan Peter Carter, Colin Chambers, Chris Collman, Emanuel Delgado, Debra Dotson, Anthony Forth, Helen Foster, Teresa Gibbison, Elena Ivanova, Mahmoud Kassaei, Tomaz Lasic, Sam Marshall, Nicolas Martignoni, Colin Matheson, David Mudrak, Chad Outten, Pierre Pichet, Jason Platts, Joseph Rézeau, Alan Thompson, Bryan Waddington, Derek Woolhead
-
-## Moodle 2.1 QA
-
-Glenn Ansley, Aparup Banerjee, Melissa Benson, Anthony Borrow, Stephen Bourget, Lynn Clark, Mary Cooch, Andrew Davis, Sue Demoor, Michael de Raadt, Debra Dotson, Moronke Fajobi, Jean-Marc Ferring, Teresa Gibbison, Marina Glancy, Stephan Green, Tzu-Chiao Hung, Andre Kruger, Brent Lee, Colin Matheson, Mark McCall, David Mudrak, Chad Outten, Vinit Prajapati, Joseph Rézeau, Adam Sanders, Lesli Smith, Javier Sola, Erin Sorensen, Michael Spall, Kristian Still, Rajesh Taneja, Paul Tosney, Steve Turley, Jon Witts, Massimo Zunino
-
-## Moodle 2.2 QA
-
-Adrian Greeve, Andrea Bicciolo, Andrew Davis, Andrew Nicols, Ankit Agarwal, Anthony Borrow, Aparup Banerjee, Charles Fulton, Colin Campbell, gavin henrick, Jason Fowler, JM Ferring, Joan Tracy, Joseph Rézeau, Marina Glancy, Martin Dougiamas, Mary Cooch, Mayank Gupta, Michael de Raadt, Nadav Kavalerchik, Nicolas Martignoni, Paul Tosney, Rossiani Wijaya, Sam Stegers, Stephen Bourget, Teresa Gibbison
-
-## Moodle 2.3 QA
-
-Adam Pawelczak, Adrian Greeve, Andrea Bicciolo, Andrew Davis, Ankit Agarwal, Aparup Banerjee, Bas Brands, Ben Reynolds, Bente Olsen, Brent Lee, Carly J Born, Chad Outten, Charles Fulton, Dan Poltawski, Drew Blessing, Frédéric Massart, Frederic Nevers, Heinrich, Ivana Bosnic, James Cracknell, Jasmin Klindzic, Jason Fowler, Javier Sola Aréchaga, Joseph Rézeau, Keith Dingley, Kingsley Udeh, Klaus Steitz, Lesli Smith, Lynn Clark, Michael de Raadt, Mitja Podreka, Nicolas Martignoni, Paul Tosney, Rajesh Taneja, Rex Lorenzo, Rossiani Wijaya, Stephen Bourget, Ted van den Brink, Teresa Gibbison, Tim Barker
-
-## Moodle 2.4 QA
-
-Ankit Agarwal, Javier Sola Aréchaga, Lehane Boonzaaier, Anthony Borrow, Ivana Bosnic, Federico Botti, Stephen Bourget, Mike Churchward, Mary Cooch, Mónico Briseño Cortés, Andrew Davis, Michael de Raadt, Joost Elshoff, Justin Filip, Helen Foster, Jason Fowler, Charles Fulton, Adrian Greeve, Karl Goddard, Jasmin Klindzic, Nicolas Martignoni, David Monllaó, Mark Nelson, Richard Oelmann, Bente Olsen, Chad Outten, Dan Poltawski, AL Rachels, Dan Rapoza, Joseph Rézeau, Peter Roberts, Michael Spall, Graham Stone, Rajesh Taneja, Mitchell van Gerwen, Damyon Wiese, Rossiani Wijaya, Kevin Wiliarty
-
-## Moodle 2.5 QA
-
-Adrian Greeve, Alan Hald, AL Rachels, Andrea Bicciolo, Andrew Davis, Ankit Agarwal, Anthony Borrow, Ben Reynolds, Chad Outten, Dan Poltawski, David Monllaó, David Perry, Don Schwartz, Farhan Karmali, Fernando Navarro Paez, Frédéric Massart, Graham Stone, Helen Foster, Iain Gray, Ivana Bosnic, Jasmin Klindzic, Jaswinder Singh, Javier Sola Aréchaga, Jayesh Anandani, Joost Elshoff, Karl Goddard, Kevin Wiliarty, Leah Hemeon, Lindy Klein, Lynn Hadfield, Mark Nelson, Mary Evans, Michael de Raadt, Mónico Briseño Cortés, Nadav Kavalerchik, Nicolas Martignoni, Nikunj Thakkar, Prateek Sachan, Richard Oelmann, Sakshi Goel, Sam Stegers, Sandareka Wickramanayake, Séverin Terrier, Stephen Bourget
-
-## Moodle 2.6 QA
-
-Adrian Greeve, AL Rachels, Andrea Bicciolo, Ankit Agarwal, Carina Martinez, Chad Outten, Dan Poltawski, David Monllaó, Eloy Lafuente (stronk7), Farhan Karmali, Fernando Rocha, Frédéric Massart, Guillermo M., Hittesh, Jasmin Klindzic, Javier Sola Aréchaga, Joe Murphy, Joseph Rézeau, Kevin Wiliarty, Lehane Boonzaaier, Lisa Caines, Mary Cooch, Michael de Raadt, Michael E, Mitchell van Gerwen, Natalia Giovagnetti, Nicolas Martignoni, Rajesh Taneja, Rossiani Wijaya, Sakshi Goel, Sam Stegers, Séverin Terrier, Stephen Bourget
-
-## Moodle 2.7 QA
-
-Adrian Greeve, Adrián J. Troncoso, AL Rachels, Andrea Bicciolo, Andrew Davis, Andrew Nicols, Ankit Agarwal, Chad Outten, Dan Bennett, Daniel Thies, Dan Poltawski, David Appleyard, Fernando Acedo, Frédéric Massart, Graham Stone, Hittesh Ahuja, Hugo Schouppe, Jasmin Klindzic, Jason Fowler, Jayesh Anandani, Jean-Marc Doucet, Jetha Chan, John Okely, Joshua Bragg, Kevin Wiliarty, Kieran Briggs, Lehane Boonzaaier, Lisa Caines, Luca Testoni, Mary Cooch, Mary Evans, Michael de Raadt, Michael E, Miraj Koradiya, Mitchell van Gerwen, Nadav Kavalerchik, nayan, Nicolas Martignoni, Prathibha B, Rajesh Taneja, Richard Oelmann, Sakshi Goel, Sam Hemelryk, Sam Stegers, Séverin Terrier, Simey Lameze, Stephanie Gerald, Stephen Bourget
-
-## Moodle 2.8 QA
-
-Adrian Greeve, AL Rachels, Andrea Bicciolo, Andrew Nicols, Ankit Agarwal, Anthony Borrow, Ben Reynolds, Bob Puffer, Brett Deaton, Clay Burell, Colin Matheson, Dave Cooper, Eric Yullu, Farhan Karmali, Frédéric Massart, Graham Stone, Guillermo Madero, Jackie Toth, Jasmin Klindzic, Jayesh Anandani, Jean-Marc Doucet, Jetha Chan, John Okely, Joseph Rézeau, Joseph Thibault, Juan Leyva, Kevin Wiliarty, Marina Glancy, Mark Nelson, Mesfin Teshome, Michael de Raadt, Mihai Bojonca, Miraj Koradiya, Mitchell van Gerwen, Nicolas Martignoni, Raúl Martínez, Sakshi Goel, Sam Hemelryk, Séverin Terrier, Shashikant Vaishnav, Simey Lameze,  Stephen Bourget, Steve James, Teresa Gibbison, Vanessa Cleary, Willy Lee, Yash Barot, Zachary Durber
-
-## Moodle 2.9 QA
-
-AL Rachels, Ankit Agarwal, Ben Reynolds, Brett Deaton, Chad Outten, Charles Fulton, Damyon Wiese, Daniel Thies, Dan Marsden, Dave Cooper, eric yullu, Fernando Acedo, Fernando Rocha, Frédéric Massart, Graham Stone, Greg Faller, Ivana Bosnic, Jasmin Klindzic, Jaswinder Singh, Jean-Marc Doucet, Jetha Chan, John Okely, Kevin Wiliarty, Lehane van der Merwe, Lisa Caines, Luiggi Sansonetti, Marina Glancy, Martin Mastny, Mary Cooch, Michael E, Michael Spall, Nicolas Martignoni, Pete Potter, Rajesh Taneja, Raúl Martínez, Sakshi Goel, Séverin Terrier, Simey Lameze, Stephen Bourget
-
-## Moodle 3.0 QA
-
-Adrian Greeve, AL Rachels, Arindam Ghosh,  Bas Brands, Ben Reynolds, Cameron Ball, Chad Outten, Dag Klimas, David Monllaó, Dominique-Alain Jan, Dr. Indira Koneru, eric yullu, Farhan Karmali, Fernando Acedo, Gemma Lesterhuis, German Valero, Ivana Bosnic, James Hamilton, Jasmin Klindzic, Jeff Webster, John Okely, Jun Pataleta, Ketan Chandaria, Kevin Wiliarty, Lisa Caines, Luiggi Sansonetti, Mary Evans, Michael de Raadt, nayan, Nicolas Martignoni, Paul Nicholls, Rajesh Taneja, Richard Oelmann, Ryan Wyllie, Sandeep Kankatala, Séverin Terrier, Simey Lameze, Slawomir Grefling, Stephanie Gerald, Stephen Bourget, Trish Zagarella, Vinit Prajapati
-
-## Moodle 3.1 QA
-
-AL Rachels, Ben Reynolds, Cameron Ball, Dag Klimas, Dan Poltawski, Dominique-Alain Jan, Dr. Indira Koneru, Eduardo Rodrigues, eric yullu, Farhan Karmali, Fernando Acedo, Frédéric Massart, German Valero, Graham Stone, Himanshi Bhardwaj, Jake Dallimore, Jasmin Klindzic, Jean-Marc Doucet, Joshua Todd Cowper, Jun Pataleta, Karol Flis, Kevin Wiliarty, Kim Salinas, Lisa Caines,  Luiggi Sansonetti, Mark Nelson, Mary Cooch, Michael Spall, Nadav Kavalerchik, Nayan, Nicolas Martignoni, rabnawaz, Rajesh Taneja, Raúl Martínez, Riady Santoso, Richard Oelmann, Ryan Wyllie, Sally Hanford, Sam Stegers, Sébastien Mehr, Stephen Bourget, Stephen Grono
-
-## Moodle 3.2 QA
-
-A. Samet Kul, Adrian Greeve, AL Rachels, Ankit Agarwal, Arindam Ghosh, Bente Olsen, Cameron Ball, Clement Prudhomme, Dag Klimas, Daniel Thies, David Mudrák, Dillon Hoy, Dominique-Alain Jan, Dr. Indira Koneru, Eloy Lafuente (stronk7), eric yullu, Fernando Acedo, Frédéric Massart, German Valero, Jake Dallimore, Jasmin Klindzic, Jean-Marc Doucet, Jeremy Schweitzer, John Okely, Juan V. Conde, Jun Pataleta, Kevin Wiliarty, Lisa Caines, Luiggi Sansonetti, Mary Evans, Michael Spall, Nadav Kavalerchik, Nicolas Martignoni, rabnawaz, Rajesh Taneja, Raymon Akbar, Simey Lameze, Slawomir Grefling, Stephen Bourget, Stephen Grono, Todd Mathews, Tomasz Szkutnik
-
-## Moodle 3.3 QA
-
-Abhishek Kumar, Adrian Greeve, AL Rachels, Andrew Nicols, Ankit Agarwal, Chad Outten, Charles Fulton, Dag Klimas, Damyon Wiese, Dan Poltawski, David Monllaó, David Mudrák, Dominique-Alain Jan, Dr. Indira Koneru, Eloy Lafuente (stronk7), eric yullu, Fernando Acedo, Frederic Nevers, German Valero, Heather Edick, Helen Foster, Jake Dallimore, Jasmin Klindzic, Jean-Marc Doucet, John Okely, Jon Bolton, Joost Elshoff, Jordan, Jun Pataleta, Kevin Wiliarty, Khushbu Nathani, Luiggi Sansonetti, Marcus Green, Mark Nelson, Michael Spall, Nadav Kavalerchik, Nayan V, Nicolas Martignoni, Oliver Tiemann, Ryan Wyllie, Sean Marx, Séverin Terrier, Slawomir Grefling, Stephen Bourget, Stephen Grono, Tomasz Szkutnik
-
-## Moodle 3.4 QA
-
-Adrian Greeve, AL Rachels, Andrew Nicols, Ankit Agarwal, Asif Iqbal, Bernd Martin, Bryan Iddings, Chad Outten, Clement Prudhomme, Dag Klimas, Damyon Wiese, David Byrne, David Monllaó, David Mudrák, Dominique-Alain Jan, Dr. Indira Koneru, Dumortier Laurence, Ed Beck, Eduardo Kraus, Eloy Lafuente (stronk7), eric yullu, Farhan Karmali, Fernando Acedo, Francisco Catena, Gemma Lesterhuis, German Valero, Helen Foster, Ivica Matotek, Jake Dallimore, Jamie Biddulph, Jasmin Klindzic, Jean-Roch Meurisse, Joost Elshoff, Juan V. Conde, Jun Pataleta, Kahraman Bulut, Eva Karall, Karen Holland, Katarzyna Karolczuk, Kevin Wiliarty, Lenka Kolesarova, Lisa Caines, Luiggi Sansonetti, Mark Nelson, Mary Cooch, Mathieu Petit-Clair, Mihail Geshoski, Nadav Kavalerchik, Nicolas Martignoni, Olga Kasatkina, Ryan Wyllie, S. kavita, Sandeep Kankatala, Sara Arjona, Sébastien Mehr, Séverin Terrier, Sharon Strauss, Simey Lameze, Slawomir Grefling, Stephen Bourget, Stephen Grono, Steven Peters, Stoyan Georgiev, Tomasz Szkutnik, Tõnis Tartes, Vicke Denniston, Zied Alaya, Ziyad Muslat
-
-## Moodle 3.5 QA
-
-Adrian Greeve, Alejandro Vásquez, AL Rachels, Anna Carissa Sadia, Avi Levy, Bente Olsen, Bernd Martin, Carlos Escobedo, Chen Levy, Chris Baldwin, Clement Prudhomme, Dag Klimas, Darwin Gonzalez, David Monllaó, David Mudrák, Dominique-Alain Jan, Ed Beck, Elizabeth Dalton, Eloy Lafuente (stronk7), eric yullu, Farhan Karmali, Fernando Acedo, Gemma Lesterhuis, German Valero, haim lavi, Helen Foster, James Cleary, Jasmin Klindzic, Jean-Marc Doucet, Jean-Roch Meurisse, John Beedell, Kahraman Bulut, Katarzyna Karolczuk, Kevin Wiliarty, Khushbu Verma, Lance Roe, Lisa Caines, Luiggi Sansonetti, Mary Cooch, Meir Ifrach, Michael Hawkins, Michael Spall, Mihail Geshoski, Nadav Kavalerchik, Nicolas Martignoni, Pankaj Somani, Priya Nagar, Richard Jones, Richard Oelmann, Rishi Anand, Ryan Wyllie, s. kavita, Sara Arjona, Sean Marx, Shamim Rezaie, Simey Lameze, Slawomir Grefling, Stephen Bourget, Steven Peters, Tomasz Szkutnik, Tõnis Tartes, Víctor Déniz Falcón, Zied Alaya, Ziyad Muslat
-
-## Moodle 3.6 QA
-
-Adrian Perez, Alex Dist, AL Rachels, Amaia Anabitarte, Anna Carissa Sadia, Bente Olsen, Carlos Escobedo, Colin Fraser, Craig Bailie, Damyon Wiese, Dan Bennett, David Monllaó, David Mudrák, Eric Yullu, Eruditiontec Innovations, Gemma Lesterhuis, German Valero, Helen Foster, Jake Dallimore, Jamie Biddulph, Jan Dageförde, Janelle Barcega, Jasmin Klindzic, Jean-Roch Meurisse, Jennifer Bauzon, Joe Murphy, Joost Elshoff, Jurgita Rimkiene, Karen Holland, Kevin Wiliarty, Luiggi Sansonetti, Mary Cooch, Michael Hawkins, Michael Spall, Mihail Geshoski, Nadav Kavalerchik, Nicolas Martignoni, Peter Dias, Praveen Chamarthi, Przemek Kaszubski, Richard Jones, Richard Oelmann, s. kavita, Sara Arjona, Séverin Terrier, Stephen Bourget, Stephen Grono, Tõnis Tartes, Víctor Déniz Falcón
-
-## Moodle 3.7 QA
-
-Alex Dist, AL Rachels, Amaia Anabitarte, Andrzej Gałuszka, Andrzej Szandała, Anna Carissa Sadia, Arkadiusz Malkowski, Artur Małka, Avi Levy, Babaso Aldar, Bente Olsen, Carlos Escobedo, Chen Levy, Clement Prudhomme, Craig Bailie, Damyon Wiese, David Mudrák, Dominique-Alain Jan, Elizabeth Dalton, Fernando Acedo, Gemma Lesterhuis, German Valero, Gladys Basiana, Gopal Sharma, haim lavi, Jake Dallimore, Janelle Barcega, Jasmin Klindzic, Jean-Marc Doucet, Jean-Roch Meurisse, Joost Elshoff, Kamil Łazarczyk, Kamil Łuczak, Karen Holland, Karina Viviana Martinez, Laurence Dumortier, Luiggi Sansonetti, Mary Cooch, Mathew May, Michael Spall, Moien Abadi, Nadav Kavalerchik, Nicolas Martignoni, Peter Dias, Praveen Chamarthi, Przemek Kaszubski, Richard Oelmann, Sara Arjona, Séverin Terrier, Simey Lameze, Stephen Bourget, Stephen Grono, Tom Cotton, Víctor Déniz Falcón, Yogev Bokobza, Łukasz Pierzgalski
-
-## Moodle 3.8 QA
-
-Adrián J. Troncoso, Adrian Perez, Augusto Luiz da Costa Schnorr, Alex Dist, AL Rachels, Arkadiusz Krawiec, Avi Levy, Bas Brands, Benjamin Kahn, Bente Olsen, Cameron Ball, Carlos Escobedo, Chen Levy, Chris Pratt, Dag Klimas, David Monllaó, David Mudrák, Dominique-Alain Jan, Elizabeth Dalton, Eric Yullu, Ferran Recio, Gemma Lesterhuis, Gladys Basiana, Haim Lavi, Ilmari M, Jan Dageförde, Janelle Barcega, Jasmin Klindzic, Jean-Roch Meurisse, Joost Elshoff, Joshua Todd Cowper, Juan V. Conde, Jun Pataleta, Karen Holland, Kathrin Braungardt, Kevan Flaming, Laurence Dumortier, Luiggi Sansonetti, Martyn Colliver, Mary Cooch, Mikel Martín Corrales, Moien Abadi, Nadav Kavalerchik, Nagi Saeed, Nicolas Martignoni, Peter Dias, Praveen Chamarthi, Raymon Akbar, Sara Arjona, Simey Lameze, Stephen Bourget, Stephen Grono, Tomasz Szkutnik, Víctor Déniz Falcón, Wanja Kimandi
-
-## Moodle 3.9 QA
-
-AL Rachels, Amaia Anabitarte, Anna Carissa Sadia, Arkadiusz Krawiec, Arto Nieminen, Avi Levy, Bas Brands, Bente Olsen, Carlos Escobedo, Chen Levy, Clement Prudhomme, Cosmas Kasumba, Dag Klimas, Daniel R. Schneider, David Mudrák, Eric Yullu, Ferran Recio, Gemma Lesterhuis, German Valero, Gladys Basiana, Hugo Ribeiro, Ingrid Granda, Jan Dageförde, Janelle Barcega, Jasmin Klindzic, Jean-Marc Doucet, John Provasnik, Joost Elshoff, Karen Holland, Kevin Wiliarty, Kiril Och, Kostya Kray, Laurence Marr, Liisi Järve, Luiggi Sansonetti, Mary Cooch, Mathew May, Max Larkin, Michael Spall, Mihail Geshoski, Moien Abadi, Nadav Kavalerchik, Nicolas Martignoni, Peter Dias, Ravi Murugesan, Sander Bangma, Séverin Terrier, Stephen Bourget, Stephen Grono, Tomasz Szkutnik, Vernon Spain, Yogesh Deore, Yogev Bokobza
-
-## Moodle 3.10 QA
-
-Adrian Greeve, AL Rachels, Amaia Anabitarte, Andrew Nicols, Anna Carissa Sadia, Anne Krull, Anneli Rumm, Arkadiusz Krawiec, Avi Levy, Bas Brands, Carlos Escobedo, Clement Prudhomme, David Matamoros, David Mudrak, Eloy Lafuente (stronk7), Fabián Glagovsky, Ferran Recio, Gemma Lesterhuis, Hittesh Ahuja, Hugo Ribeiro, Ilya Tregubov, Ingrid Granda, Ingrid Maadvere, Ivica Matotek, Jake Dallimore, James Hamilton, Janelle Barcega, John Provasnik, Josie Bronson, Jun Pataleta, Klaus Steitz, Krystian Papski, Liisi Järve, Luiggi Sansonetti, Marco Lehre, Mary Cooch, Mathew May, Michael Hawkins, Mihail Geshoski, Mikel Martín Corrales, Moien Abadi, Nicolas Martignoni, Patrick Lemaire, Paul Holden, Peter Dias, Praveen Chamarthi, Rick Jerz, Sander Bangma, Sara Arjona, Shamim Rezaie, Sille Paas, Simey Lameze, Stephen Bourget, Stephen Grono, Sumit Negi, Thomas Korner, Tomasz Szkutnik, Víctor Déniz Falcón
-
-## Moodle 3.11 QA
-
-AL Rachels, Amaia Anabitarte, Anna Carissa Sadia, Avi Levy, Ayush Parajuli, Bas Brands, Maria Blanco, Carlos Escobedo, Chen Levy, Cosmas Kasumba, Clement Prudhomme, Fabián Glagovsky, Farhan Karmali, Séverin Terrier, Gemma Lesterhuis, German Valero, Mihail Geshoski, Gladys Basiana, Krystian Papski, Minh Hanh NGUYEN, Hugo Ribeiro, Huong Nguyen, Ilya Tregubov, Jake Dallimore, Joost Elshoff, Luiggi Sansonetti, Luca Bösch, Mary Cooch, Mathew May, Nicolas Martignoni, Miri Lipson, Moien Abadi, Michael Spall, David Mudrák, Pawan Acharya, Adrian Perez, Peter Dias, Ravi Murugesan, Adriano Ruseler, Stephen Bourget, Stephen Grono, Sujith Haridasan, Tamar Elikishvili, Tomasz Szkutnik, Ferran Recio, Usman Asar, Yoni Amikam
-
-## Moodle 4.0 QA
-
-Adriano Ruseler, Adrian Perez, Alexander Dominicus, AL Rachels, Amaia Anabitarte, Amrita, Angelia Dela Cruz, Anthony Borrow, Antonia Bonaccorso, Avi Levy, Bas Brands, Carlos Escobedo, Carmen Schultz, Chen Levy, Clement Prudhomme, Cosmas Kasumba, Dag Klimas, Eric Merrill, eric yullu, erika alarcon, Farhan Karmali, Fernando Acedo, Ferran Recio, Gemma Lesterhuis, German Valero, Gladys Basiana, Hugo Ribeiro, Huong Nguyen, Ilya Tregubov, Ira Eickhoff, Jean-Marc Doucet, Jean-Roch Meurisse, Joost Elshoff, Karen Holland, Klaus Steitz, Laurence Dumortier, Lisa Eckerstorfer, Luca Bösch, Luiggi Sansonetti, Mathew May, Michael Hawkins, Michael Milette, Michael Spall, Michelle Lomman, Mihail Geshoski, Miri Lipson, Nadav Kavalerchik, Nicolas Martignoni, Patrycja Glogowska, Richard Oelmann, Sander Bangma, Sara Arjona (@sarjona), SarasChandrika Grandhi, Sebastian Homer, Sébastien Mehr, Simey Lameze, Stephen Bourget, Stephen Grono, Stephen Leppard, Sujith Haridasan, Tamar Elikishvili, Thomas Korner, Tomasz Szkutnik, Tore Høgås, Vardaan Solia, Wiebke Mueller
-
-## Moodle 4.1 QA
-
-Adriano Ruseler, Alistair Spark, AL Rachels, Amaia Anabitarte, Angelia Dela Cruz, Anthony Borrow, Avi Levy, Chen Levy, Chris Pratt, David Woloszyn, Eli Zard, Eva Dörfler, Ferran Recio, Hoda Askar, Huong Nguyen, Ilya Tregubov, Jake Dallimore, Jasmin Klindzic, Jean-Roch Meurisse, Jeremy Carre, John Edward Pedregosa, Julia, Jun Pataleta, Kevin Percy, Kim Jared Lucas, Laurent David, Luiggi Sansonetti, Lya Gobetti, Maria João, Mathew May, Meirza, Mihail Geshoski, Minh Hanh NGUYEN, Miri Lipson, Moien Abadi, Nadav Kavalerchik, Nicolas Martignoni, parsaseidahmad, Parto Khalili, Patrycja Glogowska, Praveen Chamarthi, Raquel Ortega, Ron Carl Alfon Yu, Saeed Ighanian, Sepehr Niki, Shamim Rezaie, Simey Lameze, Stephen Bourget, Stephen Grono, Stevani Andolo, Tamar Elikishvili, Tamir Hajaj, Tomasz Szkutnik
-
-## Moodle 4.2 QA
-
-Abe de Boer, Adriano Ruseler, Almog Aharon, AL Rachels, Amaia Anabitarte, Anderson Blaine, Angelia Dela Cruz, Angelina sutton , Arkadiusz Krawiec, Avi Levy, Carlos Escobedo, Chen Levy, Clement Prudhomme, Dag Klimas, David Woloszyn, Dominique-Alain Jan, Eli Zard, Eric Merrill, Fernando Acedo, Gemma Lesterhuis, Huong Nguyen, Jake Dallimore, Jean-Marc Doucet, Karen Holland, Kevin Percy, Kim Jared Lucas, Laurent David, Luiggi Sansonetti, Mary Cooch, Mathew May, Meirza, Michelle Lomman, Mihail Geshoski, Miri Lipson, Nadav Kavalerchik, Nicolas Martignoni, Patrycja Glogowska, Raquel Ortega, Ron Carl Alfon Yu, Shamim Rezaie, Simey Lameze, Stephen Bourget, Stephen Grono, Stevani Andolo, Tamahou Te Kowhai Scott, Tamar Elikishvili, Tamir Hajaj, Tomasz Szkutnik, Vika ablogeev
+Adriano Ruseler, Alain Corbière, AL Rachels, Alistair Spark, Amaia Anabitarte, Angelia Dela Cruz, Avi Levy, Carlos Escobedo, Chris Pratt, David Woloszyn, Eric Yullu, Ferran Recio, Gemma Lesterhuis, German Valero, Huong Nguyen, Ilya Tregubov, Jake Dallimore, Jean-Marc Doucet, John Provasnik, Joseph Rézeau, Kevin Percy, Kim Jared Lucas, Laurent David, Luiggi Sansonetti, Mathew May, Meirza, Mihail Geshoski, Mikel Martín Corrales, Nicolas Martignoni, Patrick Lemaire, Rajeshwar S, Raquel Ortega, Ron Carl Alfon Yu, Sabina Abellan, Safat Shahin, Sara Arjona (@sarjona), Shamim Rezaie, Simey Lameze, Stevani Andolo, Victor Déniz Falcón, Vika ablogeev
 
 ## Moodle 4.3 QA
 
 Adriano Ruseler, Alain Corbière, Amaia Anabitarte, Angelia Dela Cruz, Chen Levy, Chris Pratt, Daniel Dubbeldam, David Woloszyn, Gemma Lesterhuis, German Valero, Huong Nguyen, Jake Dallimore, Joseph Rézeau, Kim Jared Lucas, Laurent David, Luiggi Sansonetti, Mary Cooch, Meirza, Michelle Lomman, Mihail Geshoski, Mikel Martín Corrales, Minh Hanh NGUYEN, Miri Lipson, Nicolas Martignoni, Raquel Ortega, Ron Carl Alfon Yu, Safat Shahin, Sara Arjona (@sarjona), Simey Lameze, Stephen Grono, Stevani Andolo, Tamahou Te Kowhai Scott, Tamir Hajaj, Vika ablogeev
 
-## Moodle 4.4 QA
+## Moodle 4.2 QA
 
-Adriano Ruseler, Alain Corbière, AL Rachels, Alistair Spark, Amaia Anabitarte, Angelia Dela Cruz, Avi Levy, Carlos Escobedo, Chris Pratt, David Woloszyn, Eric Yullu, Ferran Recio, Gemma Lesterhuis, German Valero, Huong Nguyen, Ilya Tregubov, Jake Dallimore, Jean-Marc Doucet, John Provasnik, Joseph Rézeau, Kevin Percy, Kim Jared Lucas, Laurent David, Luiggi Sansonetti, Mathew May, Meirza, Mihail Geshoski, Mikel Martín Corrales, Nicolas Martignoni, Patrick Lemaire, Rajeshwar S, Raquel Ortega, Ron Carl Alfon Yu, Sabina Abellan, Safat Shahin, Sara Arjona (@sarjona), Shamim Rezaie, Simey Lameze, Stevani Andolo, Victor Déniz Falcón, Vika ablogeev
+Abe de Boer, Adriano Ruseler, Almog Aharon, AL Rachels, Amaia Anabitarte, Anderson Blaine, Angelia Dela Cruz, Angelina sutton , Arkadiusz Krawiec, Avi Levy, Carlos Escobedo, Chen Levy, Clement Prudhomme, Dag Klimas, David Woloszyn, Dominique-Alain Jan, Eli Zard, Eric Merrill, Fernando Acedo, Gemma Lesterhuis, Huong Nguyen, Jake Dallimore, Jean-Marc Doucet, Karen Holland, Kevin Percy, Kim Jared Lucas, Laurent David, Luiggi Sansonetti, Mary Cooch, Mathew May, Meirza, Michelle Lomman, Mihail Geshoski, Miri Lipson, Nadav Kavalerchik, Nicolas Martignoni, Patrycja Glogowska, Raquel Ortega, Ron Carl Alfon Yu, Shamim Rezaie, Simey Lameze, Stephen Bourget, Stephen Grono, Stevani Andolo, Tamahou Te Kowhai Scott, Tamar Elikishvili, Tamir Hajaj, Tomasz Szkutnik, Vika ablogeev
+
+## Moodle 4.1 QA
+
+Adriano Ruseler, Alistair Spark, AL Rachels, Amaia Anabitarte, Angelia Dela Cruz, Anthony Borrow, Avi Levy, Chen Levy, Chris Pratt, David Woloszyn, Eli Zard, Eva Dörfler, Ferran Recio, Hoda Askar, Huong Nguyen, Ilya Tregubov, Jake Dallimore, Jasmin Klindzic, Jean-Roch Meurisse, Jeremy Carre, John Edward Pedregosa, Julia, Jun Pataleta, Kevin Percy, Kim Jared Lucas, Laurent David, Luiggi Sansonetti, Lya Gobetti, Maria João, Mathew May, Meirza, Mihail Geshoski, Minh Hanh NGUYEN, Miri Lipson, Moien Abadi, Nadav Kavalerchik, Nicolas Martignoni, parsaseidahmad, Parto Khalili, Patrycja Glogowska, Praveen Chamarthi, Raquel Ortega, Ron Carl Alfon Yu, Saeed Ighanian, Sepehr Niki, Shamim Rezaie, Simey Lameze, Stephen Bourget, Stephen Grono, Stevani Andolo, Tamar Elikishvili, Tamir Hajaj, Tomasz Szkutnik
+
+## Moodle 4.0 QA
+
+Adriano Ruseler, Adrian Perez, Alexander Dominicus, AL Rachels, Amaia Anabitarte, Amrita, Angelia Dela Cruz, Anthony Borrow, Antonia Bonaccorso, Avi Levy, Bas Brands, Carlos Escobedo, Carmen Schultz, Chen Levy, Clement Prudhomme, Cosmas Kasumba, Dag Klimas, Eric Merrill, eric yullu, erika alarcon, Farhan Karmali, Fernando Acedo, Ferran Recio, Gemma Lesterhuis, German Valero, Gladys Basiana, Hugo Ribeiro, Huong Nguyen, Ilya Tregubov, Ira Eickhoff, Jean-Marc Doucet, Jean-Roch Meurisse, Joost Elshoff, Karen Holland, Klaus Steitz, Laurence Dumortier, Lisa Eckerstorfer, Luca Bösch, Luiggi Sansonetti, Mathew May, Michael Hawkins, Michael Milette, Michael Spall, Michelle Lomman, Mihail Geshoski, Miri Lipson, Nadav Kavalerchik, Nicolas Martignoni, Patrycja Glogowska, Richard Oelmann, Sander Bangma, Sara Arjona (@sarjona), SarasChandrika Grandhi, Sebastian Homer, Sébastien Mehr, Simey Lameze, Stephen Bourget, Stephen Grono, Stephen Leppard, Sujith Haridasan, Tamar Elikishvili, Thomas Korner, Tomasz Szkutnik, Tore Høgås, Vardaan Solia, Wiebke Mueller
+
+## Moodle 3.11 QA
+
+AL Rachels, Amaia Anabitarte, Anna Carissa Sadia, Avi Levy, Ayush Parajuli, Bas Brands, Maria Blanco, Carlos Escobedo, Chen Levy, Cosmas Kasumba, Clement Prudhomme, Fabián Glagovsky, Farhan Karmali, Séverin Terrier, Gemma Lesterhuis, German Valero, Mihail Geshoski, Gladys Basiana, Krystian Papski, Minh Hanh NGUYEN, Hugo Ribeiro, Huong Nguyen, Ilya Tregubov, Jake Dallimore, Joost Elshoff, Luiggi Sansonetti, Luca Bösch, Mary Cooch, Mathew May, Nicolas Martignoni, Miri Lipson, Moien Abadi, Michael Spall, David Mudrák, Pawan Acharya, Adrian Perez, Peter Dias, Ravi Murugesan, Adriano Ruseler, Stephen Bourget, Stephen Grono, Sujith Haridasan, Tamar Elikishvili, Tomasz Szkutnik, Ferran Recio, Usman Asar, Yoni Amikam
+
+## Moodle 3.10 QA
+
+Adrian Greeve, AL Rachels, Amaia Anabitarte, Andrew Nicols, Anna Carissa Sadia, Anne Krull, Anneli Rumm, Arkadiusz Krawiec, Avi Levy, Bas Brands, Carlos Escobedo, Clement Prudhomme, David Matamoros, David Mudrak, Eloy Lafuente (stronk7), Fabián Glagovsky, Ferran Recio, Gemma Lesterhuis, Hittesh Ahuja, Hugo Ribeiro, Ilya Tregubov, Ingrid Granda, Ingrid Maadvere, Ivica Matotek, Jake Dallimore, James Hamilton, Janelle Barcega, John Provasnik, Josie Bronson, Jun Pataleta, Klaus Steitz, Krystian Papski, Liisi Järve, Luiggi Sansonetti, Marco Lehre, Mary Cooch, Mathew May, Michael Hawkins, Mihail Geshoski, Mikel Martín Corrales, Moien Abadi, Nicolas Martignoni, Patrick Lemaire, Paul Holden, Peter Dias, Praveen Chamarthi, Rick Jerz, Sander Bangma, Sara Arjona, Shamim Rezaie, Sille Paas, Simey Lameze, Stephen Bourget, Stephen Grono, Sumit Negi, Thomas Korner, Tomasz Szkutnik, Víctor Déniz Falcón
+
+## Moodle 3.9 QA
+
+AL Rachels, Amaia Anabitarte, Anna Carissa Sadia, Arkadiusz Krawiec, Arto Nieminen, Avi Levy, Bas Brands, Bente Olsen, Carlos Escobedo, Chen Levy, Clement Prudhomme, Cosmas Kasumba, Dag Klimas, Daniel R. Schneider, David Mudrák, Eric Yullu, Ferran Recio, Gemma Lesterhuis, German Valero, Gladys Basiana, Hugo Ribeiro, Ingrid Granda, Jan Dageförde, Janelle Barcega, Jasmin Klindzic, Jean-Marc Doucet, John Provasnik, Joost Elshoff, Karen Holland, Kevin Wiliarty, Kiril Och, Kostya Kray, Laurence Marr, Liisi Järve, Luiggi Sansonetti, Mary Cooch, Mathew May, Max Larkin, Michael Spall, Mihail Geshoski, Moien Abadi, Nadav Kavalerchik, Nicolas Martignoni, Peter Dias, Ravi Murugesan, Sander Bangma, Séverin Terrier, Stephen Bourget, Stephen Grono, Tomasz Szkutnik, Vernon Spain, Yogesh Deore, Yogev Bokobza
+
+## Moodle 3.8 QA
+
+Adrián J. Troncoso, Adrian Perez, Augusto Luiz da Costa Schnorr, Alex Dist, AL Rachels, Arkadiusz Krawiec, Avi Levy, Bas Brands, Benjamin Kahn, Bente Olsen, Cameron Ball, Carlos Escobedo, Chen Levy, Chris Pratt, Dag Klimas, David Monllaó, David Mudrák, Dominique-Alain Jan, Elizabeth Dalton, Eric Yullu, Ferran Recio, Gemma Lesterhuis, Gladys Basiana, Haim Lavi, Ilmari M, Jan Dageförde, Janelle Barcega, Jasmin Klindzic, Jean-Roch Meurisse, Joost Elshoff, Joshua Todd Cowper, Juan V. Conde, Jun Pataleta, Karen Holland, Kathrin Braungardt, Kevan Flaming, Laurence Dumortier, Luiggi Sansonetti, Martyn Colliver, Mary Cooch, Mikel Martín Corrales, Moien Abadi, Nadav Kavalerchik, Nagi Saeed, Nicolas Martignoni, Peter Dias, Praveen Chamarthi, Raymon Akbar, Sara Arjona, Simey Lameze, Stephen Bourget, Stephen Grono, Tomasz Szkutnik, Víctor Déniz Falcón, Wanja Kimandi
+
+## Moodle 3.7 QA
+
+Alex Dist, AL Rachels, Amaia Anabitarte, Andrzej Gałuszka, Andrzej Szandała, Anna Carissa Sadia, Arkadiusz Malkowski, Artur Małka, Avi Levy, Babaso Aldar, Bente Olsen, Carlos Escobedo, Chen Levy, Clement Prudhomme, Craig Bailie, Damyon Wiese, David Mudrák, Dominique-Alain Jan, Elizabeth Dalton, Fernando Acedo, Gemma Lesterhuis, German Valero, Gladys Basiana, Gopal Sharma, haim lavi, Jake Dallimore, Janelle Barcega, Jasmin Klindzic, Jean-Marc Doucet, Jean-Roch Meurisse, Joost Elshoff, Kamil Łazarczyk, Kamil Łuczak, Karen Holland, Karina Viviana Martinez, Laurence Dumortier, Luiggi Sansonetti, Mary Cooch, Mathew May, Michael Spall, Moien Abadi, Nadav Kavalerchik, Nicolas Martignoni, Peter Dias, Praveen Chamarthi, Przemek Kaszubski, Richard Oelmann, Sara Arjona, Séverin Terrier, Simey Lameze, Stephen Bourget, Stephen Grono, Tom Cotton, Víctor Déniz Falcón, Yogev Bokobza, Łukasz Pierzgalski
+
+## Moodle 3.6 QA
+
+Adrian Perez, Alex Dist, AL Rachels, Amaia Anabitarte, Anna Carissa Sadia, Bente Olsen, Carlos Escobedo, Colin Fraser, Craig Bailie, Damyon Wiese, Dan Bennett, David Monllaó, David Mudrák, Eric Yullu, Eruditiontec Innovations, Gemma Lesterhuis, German Valero, Helen Foster, Jake Dallimore, Jamie Biddulph, Jan Dageförde, Janelle Barcega, Jasmin Klindzic, Jean-Roch Meurisse, Jennifer Bauzon, Joe Murphy, Joost Elshoff, Jurgita Rimkiene, Karen Holland, Kevin Wiliarty, Luiggi Sansonetti, Mary Cooch, Michael Hawkins, Michael Spall, Mihail Geshoski, Nadav Kavalerchik, Nicolas Martignoni, Peter Dias, Praveen Chamarthi, Przemek Kaszubski, Richard Jones, Richard Oelmann, s. kavita, Sara Arjona, Séverin Terrier, Stephen Bourget, Stephen Grono, Tõnis Tartes, Víctor Déniz Falcón
+
+## Moodle 3.5 QA
+
+Adrian Greeve, Alejandro Vásquez, AL Rachels, Anna Carissa Sadia, Avi Levy, Bente Olsen, Bernd Martin, Carlos Escobedo, Chen Levy, Chris Baldwin, Clement Prudhomme, Dag Klimas, Darwin Gonzalez, David Monllaó, David Mudrák, Dominique-Alain Jan, Ed Beck, Elizabeth Dalton, Eloy Lafuente (stronk7), eric yullu, Farhan Karmali, Fernando Acedo, Gemma Lesterhuis, German Valero, haim lavi, Helen Foster, James Cleary, Jasmin Klindzic, Jean-Marc Doucet, Jean-Roch Meurisse, John Beedell, Kahraman Bulut, Katarzyna Karolczuk, Kevin Wiliarty, Khushbu Verma, Lance Roe, Lisa Caines, Luiggi Sansonetti, Mary Cooch, Meir Ifrach, Michael Hawkins, Michael Spall, Mihail Geshoski, Nadav Kavalerchik, Nicolas Martignoni, Pankaj Somani, Priya Nagar, Richard Jones, Richard Oelmann, Rishi Anand, Ryan Wyllie, s. kavita, Sara Arjona, Sean Marx, Shamim Rezaie, Simey Lameze, Slawomir Grefling, Stephen Bourget, Steven Peters, Tomasz Szkutnik, Tõnis Tartes, Víctor Déniz Falcón, Zied Alaya, Ziyad Muslat
+
+## Moodle 3.4 QA
+
+Adrian Greeve, AL Rachels, Andrew Nicols, Ankit Agarwal, Asif Iqbal, Bernd Martin, Bryan Iddings, Chad Outten, Clement Prudhomme, Dag Klimas, Damyon Wiese, David Byrne, David Monllaó, David Mudrák, Dominique-Alain Jan, Dr. Indira Koneru, Dumortier Laurence, Ed Beck, Eduardo Kraus, Eloy Lafuente (stronk7), eric yullu, Farhan Karmali, Fernando Acedo, Francisco Catena, Gemma Lesterhuis, German Valero, Helen Foster, Ivica Matotek, Jake Dallimore, Jamie Biddulph, Jasmin Klindzic, Jean-Roch Meurisse, Joost Elshoff, Juan V. Conde, Jun Pataleta, Kahraman Bulut, Eva Karall, Karen Holland, Katarzyna Karolczuk, Kevin Wiliarty, Lenka Kolesarova, Lisa Caines, Luiggi Sansonetti, Mark Nelson, Mary Cooch, Mathieu Petit-Clair, Mihail Geshoski, Nadav Kavalerchik, Nicolas Martignoni, Olga Kasatkina, Ryan Wyllie, S. kavita, Sandeep Kankatala, Sara Arjona, Sébastien Mehr, Séverin Terrier, Sharon Strauss, Simey Lameze, Slawomir Grefling, Stephen Bourget, Stephen Grono, Steven Peters, Stoyan Georgiev, Tomasz Szkutnik, Tõnis Tartes, Vicke Denniston, Zied Alaya, Ziyad Muslat
+
+## Moodle 3.3 QA
+
+Abhishek Kumar, Adrian Greeve, AL Rachels, Andrew Nicols, Ankit Agarwal, Chad Outten, Charles Fulton, Dag Klimas, Damyon Wiese, Dan Poltawski, David Monllaó, David Mudrák, Dominique-Alain Jan, Dr. Indira Koneru, Eloy Lafuente (stronk7), eric yullu, Fernando Acedo, Frederic Nevers, German Valero, Heather Edick, Helen Foster, Jake Dallimore, Jasmin Klindzic, Jean-Marc Doucet, John Okely, Jon Bolton, Joost Elshoff, Jordan, Jun Pataleta, Kevin Wiliarty, Khushbu Nathani, Luiggi Sansonetti, Marcus Green, Mark Nelson, Michael Spall, Nadav Kavalerchik, Nayan V, Nicolas Martignoni, Oliver Tiemann, Ryan Wyllie, Sean Marx, Séverin Terrier, Slawomir Grefling, Stephen Bourget, Stephen Grono, Tomasz Szkutnik
+
+## Moodle 3.2 QA
+
+A. Samet Kul, Adrian Greeve, AL Rachels, Ankit Agarwal, Arindam Ghosh, Bente Olsen, Cameron Ball, Clement Prudhomme, Dag Klimas, Daniel Thies, David Mudrák, Dillon Hoy, Dominique-Alain Jan, Dr. Indira Koneru, Eloy Lafuente (stronk7), eric yullu, Fernando Acedo, Frédéric Massart, German Valero, Jake Dallimore, Jasmin Klindzic, Jean-Marc Doucet, Jeremy Schweitzer, John Okely, Juan V. Conde, Jun Pataleta, Kevin Wiliarty, Lisa Caines, Luiggi Sansonetti, Mary Evans, Michael Spall, Nadav Kavalerchik, Nicolas Martignoni, rabnawaz, Rajesh Taneja, Raymon Akbar, Simey Lameze, Slawomir Grefling, Stephen Bourget, Stephen Grono, Todd Mathews, Tomasz Szkutnik
+
+## Moodle 3.1 QA
+
+AL Rachels, Ben Reynolds, Cameron Ball, Dag Klimas, Dan Poltawski, Dominique-Alain Jan, Dr. Indira Koneru, Eduardo Rodrigues, eric yullu, Farhan Karmali, Fernando Acedo, Frédéric Massart, German Valero, Graham Stone, Himanshi Bhardwaj, Jake Dallimore, Jasmin Klindzic, Jean-Marc Doucet, Joshua Todd Cowper, Jun Pataleta, Karol Flis, Kevin Wiliarty, Kim Salinas, Lisa Caines,  Luiggi Sansonetti, Mark Nelson, Mary Cooch, Michael Spall, Nadav Kavalerchik, Nayan, Nicolas Martignoni, rabnawaz, Rajesh Taneja, Raúl Martínez, Riady Santoso, Richard Oelmann, Ryan Wyllie, Sally Hanford, Sam Stegers, Sébastien Mehr, Stephen Bourget, Stephen Grono
+
+## Moodle 3.0 QA
+
+Adrian Greeve, AL Rachels, Arindam Ghosh,  Bas Brands, Ben Reynolds, Cameron Ball, Chad Outten, Dag Klimas, David Monllaó, Dominique-Alain Jan, Dr. Indira Koneru, eric yullu, Farhan Karmali, Fernando Acedo, Gemma Lesterhuis, German Valero, Ivana Bosnic, James Hamilton, Jasmin Klindzic, Jeff Webster, John Okely, Jun Pataleta, Ketan Chandaria, Kevin Wiliarty, Lisa Caines, Luiggi Sansonetti, Mary Evans, Michael de Raadt, nayan, Nicolas Martignoni, Paul Nicholls, Rajesh Taneja, Richard Oelmann, Ryan Wyllie, Sandeep Kankatala, Séverin Terrier, Simey Lameze, Slawomir Grefling, Stephanie Gerald, Stephen Bourget, Trish Zagarella, Vinit Prajapati
+
+## Moodle 2.9 QA
+
+AL Rachels, Ankit Agarwal, Ben Reynolds, Brett Deaton, Chad Outten, Charles Fulton, Damyon Wiese, Daniel Thies, Dan Marsden, Dave Cooper, eric yullu, Fernando Acedo, Fernando Rocha, Frédéric Massart, Graham Stone, Greg Faller, Ivana Bosnic, Jasmin Klindzic, Jaswinder Singh, Jean-Marc Doucet, Jetha Chan, John Okely, Kevin Wiliarty, Lehane van der Merwe, Lisa Caines, Luiggi Sansonetti, Marina Glancy, Martin Mastny, Mary Cooch, Michael E, Michael Spall, Nicolas Martignoni, Pete Potter, Rajesh Taneja, Raúl Martínez, Sakshi Goel, Séverin Terrier, Simey Lameze, Stephen Bourget
+
+## Moodle 2.8 QA
+
+Adrian Greeve, AL Rachels, Andrea Bicciolo, Andrew Nicols, Ankit Agarwal, Anthony Borrow, Ben Reynolds, Bob Puffer, Brett Deaton, Clay Burell, Colin Matheson, Dave Cooper, Eric Yullu, Farhan Karmali, Frédéric Massart, Graham Stone, Guillermo Madero, Jackie Toth, Jasmin Klindzic, Jayesh Anandani, Jean-Marc Doucet, Jetha Chan, John Okely, Joseph Rézeau, Joseph Thibault, Juan Leyva, Kevin Wiliarty, Marina Glancy, Mark Nelson, Mesfin Teshome, Michael de Raadt, Mihai Bojonca, Miraj Koradiya, Mitchell van Gerwen, Nicolas Martignoni, Raúl Martínez, Sakshi Goel, Sam Hemelryk, Séverin Terrier, Shashikant Vaishnav, Simey Lameze,  Stephen Bourget, Steve James, Teresa Gibbison, Vanessa Cleary, Willy Lee, Yash Barot, Zachary Durber
+
+## Moodle 2.7 QA
+
+Adrian Greeve, Adrián J. Troncoso, AL Rachels, Andrea Bicciolo, Andrew Davis, Andrew Nicols, Ankit Agarwal, Chad Outten, Dan Bennett, Daniel Thies, Dan Poltawski, David Appleyard, Fernando Acedo, Frédéric Massart, Graham Stone, Hittesh Ahuja, Hugo Schouppe, Jasmin Klindzic, Jason Fowler, Jayesh Anandani, Jean-Marc Doucet, Jetha Chan, John Okely, Joshua Bragg, Kevin Wiliarty, Kieran Briggs, Lehane Boonzaaier, Lisa Caines, Luca Testoni, Mary Cooch, Mary Evans, Michael de Raadt, Michael E, Miraj Koradiya, Mitchell van Gerwen, Nadav Kavalerchik, nayan, Nicolas Martignoni, Prathibha B, Rajesh Taneja, Richard Oelmann, Sakshi Goel, Sam Hemelryk, Sam Stegers, Séverin Terrier, Simey Lameze, Stephanie Gerald, Stephen Bourget
+
+## Moodle 2.6 QA
+
+Adrian Greeve, AL Rachels, Andrea Bicciolo, Ankit Agarwal, Carina Martinez, Chad Outten, Dan Poltawski, David Monllaó, Eloy Lafuente (stronk7), Farhan Karmali, Fernando Rocha, Frédéric Massart, Guillermo M., Hittesh, Jasmin Klindzic, Javier Sola Aréchaga, Joe Murphy, Joseph Rézeau, Kevin Wiliarty, Lehane Boonzaaier, Lisa Caines, Mary Cooch, Michael de Raadt, Michael E, Mitchell van Gerwen, Natalia Giovagnetti, Nicolas Martignoni, Rajesh Taneja, Rossiani Wijaya, Sakshi Goel, Sam Stegers, Séverin Terrier, Stephen Bourget
+
+## Moodle 2.5 QA
+
+Adrian Greeve, Alan Hald, AL Rachels, Andrea Bicciolo, Andrew Davis, Ankit Agarwal, Anthony Borrow, Ben Reynolds, Chad Outten, Dan Poltawski, David Monllaó, David Perry, Don Schwartz, Farhan Karmali, Fernando Navarro Paez, Frédéric Massart, Graham Stone, Helen Foster, Iain Gray, Ivana Bosnic, Jasmin Klindzic, Jaswinder Singh, Javier Sola Aréchaga, Jayesh Anandani, Joost Elshoff, Karl Goddard, Kevin Wiliarty, Leah Hemeon, Lindy Klein, Lynn Hadfield, Mark Nelson, Mary Evans, Michael de Raadt, Mónico Briseño Cortés, Nadav Kavalerchik, Nicolas Martignoni, Nikunj Thakkar, Prateek Sachan, Richard Oelmann, Sakshi Goel, Sam Stegers, Sandareka Wickramanayake, Séverin Terrier, Stephen Bourget
+
+## Moodle 2.4 QA
+
+Ankit Agarwal, Javier Sola Aréchaga, Lehane Boonzaaier, Anthony Borrow, Ivana Bosnic, Federico Botti, Stephen Bourget, Mike Churchward, Mary Cooch, Mónico Briseño Cortés, Andrew Davis, Michael de Raadt, Joost Elshoff, Justin Filip, Helen Foster, Jason Fowler, Charles Fulton, Adrian Greeve, Karl Goddard, Jasmin Klindzic, Nicolas Martignoni, David Monllaó, Mark Nelson, Richard Oelmann, Bente Olsen, Chad Outten, Dan Poltawski, AL Rachels, Dan Rapoza, Joseph Rézeau, Peter Roberts, Michael Spall, Graham Stone, Rajesh Taneja, Mitchell van Gerwen, Damyon Wiese, Rossiani Wijaya, Kevin Wiliarty
+
+## Moodle 2.3 QA
+
+Adam Pawelczak, Adrian Greeve, Andrea Bicciolo, Andrew Davis, Ankit Agarwal, Aparup Banerjee, Bas Brands, Ben Reynolds, Bente Olsen, Brent Lee, Carly J Born, Chad Outten, Charles Fulton, Dan Poltawski, Drew Blessing, Frédéric Massart, Frederic Nevers, Heinrich, Ivana Bosnic, James Cracknell, Jasmin Klindzic, Jason Fowler, Javier Sola Aréchaga, Joseph Rézeau, Keith Dingley, Kingsley Udeh, Klaus Steitz, Lesli Smith, Lynn Clark, Michael de Raadt, Mitja Podreka, Nicolas Martignoni, Paul Tosney, Rajesh Taneja, Rex Lorenzo, Rossiani Wijaya, Stephen Bourget, Ted van den Brink, Teresa Gibbison, Tim Barker
+
+## Moodle 2.2 QA
+
+Adrian Greeve, Andrea Bicciolo, Andrew Davis, Andrew Nicols, Ankit Agarwal, Anthony Borrow, Aparup Banerjee, Charles Fulton, Colin Campbell, gavin henrick, Jason Fowler, JM Ferring, Joan Tracy, Joseph Rézeau, Marina Glancy, Martin Dougiamas, Mary Cooch, Mayank Gupta, Michael de Raadt, Nadav Kavalerchik, Nicolas Martignoni, Paul Tosney, Rossiani Wijaya, Sam Stegers, Stephen Bourget, Teresa Gibbison
+
+## Moodle 2.1 QA
+
+Glenn Ansley, Aparup Banerjee, Melissa Benson, Anthony Borrow, Stephen Bourget, Lynn Clark, Mary Cooch, Andrew Davis, Sue Demoor, Michael de Raadt, Debra Dotson, Moronke Fajobi, Jean-Marc Ferring, Teresa Gibbison, Marina Glancy, Stephan Green, Tzu-Chiao Hung, Andre Kruger, Brent Lee, Colin Matheson, Mark McCall, David Mudrak, Chad Outten, Vinit Prajapati, Joseph Rézeau, Adam Sanders, Lesli Smith, Javier Sola, Erin Sorensen, Michael Spall, Kristian Still, Rajesh Taneja, Paul Tosney, Steve Turley, Jon Witts, Massimo Zunino
+
+## Moodle 2.0 QA Cycle 2
+
+Jes Ackland-Snow, Andrea Bicciolo, Ashley Blakeston, Anthony Borrow, Mónico Briseño Cortés, James Brisland, Alan Peter Carter, Colin Chambers, Chris Collman, Emanuel Delgado, Debra Dotson, Anthony Forth, Helen Foster, Teresa Gibbison, Elena Ivanova, Mahmoud Kassaei, Tomaz Lasic, Sam Marshall, Nicolas Martignoni, Colin Matheson, David Mudrak, Chad Outten, Pierre Pichet, Jason Platts, Joseph Rézeau, Alan Thompson, Bryan Waddington, Derek Woolhead
+
+## Moodle 2.0 QA Cycle 1
+
+Andrea Bicciolo, Ashley Blakeston, Anthony Borrow, Stephen Bourget, Mónico Briseño Cortés, Chris Collman, Mary Cooch, Emanuel Delgado, Debra Dotson, Buddy Ethridge, Teresa Gibbison, Amy Groshek, Elena Ivanova, Matt Jenner, Brent Lee, Nicolas Martignoni, Colin Matheson, Mark McCall, Chad Outten, Joseph Rézeau, Michael Spall, Joseph Thibault, Jon Witts
 
 <!-- cspell:enable -->
 


### PR DESCRIPTION
As suggested in the iteam chat, it would be better to display the list of testing credits showing the recent Moodle release first.