### PR TITLE
Link to the statement of conformance file

### DIFF
--- a/general/development/policies/accessibility.md
+++ b/general/development/policies/accessibility.md
@@ -16,7 +16,7 @@ As part of our ongoing commitment to accessibility and continuously improving co
 
 #### Moodle LMS
 
-Moodle LMS has been accredited to meet [WCAG 2.1 Level AA conformance](https://www.webkeyit.com/accessibility-services/accessibility-accreditations/moodle).
+Moodle LMS has been accredited to meet [WCAG 2.1 Level AA conformance](https://tracker.moodle.org/secure/attachment/147694/Moodle%20Statement%20of%20Conformance%202024.pdf).
 
 The table below provides a history of the accessibility audits performed on the Moodle LMS.
 


### PR DESCRIPTION
WebKey IT used to list its clients' accreditations on its website. However, since it was acquired by AbleDocs and later became GrackleDocs, it no longer seems to update this list.

Because of this, the link to the "WCAG 2.1 Level AA conformance" in our dev docs points to an old accreditation. I think it's better to replace the link with a URL to the actual statement of conformance that is currently on the 4.2 accessibility audit epic (MDL-78185).