### PR TITLE
Specify value for XDEBUG_PROFILE in profiling page 

### DIFF
--- a/docs/guides/profiling/index.md
+++ b/docs/guides/profiling/index.md
@@ -148,9 +148,9 @@ xdebug.trigger_value = ProfileMe
 
 :::
 
-When using a trigger to start xdebug, open any php page on your server in your browser having added `XDEBUG_PROFILE` parameter to URL string, for example `http://servername/moodle2/index.php?XDEBUG_PROFILE`.
+When using a trigger to start xdebug, open any php page on your server in your browser having added `XDEBUG_PROFILE` parameter to URL string, for example `http://servername/moodle2/index.php?XDEBUG_PROFILE=ProfileMe`.
 
-If that page already has some parameters, just add our trigger to the URL end, for example: `http://servername/moodle2/mod/forum/view.php?id=5&XDEBUG_PROFILE`.
+If that page already has some parameters, just add our trigger to the URL end, for example: `http://servername/moodle2/mod/forum/view.php?id=5&XDEBUG_PROFILE=ProfileMe`.
 
 The profile should be generated in the directory you specified with `xdebug.output_dir` directive:
 

--- a/versioned_docs/version-4.3/guides/profiling/index.md
+++ b/versioned_docs/version-4.3/guides/profiling/index.md
@@ -172,9 +172,9 @@ xdebug.trigger_value = ProfileMe
 
 :::
 
-When using a trigger to start xdebug, open any php page on your server in your browser having added `XDEBUG_PROFILE` parameter to URL string, for example `http://servername/moodle2/index.php?XDEBUG_PROFILE`.
+When using a trigger to start xdebug, open any php page on your server in your browser having added `XDEBUG_PROFILE` parameter to URL string, for example `http://servername/moodle2/index.php?XDEBUG_PROFILE=ProfileMe`.
 
-If that page already has some parameters, just add our trigger to the URL end, for example: `http://servername/moodle2/mod/forum/view.php?id=5&XDEBUG_PROFILE`.
+If that page already has some parameters, just add our trigger to the URL end, for example: `http://servername/moodle2/mod/forum/view.php?id=5&XDEBUG_PROFILE=ProfileMe`.
 
 The profile should be generated in the directory you specified with `xdebug.output_dir` directive:
 

--- a/versioned_docs/version-4.4/guides/profiling/index.md
+++ b/versioned_docs/version-4.4/guides/profiling/index.md
@@ -148,9 +148,9 @@ xdebug.trigger_value = ProfileMe
 
 :::
 
-When using a trigger to start xdebug, open any php page on your server in your browser having added `XDEBUG_PROFILE` parameter to URL string, for example `http://servername/moodle2/index.php?XDEBUG_PROFILE`.
+When using a trigger to start xdebug, open any php page on your server in your browser having added `XDEBUG_PROFILE` parameter to URL string, for example `http://servername/moodle2/index.php?XDEBUG_PROFILE=ProfileMe`.
 
-If that page already has some parameters, just add our trigger to the URL end, for example: `http://servername/moodle2/mod/forum/view.php?id=5&XDEBUG_PROFILE`.
+If that page already has some parameters, just add our trigger to the URL end, for example: `http://servername/moodle2/mod/forum/view.php?id=5&XDEBUG_PROFILE=ProfileMe`.
 
 The profile should be generated in the directory you specified with `xdebug.output_dir` directive:
 


### PR DESCRIPTION
Specify the value for `XDEBUG_PROFILE` param to solve this issue: The trigger value '', as set through 'XDEBUG_PROFILE', did not match the shared secret (xdebug.trigger_value) for mode 'profile'.