### PR TITLE
[repo] Update Husky installation for Yarn2

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
 
 yarn lint-staged

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "mdxfix-all": "markdownlint-cli2 --config .markdownlint/mdx/fix/.markdownlint-cli2.cjs '{docs,general}/**/*.mdx' '*.mdx'",
     "migrate": "scripts/wikimedia-fetch.mjs migrate",
     "lint": "yarn mdlint-all; yarn mdxlint-all; yarn spell",
-    "prepare": "husky install",
+    "postinstall": "husky install",
     "spell": "cspell '*.md' '*.mdx' '**/*.md' '**/*.mdx' 'docs/*.md' 'docs/*.mdx' 'docs/**/*.md' 'docs/**/*.mdx' 'general/*.md' 'general/*.mdx' 'general/**/*.md' 'general/**/*.mdx'"
   },
   "dependencies": {


### PR DESCRIPTION
Yarn 2 does not run the `prepare` script. We need to switch to `postinstall` or `install`. Husky recommends using the postinstall.