### PR TITLE
Update index.md

### DIFF
--- a/general/development/policies/codingstyle/index.md
+++ b/general/development/policies/codingstyle/index.md
@@ -2056,6 +2056,9 @@ To get the full list of exception types, search for the regular expression 'clas
 
 Where appropriate, you should create new subclasses of moodle_exception for use in your code. 
 
+
+<Since version="4.5" issueNumber="MDL-81903" />
+
 If you create a custom exception class it *may* live in the `classes/exception/` directory, and be namespaced in `<plugin>/exception/`
 
 A few notable exception types:

--- a/general/development/policies/codingstyle/index.md
+++ b/general/development/policies/codingstyle/index.md
@@ -2054,7 +2054,9 @@ We have a set of custom exception classes. The base class is moodle_exception. Y
 
 To get the full list of exception types, search for the regular expression 'class +\w+_exception +extends' or ask your IDE to list all the subclasses of moodle_exception.
 
-Where appropriate, you should create new subclasses of moodle_exception for use in your code.
+Where appropriate, you should create new subclasses of moodle_exception for use in your code. 
+
+If you create a custom exception class it *may* live in the `classes/exception/` directory, and be namespaced in `<plugin>/exception/`
 
 A few notable exception types:
 


### PR DESCRIPTION
Added line to indicate a good location for custom exception classes inline with https://github.com/moodle/moodle/blob/main/lib/apis.json#L107

It was hard to discover the details of where exception classes should be physically located, so this would tighten that up, whilst not necessarily being absolutely proscriptive.