### PR TITLE
Display banner for versioned docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,7 +28,7 @@ dotEnvConfig();
 
 const versionConfig = Object.fromEntries(Versions.map((version) => [version, {
     label: version,
-    banner: 'none',
+    banner: 'unmaintained',
 }]));
 versionConfig.current = {
     label: `main (${nextVersion.nextVersion})`,


### PR DESCRIPTION
William Entriken requested this at https://tracker.moodle.org/browse/MDLSITE-7820. To implement it, we're taking advantage of the banner setting: https://docusaurus.io/docs/versioning#configuring-versioning-behavior.