### PR TITLE
Experimental release support and 4.6 docs

### DIFF
--- a/data/versions.json
+++ b/data/versions.json
@@ -19,6 +19,22 @@
             ]
         },
         {
+            "name": "4.6",
+            "releaseDate": "20 December 2024",
+            "generalEndDate": "14 April 2025",
+            "securityEndDate": "14 April 2025",
+            "isLTS": false,
+            "isExperimental": true,
+            "releases": [
+                {
+                    "name": "4.6.0",
+                    "releaseDate": "20 December 2024",
+                    "version": 2024102100,
+                    "upgradePath": "https://docs.moodle.org/405/en/Upgrading"
+                }
+            ]
+        },
+        {
             "name": "4.5",
             "releaseDate": "7 October 2024",
             "generalEndDate": "6 October 2025",

--- a/general/releases.md
+++ b/general/releases.md
@@ -90,6 +90,19 @@ Minor releases dates differ slightly from release to release depending on the ti
 
 :::
 
+## Moodle 4.6 (Experimental)
+
+Please note that Moodle 4.6 is an experimental version integrating MDL-71378 with the Moodle 4.5.x code, intended as a preview and testing release.  It is not recommended that it be used as part of general production.
+
+<ReleaseTable releaseName="4.6" />
+
+:::info
+
+Bug fixes for general core bugs in 4.6.x will end 14 April 2025 (4 months).<br/>
+Bug fixes for security issues in 4.6.x will end 14 April 2025 (4 months).
+
+:::
+
 ## Moodle 4.5 (LTS)
 
 <ReleaseTable releaseName="4.5" />

--- a/general/releases/4.6.md
+++ b/general/releases/4.6.md
@@ -1,0 +1,23 @@
+---
+title: Moodle 4.6 (experimental)
+tags:
+  - Release notes
+  - Moodle 4.6
+sidebar_position: -406
+moodleVersion: 4.6.0
+description: The release notes for Moodle version 4.6.0.
+---
+
+import { ReleaseNoteIntro } from '@site/src/components/ReleaseInformation';
+
+Release date: 20 December 2024
+
+Please note that Moodle 4.6 is an experimental version integrating [MDL-71378](https://tracker.moodle.org/browse/MDL-71378) with the Moodle 4.5.x code, intended as a preview and testing release.  It is not recommended that it be used as part of general production.
+
+For a list of fixes from previous releases please see the latest 4.5.x release notes.
+
+If you are upgrading from a previous version, please see [Upgrading](https://docs.moodle.org/en/Upgrading) in the user docs.
+
+## Server and client requirements
+
+Please see the [Moodle 4.5](https://moodledev.io/general/releases/4.5) server requirements, database requirements, and client requirements for details.

--- a/sidebars/releaseNotes.js
+++ b/sidebars/releaseNotes.js
@@ -66,6 +66,10 @@ module.exports = function getReleaseNotes() {
             }
         }
 
+        if (versionData.isExperimental) {
+            return;
+        }
+
         const entry = getReleaseEntry(versionData);
         if (existsSync(path.resolve(__dirname, '..', 'general', 'releases', versionData.name))) {
             entry.items.push({

--- a/src/theme/UnsupportedVersionBanner/index.js
+++ b/src/theme/UnsupportedVersionBanner/index.js
@@ -141,8 +141,36 @@ function SecuritySupportExpiredWarning({ versionData }) {
     );
 }
 
+function ExperimentalWarning() {
+    return (
+        <Admonition
+            type="danger"
+            icon={
+                <AutoFixHighIcon fontSize="inherit" />
+            }
+            title="Experimental release"
+        >
+            <strong>
+                <Translate
+                    description="A message to indicate that the version indicated an experimental release"
+                    id="version.support.experimental"
+                >
+                    This version of Moodle is an experimental release and not intended for general production systems.
+                </Translate>
+            </strong>
+        </Admonition>
+    );
+}
+
 function VersionedSupportWarning({ versionData, moodleVersion }) {
     const releaseStatus = getReleaseStatus(versionData, moodleVersion);
+
+    if (versionData.isExperimental) {
+        // Experimental version.
+        return (
+            <ExperimentalWarning versionData={versionData} />
+        );
+    }
 
     if (releaseStatus === 'current') {
         // Still in general support.

--- a/src/utils/SupportedReleases.ts
+++ b/src/utils/SupportedReleases.ts
@@ -37,12 +37,16 @@ export interface majorVersionData {
     securityEndDate: string,
     extendedSecurityEndDate?: string,
     isLTS: boolean,
+    isExperimental: boolean,
     releases?: Array<versionInfo>
 }
 
 export const isSupported = (versionData: majorVersionData): boolean => {
     if (versionData.extendedSecurityEndDate) {
         return (new Date(versionData.extendedSecurityEndDate)) > today;
+    } else if (versionData.isExperimental) {
+        // Do not display experimental releases in the version support info.
+        return false;
     }
 
     return (new Date(versionData.securityEndDate)) > today;

--- a/static/schema/versions.json
+++ b/static/schema/versions.json
@@ -39,6 +39,9 @@
                 "isLTS": {
                     "type": "boolean"
                 },
+                "isExperimental": {
+                    "type": "boolean"
+                },
                 "releases": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
This adds the ability to define an experimental release, which is omitted from the main releases nav and the release table, and adds a warning on the release notes page. This is then implemented for the 4.6 experimental release, which was made available today.

For the record: It's intentional that the upgrade link for 4.6 points to 4.5.