### PR TITLE
MDL-83469 adding core_courseformat_new_module references

### DIFF
--- a/docs/apis/plugintypes/mod/_files/lib_description.md
+++ b/docs/apis/plugintypes/mod/_files/lib_description.md
@@ -33,7 +33,7 @@ Each feature is identified by a constant, which is defined in the `lib
 
 - `FEATURE_GROUPS` and `FEATURE_GROUPINGS`: The activity module supports groups and groupings.
 - `FEATURE_SHOW_DESCRIPTION`: The activity module supports showing the description on the course page.
-- `FEATURE_QUICKCREATE`: The activity `[modname]_add_instance()` function is able to create an instance without showing a form using the default settings. It is used by the `core_courseformat_create_module` webservice to know which activities are compatible. If this feature is supported, the activity module should provide a `quickcreatename` string in the language file that will be used as the name of the instance created.
+- `FEATURE_QUICKCREATE`: The activity `[modname]_add_instance()` function is able to create an instance without showing a form using the default settings. It is used by the `core_courseformat_new_module` webservice to know which activities are compatible. If this feature is supported, the activity module should provide a `quickcreatename` string in the language file that will be used as the name of the instance created.
 - `FEATURE_COMPLETION`: The activity module supports activity completion. For now this feature only affects the bulk completion settings. However, in the future ([MDL-83027](https://tracker.moodle.org/browse/MDL-83027)) activities can set to false to disable all completion settings.
 
 <details>

--- a/docs/devupdate.md
+++ b/docs/devupdate.md
@@ -53,6 +53,17 @@ The section and activity action menus now utilize output classes instead of glob
 - `core_courseformat\output\local\content\section\controlmenu`: the existing class has been refactored and now uses `action_menu_link` objects instead. If your format add more options to the section menu, you should update your code to use the new class instead of using arrays.
 - `core_courseformat\output\local\content\cm\delegatedcontrolmenu`: like the section control menu, the existing class has been refactored to use `action_menu_link` objects instead of arrays.
 
+### New `core_courseformat_new_module` webservice
+
+<Since version="5.0" issueNumber="MDL-83469" />
+
+A new webservice, `core_courseformat_new_module`, has been introduced to replace the previous `core_courseformat_create_module`. The main difference between the two is that the new webservice uses the section id instead of the section number.
+
+To be sure your format plugin is not affected by the change, you must check:
+
+- If the plugin calls the deprecated webservice `core_courseformat_create_module`. If it does, you should update your code to use the new webservice.
+- The plugin has some link with `data-action` set to `addModule`. If it does, replace it by `data-action` set to `newModule` and add a `data-sectionid` attribute with the section id.
+
 ## Plugin type deprecation
 
 <Since version="5.0" issueNumber="MDL-79843" />

--- a/versioned_docs/version-4.5/apis/plugintypes/mod/_files/lib_description.md
+++ b/versioned_docs/version-4.5/apis/plugintypes/mod/_files/lib_description.md
@@ -33,7 +33,7 @@ Each feature is identified by a constant, which is defined in the `lib
 
 - `FEATURE_GROUPS` and `FEATURE_GROUPINGS`: The activity module supports groups and groupings.
 - `FEATURE_SHOW_DESCRIPTION`: The activity module supports showing the description on the course page.
-- `FEATURE_QUICKCREATE`: The activity `[modname]_add_instance()` function is able to create an instance without showing a form using the default settings. It is used by the `core_courseformat_create_module` webservice to know which activities are compatible. If this feature is supported, the activity module should provide a `quickcreatename` string in the language file that will be used as the name of the instance created.
+- `FEATURE_QUICKCREATE`: The activity `[modname]_add_instance()` function is able to create an instance without showing a form using the default settings. It is used by the `core_courseformat_new_module` webservice to know which activities are compatible. If this feature is supported, the activity module should provide a `quickcreatename` string in the language file that will be used as the name of the instance created.
 - `FEATURE_COMPLETION`: The activity module supports activity completion. For now this feature only affects the bulk completion settings. However, in the future ([MDL-83027](https://tracker.moodle.org/browse/MDL-83027)) activities can set to false to disable all completion settings.
 
 <details>


### PR DESCRIPTION
Documentation about the replacement for core_courseformat_create_module created in MDL-83469.