### PR TITLE
Import ModalRegistry instead of ModalFactory

### DIFF
--- a/versioned_docs/version-4.1/guides/javascript/modal/index.md
+++ b/versioned_docs/version-4.1/guides/javascript/modal/index.md
@@ -145,7 +145,7 @@ We highly recommend declaring the _template_ as a static property on the class t
 
 ```javascript title="mod/example/amd/src/my_modal.js"
 import Modal from 'core/modal';
-import ModalFactory from 'core/modal_factory';
+import ModalRegistry from 'core/modal_registry';
 
 export default class MyModal extends Modal {
     static TYPE = "mod_example/my_modal";

--- a/versioned_docs/version-4.2/guides/javascript/modal/index.md
+++ b/versioned_docs/version-4.2/guides/javascript/modal/index.md
@@ -145,7 +145,7 @@ We highly recommend declaring the _template_ as a static property on the class t
 
 ```javascript title="mod/example/amd/src/my_modal.js"
 import Modal from 'core/modal';
-import ModalFactory from 'core/modal_factory';
+import ModalRegistry from 'core/modal_registry';
 
 export default class MyModal extends Modal {
     static TYPE = "mod_example/my_modal";


### PR DESCRIPTION
We need to import ModalRegistry not ModalFactory when defining a new Modal Class for creating custom modal types