### PR TITLE
Change discovery_agent interface name

### DIFF
--- a/docs/apis/core/hooks/index.md
+++ b/docs/apis/core/hooks/index.md
@@ -126,7 +126,7 @@ If you define a hook which is _not_ in the `[component]\hook\*` namespace then y
 
 namespace mod_example;
 
-class hooks implements \core\hook\hook_discovery_agent {
+class hooks implements \core\hook\hook\discovery_agent {
     public static function discover_hooks(): array {
         return [
             [

--- a/versioned_docs/version-4.3/apis/core/hooks/index.md
+++ b/versioned_docs/version-4.3/apis/core/hooks/index.md
@@ -100,7 +100,7 @@ If you define a hook which is _not_ in the `[component]\hook\*` namespace then y
 
 namespace mod_example;
 
-class hooks implements \core\hook\hook_discovery_agent {
+class hooks implements \core\hook\hook\discovery_agent {
     public static function discover_hooks(): array {
         return [
             [

--- a/versioned_docs/version-4.4/apis/core/hooks/index.md
+++ b/versioned_docs/version-4.4/apis/core/hooks/index.md
@@ -126,7 +126,7 @@ If you define a hook which is _not_ in the `[component]\hook\*` namespace then y
 
 namespace mod_example;
 
-class hooks implements \core\hook\hook_discovery_agent {
+class hooks implements \core\hook\hook\discovery_agent {
     public static function discover_hooks(): array {
         return [
             [

--- a/versioned_docs/version-4.5/apis/core/hooks/index.md
+++ b/versioned_docs/version-4.5/apis/core/hooks/index.md
@@ -126,7 +126,7 @@ If you define a hook which is _not_ in the `[component]\hook\*` namespace then y
 
 namespace mod_example;
 
-class hooks implements \core\hook\hook_discovery_agent {
+class hooks implements \core\hook\discovery_agent {
     public static function discover_hooks(): array {
         return [
             [


### PR DESCRIPTION
Interface '\core\hook\hook_discovery_agent' does not exist in the \core\hook, it should be '\core\hook\discovery_agent'.

![image](https://github.com/user-attachments/assets/0e2bb07c-768c-40da-b927-b759a47b31e4)
