### PR TITLE
Update Inplace editable docs with new events and template

### DIFF
--- a/docs/apis/subsystems/output/inplace.md
+++ b/docs/apis/subsystems/output/inplace.md
@@ -266,7 +266,7 @@ class inplace_edit_select extends \core\output\inplace_editable {
 $renderer = $PAGE->get_renderer('core');
 $inplaceedit = new tool_mytest\local\inplace_edit_text($record);
 $params = $inplaceedit->export_for_template($renderer);
-echo $OUTPUT->render_from_template('core/inplace_edit', $params);
+echo $OUTPUT->render_from_template('core/inplace_editable', $params);
 ```
 
   </div>
@@ -284,7 +284,7 @@ $params = $inplaceedit->export_for_template($renderer);
 ```
 
 ```js title="The params are transferred via webservice and are then processed by JavaScript"
-Templates.renderForPromise('core/inplace_edit', params)
+Templates.renderForPromise('core/inplace_editable', params)
     .then(({html, js}) => {
         Templates.replaceNodeContents('nodeid', html, js);
         return true;
@@ -325,7 +325,7 @@ Plugin page can listen to JQuery events that are triggered on successful update 
 ```php
 $PAGE->requires->js_amd_inline("
 require(['jquery'], function(\$) {
-    $('body').on('updatefailed', '[data-inplaceeditable]', (e) => {
+    $('body').on('event:core/inplace_editable:updateFailed', '[data-inplaceeditable]', (e) => {
         // The exception object returned by the callback.
         const exception = e.exception;
 
@@ -337,7 +337,7 @@ require(['jquery'], function(\$) {
 
         // Do your own error processing here.
     });
-    $('body').on('updated', '[data-inplaceeditable]', (e) => {
+    $('body').on('core/inplace_editable:updated', '[data-inplaceeditable]', (e) => {
         // Everything that web service returned.
         const ajaxreturn = e.ajaxreturn;
 

--- a/docs/apis/subsystems/output/inplace.md
+++ b/docs/apis/subsystems/output/inplace.md
@@ -324,8 +324,8 @@ Plugin page can listen to JQuery events that are triggered on successful update 
 
 ```php
 $PAGE->requires->js_amd_inline("
-require(['jquery'], function(\$) {
-    $('body').on('event:core/inplace_editable:updateFailed', '[data-inplaceeditable]', (e) => {
+require(['jquery', 'core/local/inplace_editable/events'], function(\$, Events) {
+    $('body').on(Events.eventTypes.elementUpdateFailed, '[data-inplaceeditable]', (e) => {
         // The exception object returned by the callback.
         const exception = e.exception;
 
@@ -337,7 +337,7 @@ require(['jquery'], function(\$) {
 
         // Do your own error processing here.
     });
-    $('body').on('core/inplace_editable:updated', '[data-inplaceeditable]', (e) => {
+    $('body').on(Events.eventTypes.elementUpdated, '[data-inplaceeditable]', (e) => {
         // Everything that web service returned.
         const ajaxreturn = e.ajaxreturn;
 

--- a/versioned_docs/version-4.3/apis/subsystems/output/inplace.md
+++ b/versioned_docs/version-4.3/apis/subsystems/output/inplace.md
@@ -266,7 +266,7 @@ class inplace_edit_select extends \core\output\inplace_editable {
 $renderer = $PAGE->get_renderer('core');
 $inplaceedit = new tool_mytest\local\inplace_edit_text($record);
 $params = $inplaceedit->export_for_template($renderer);
-echo $OUTPUT->render_from_template('core/inplace_edit', $params);
+echo $OUTPUT->render_from_template('core/inplace_editable', $params);
 ```
 
   </div>
@@ -284,7 +284,7 @@ $params = $inplaceedit->export_for_template($renderer);
 ```
 
 ```js title="The params are transferred via webservice and are then processed by JavaScript"
-Templates.renderForPromise('core/inplace_edit', params)
+Templates.renderForPromise('core/inplace_editable', params)
     .then(({html, js}) => {
         Templates.replaceNodeContents('nodeid', html, js);
         return true;
@@ -325,7 +325,7 @@ Plugin page can listen to JQuery events that are triggered on successful update 
 ```php
 $PAGE->requires->js_amd_inline("
 require(['jquery'], function(\$) {
-    $('body').on('updatefailed', '[data-inplaceeditable]', (e) => {
+    $('body').on('event:core/inplace_editable:updateFailed', '[data-inplaceeditable]', (e) => {
         // The exception object returned by the callback.
         const exception = e.exception;
 
@@ -337,7 +337,7 @@ require(['jquery'], function(\$) {
 
         // Do your own error processing here.
     });
-    $('body').on('updated', '[data-inplaceeditable]', (e) => {
+    $('body').on('core/inplace_editable:updated', '[data-inplaceeditable]', (e) => {
         // Everything that web service returned.
         const ajaxreturn = e.ajaxreturn;
 

--- a/versioned_docs/version-4.3/apis/subsystems/output/inplace.md
+++ b/versioned_docs/version-4.3/apis/subsystems/output/inplace.md
@@ -324,8 +324,8 @@ Plugin page can listen to JQuery events that are triggered on successful update 
 
 ```php
 $PAGE->requires->js_amd_inline("
-require(['jquery'], function(\$) {
-    $('body').on('event:core/inplace_editable:updateFailed', '[data-inplaceeditable]', (e) => {
+require(['jquery', 'core/local/inplace_editable/events'], function(\$, Events) {
+    $('body').on(Events.eventTypes.elementUpdateFailed, '[data-inplaceeditable]', (e) => {
         // The exception object returned by the callback.
         const exception = e.exception;
 
@@ -337,7 +337,7 @@ require(['jquery'], function(\$) {
 
         // Do your own error processing here.
     });
-    $('body').on('core/inplace_editable:updated', '[data-inplaceeditable]', (e) => {
+    $('body').on(Events.eventTypes.elementUpdated, '[data-inplaceeditable]', (e) => {
         // Everything that web service returned.
         const ajaxreturn = e.ajaxreturn;
 

--- a/versioned_docs/version-4.4/apis/subsystems/output/inplace.md
+++ b/versioned_docs/version-4.4/apis/subsystems/output/inplace.md
@@ -266,7 +266,7 @@ class inplace_edit_select extends \core\output\inplace_editable {
 $renderer = $PAGE->get_renderer('core');
 $inplaceedit = new tool_mytest\local\inplace_edit_text($record);
 $params = $inplaceedit->export_for_template($renderer);
-echo $OUTPUT->render_from_template('core/inplace_edit', $params);
+echo $OUTPUT->render_from_template('core/inplace_editable', $params);
 ```
 
   </div>
@@ -284,7 +284,7 @@ $params = $inplaceedit->export_for_template($renderer);
 ```
 
 ```js title="The params are transferred via webservice and are then processed by JavaScript"
-Templates.renderForPromise('core/inplace_edit', params)
+Templates.renderForPromise('core/inplace_editable', params)
     .then(({html, js}) => {
         Templates.replaceNodeContents('nodeid', html, js);
         return true;
@@ -325,7 +325,7 @@ Plugin page can listen to JQuery events that are triggered on successful update 
 ```php
 $PAGE->requires->js_amd_inline("
 require(['jquery'], function(\$) {
-    $('body').on('updatefailed', '[data-inplaceeditable]', (e) => {
+    $('body').on('event:core/inplace_editable:updateFailed', '[data-inplaceeditable]', (e) => {
         // The exception object returned by the callback.
         const exception = e.exception;
 
@@ -337,7 +337,7 @@ require(['jquery'], function(\$) {
 
         // Do your own error processing here.
     });
-    $('body').on('updated', '[data-inplaceeditable]', (e) => {
+    $('body').on('core/inplace_editable:updated', '[data-inplaceeditable]', (e) => {
         // Everything that web service returned.
         const ajaxreturn = e.ajaxreturn;
 

--- a/versioned_docs/version-4.4/apis/subsystems/output/inplace.md
+++ b/versioned_docs/version-4.4/apis/subsystems/output/inplace.md
@@ -324,8 +324,8 @@ Plugin page can listen to JQuery events that are triggered on successful update 
 
 ```php
 $PAGE->requires->js_amd_inline("
-require(['jquery'], function(\$) {
-    $('body').on('event:core/inplace_editable:updateFailed', '[data-inplaceeditable]', (e) => {
+require(['jquery', 'core/local/inplace_editable/events'], function(\$, Events) {
+    $('body').on(Events.eventTypes.elementUpdateFailed, '[data-inplaceeditable]', (e) => {
         // The exception object returned by the callback.
         const exception = e.exception;
 
@@ -337,7 +337,7 @@ require(['jquery'], function(\$) {
 
         // Do your own error processing here.
     });
-    $('body').on('core/inplace_editable:updated', '[data-inplaceeditable]', (e) => {
+    $('body').on(Events.eventTypes.elementUpdated, '[data-inplaceeditable]', (e) => {
         // Everything that web service returned.
         const ajaxreturn = e.ajaxreturn;
 

--- a/versioned_docs/version-4.5/apis/subsystems/output/inplace.md
+++ b/versioned_docs/version-4.5/apis/subsystems/output/inplace.md
@@ -266,7 +266,7 @@ class inplace_edit_select extends \core\output\inplace_editable {
 $renderer = $PAGE->get_renderer('core');
 $inplaceedit = new tool_mytest\local\inplace_edit_text($record);
 $params = $inplaceedit->export_for_template($renderer);
-echo $OUTPUT->render_from_template('core/inplace_edit', $params);
+echo $OUTPUT->render_from_template('core/inplace_editable', $params);
 ```
 
   </div>
@@ -284,7 +284,7 @@ $params = $inplaceedit->export_for_template($renderer);
 ```
 
 ```js title="The params are transferred via webservice and are then processed by JavaScript"
-Templates.renderForPromise('core/inplace_edit', params)
+Templates.renderForPromise('core/inplace_editable', params)
     .then(({html, js}) => {
         Templates.replaceNodeContents('nodeid', html, js);
         return true;
@@ -325,7 +325,7 @@ Plugin page can listen to JQuery events that are triggered on successful update 
 ```php
 $PAGE->requires->js_amd_inline("
 require(['jquery'], function(\$) {
-    $('body').on('updatefailed', '[data-inplaceeditable]', (e) => {
+    $('body').on('event:core/inplace_editable:updateFailed', '[data-inplaceeditable]', (e) => {
         // The exception object returned by the callback.
         const exception = e.exception;
 
@@ -337,7 +337,7 @@ require(['jquery'], function(\$) {
 
         // Do your own error processing here.
     });
-    $('body').on('updated', '[data-inplaceeditable]', (e) => {
+    $('body').on('core/inplace_editable:updated', '[data-inplaceeditable]', (e) => {
         // Everything that web service returned.
         const ajaxreturn = e.ajaxreturn;
 

--- a/versioned_docs/version-4.5/apis/subsystems/output/inplace.md
+++ b/versioned_docs/version-4.5/apis/subsystems/output/inplace.md
@@ -324,8 +324,8 @@ Plugin page can listen to JQuery events that are triggered on successful update 
 
 ```php
 $PAGE->requires->js_amd_inline("
-require(['jquery'], function(\$) {
-    $('body').on('event:core/inplace_editable:updateFailed', '[data-inplaceeditable]', (e) => {
+require(['jquery', 'core/local/inplace_editable/events'], function(\$, Events) {
+    $('body').on(Events.eventTypes.elementUpdateFailed, '[data-inplaceeditable]', (e) => {
         // The exception object returned by the callback.
         const exception = e.exception;
 
@@ -337,7 +337,7 @@ require(['jquery'], function(\$) {
 
         // Do your own error processing here.
     });
-    $('body').on('core/inplace_editable:updated', '[data-inplaceeditable]', (e) => {
+    $('body').on(Events.eventTypes.elementUpdated, '[data-inplaceeditable]', (e) => {
         // Everything that web service returned.
         const ajaxreturn = e.ajaxreturn;
 


### PR DESCRIPTION
The current document is outdated since the code have changes.
So it is hard to using the example as references.