### PR TITLE
[docs] Fix a small typo on a git command in fixups.md

### DIFF
--- a/general/development/abc/fixups.md
+++ b/general/development/abc/fixups.md
@@ -36,7 +36,7 @@ Changes not staged for commit:
 no changes added to commit (use "git add" and/or "git commit -a")
 ```
 
-If your only goal was to make an updated commit for integration, you could do `git commit -a --ammend`. However, to be nice to the integrator, it is better to make a separate commit:
+If your only goal was to make an updated commit for integration, you could do `git commit -a --amend`. However, to be nice to the integrator, it is better to make a separate commit:
 
 ```
 $ git commit -a -m "MDL-12345 code review changes"


### PR DESCRIPTION
I just replaced the typo `git commit --ammend` by `git commit --amend`

Ref: [https://moodledev.io/general/development/abc/fixups](https://moodledev.io/general/development/abc/fixups#:~:text=git%20commit%20-a%20--ammend)