### PR TITLE
[repo] Show a warning for stable versions that newer docs are available.

### DIFF
--- a/nextVersion.js
+++ b/nextVersion.js
@@ -15,11 +15,13 @@
  * along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+const latestVersion = '4.5';
 const nextVersion = '5.0';
 const nextLTSVersion = '5.3';
 const nextVersionRoot = `/docs/${nextVersion}`;
 
 module.exports = {
+    latestVersion,
     nextVersion,
     nextLTSVersion,
     nextVersionRoot,

--- a/src/theme/MoodlePageBanner/index.js
+++ b/src/theme/MoodlePageBanner/index.js
@@ -28,6 +28,7 @@ export default function MoodlePageBanner({ frontMatter, metadata = {} }) {
             />
             <UnsupportedVersionBanner
                 frontMatter={frontMatter}
+                metadata={metadata}
             />
         </>
     );


### PR DESCRIPTION
[~sarjona]: Here's the alternative for #1217.

I 100% do not agree with doing this and I have no intention of landing this. It's a blight on the documentation and I feel that it serves no useful purpose but to add more junk on the top of the page and to push the _useful_ part of the docs out of the immediate code window.

The pages you want to add this to are for fully supported versions of the codebase. I also do not agree that we should point people to docs for _unstable_ versions of the codebase.

I won't land this.