### PR TITLE
Add ' to create valid JS on selectors

### DIFF
--- a/docs/guides/javascript/index.md
+++ b/docs/guides/javascript/index.md
@@ -206,8 +206,8 @@ For example:
 ```js title="mod/example/lib/amd/src/local/helloworld/selectors.js"
 export default {
     actions: {
-        showAlertButton: '[data-action="mod_example/helloworld-update_button"],
-        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"],
+        showAlertButton: '[data-action="mod_example/helloworld-update_button"]',
+        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"]',
     },
 };
 ```

--- a/versioned_docs/version-4.1/guides/javascript/index.md
+++ b/versioned_docs/version-4.1/guides/javascript/index.md
@@ -206,8 +206,8 @@ For example:
 ```js title="mod/example/lib/amd/src/local/helloworld/selectors.js"
 export default {
     actions: {
-        showAlertButton: '[data-action="mod_example/helloworld-update_button"],
-        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"],
+        showAlertButton: '[data-action="mod_example/helloworld-update_button"]',
+        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"]',
     },
 };
 ```

--- a/versioned_docs/version-4.2/guides/javascript/index.md
+++ b/versioned_docs/version-4.2/guides/javascript/index.md
@@ -206,8 +206,8 @@ For example:
 ```js title="mod/example/lib/amd/src/local/helloworld/selectors.js"
 export default {
     actions: {
-        showAlertButton: '[data-action="mod_example/helloworld-update_button"],
-        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"],
+        showAlertButton: '[data-action="mod_example/helloworld-update_button"]',
+        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"]',
     },
 };
 ```

--- a/versioned_docs/version-4.3/guides/javascript/index.md
+++ b/versioned_docs/version-4.3/guides/javascript/index.md
@@ -206,8 +206,8 @@ For example:
 ```js title="mod/example/lib/amd/src/local/helloworld/selectors.js"
 export default {
     actions: {
-        showAlertButton: '[data-action="mod_example/helloworld-update_button"],
-        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"],
+        showAlertButton: '[data-action="mod_example/helloworld-update_button"]',
+        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"]',
     },
 };
 ```

--- a/versioned_docs/version-4.4/guides/javascript/index.md
+++ b/versioned_docs/version-4.4/guides/javascript/index.md
@@ -206,8 +206,8 @@ For example:
 ```js title="mod/example/lib/amd/src/local/helloworld/selectors.js"
 export default {
     actions: {
-        showAlertButton: '[data-action="mod_example/helloworld-update_button"],
-        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"],
+        showAlertButton: '[data-action="mod_example/helloworld-update_button"]',
+        bigRedButton: '[data-action="mod_example/helloworld-big_red_button"]',
     },
 };
 ```


### PR DESCRIPTION
The missing quote means the JS is invalid. This fixes it.