### PR TITLE
Fix the intro page for the 5.0 dev docs

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,13 +1,13 @@
 ---
 id: introduction
 title: Introduction
-description: Developer documentation for Moodle 4.5.
+description: Developer documentation for Moodle 5.0.
 slug: /
 tags:
   - Getting started
 ---
 
-Welcome to the Developer Documentation for **Moodle 4.5**.
+Welcome to the Developer Documentation for **Moodle 5.0**.
 
 This documentation is version-specific and includes a range of useful guides and information.
 
@@ -17,10 +17,10 @@ This documentation is version-specific and includes a range of useful guides and
 - Look through our [guides to Moodle APIs](./apis.md)
 - Browse our [Moodle feature](./guides.md) deep dives
 - Interested in supporting the Moodle App in your plugins? Read the [Moodle App documentation](/general/app)
-{/*- You may want to read the [Release notes](/general/releases/4.5) for Moodle 4.5 */}
+{/*- You may want to read the [Release notes](/general/releases/5.0) for Moodle 5.0 */}
 
 :::
 
 import ReleaseStateSummary from '@site/src/components/ReleaseStateSummary';
 
-<ReleaseStateSummary releaseName="4.5" />
+<ReleaseStateSummary releaseName="5.0" />

--- a/general/documentation/forking-versions.md
+++ b/general/documentation/forking-versions.md
@@ -32,6 +32,8 @@ Typically this task is performed by the Integration team using the following ste
 1. Uncomment and update the link to the release notes for this version
 1. Open `docs/devupdate.md` in your editor
 1. Clear the content of this file and update the version numbers
+1. Open `docs/intro.md` in your editor
+1. Update the occurrences of the version number for the recent release with the version number for the next major version of Moodle
 1. Open `nextVersion.js` in your editor
 1. Update the values for `nextVersion` (and `nextLTSVersion` after the release of an LTS version)
 1. Commit these changes ([Example from Moodle 4.4](https://github.com/moodle/devdocs/commit/XXaeb6385209caed38d757d53bc47f9bd66fdcfa0cY))

--- a/src/components/ReleaseStateSummary/index.tsx
+++ b/src/components/ReleaseStateSummary/index.tsx
@@ -105,7 +105,7 @@ function futureRelease({ releaseData }: majorVersionData): JSX.Element {
                     , which
                     {' '}
                     {releaseData.isLTS && <strong>will be an LTS release</strong>}
-                    {!releaseData.isLTS && <strong>will not an LTS release</strong>}
+                    {!releaseData.isLTS && <strong>will not be an LTS release</strong>}
                     , is scheduled for release on
                     {' '}
                     <strong>


### PR DESCRIPTION
I thought I had already sorted out this in #1162, but apparently, I missed it. 

I also added another commit that fixes the wording for future non-LTS versions in the release state summary.