### PR TITLE
Fix typo

### DIFF
--- a/versioned_docs/version-4.5/apis/core/di/index.md
+++ b/versioned_docs/version-4.5/apis/core/di/index.md
@@ -219,7 +219,7 @@ The container is already reset after each test when running unit tests. It is no
 :::
 
 ```php title="Resetting the Container"
-\core\di::reset_container():
+\core\di::reset_container();
 ```
 
 :::danger


### PR DESCRIPTION
There is a typo in the example code for resetting the container - a colon instead of a semi-colon.