### PR TITLE
Add link and list of 5.0 QA testers

### DIFF
--- a/general/community/credits/testing.md
+++ b/general/community/credits/testing.md
@@ -10,6 +10,10 @@ tags:
 
 The following people have helped with [Quality Assurance (QA) testing](../../development/process/testing/qa):
 
+## Moodle 5.0 QA
+
+Adriano Ruseler, Alain Corbière, Alistair Spark, Amaia Anabitarte, Andrew Gosali, Angelia Dela Cruz, Antonia Bonaccorso, Avi Levy, Carol, Chris Pratt, Dag Klimas, David Woloszyn, Eli Zard, Fernando Acedo, Ferran Recio, German Valero, Huong Nguyen, Jean-Marc Doucet, John Provasnik, Joseph Rézeau, Kim Jared Lucas, Klaus Steitz, Laurent David, Luiggi Sansonetti, Meirza, Mihail Geshoski, Miri Lipson, Moien Abadi, Nadav Kavalerchik, Nicolas Martignoni, Raquel Ortega, Ron Carl Alfon Yu, Sara Arjona (@sarjona), Simey Lameze, Thom Rawson, Vika ablogeev, yonatan kostov
+
 ## Moodle 4.5 QA
 
 Adriano Ruseler, Alain Corbière, Alistair Spark, Amaia Anabitarte, Angelia Dela Cruz, Avi Levy, Carol, Dag Klimas, David Woloszyn, Eli Zard, Fernando Acedo, Ferran Recio, Jake Dallimore, Joe Goldberg, John Provasnik, Joseph Rézeau, Kevin Percy, Kim Jared Lucas, Laurent David, Luiggi Sansonetti, Maria João, Mary Cooch, Mathew May, Meirza, Michelle Lomman, Mihail Geshoski, Mikel Martín Corrales, Minh Hanh NGUYEN, Miri Lipson, Nadav Kavalerchik, Nicolas Martignoni, Praveen Chamarthi, Rajeshwar S, Raquel Ortega, Ron Carl Alfon Yu, Sabina Abellan, Safat Shahin, Sara Arjona (@sarjona), Simey Lameze, Stevani Andolo, Tamar Elikishvili, Victor Déniz Falcón, Vika ablogeev, yonatan kostov

--- a/general/development/process/testing/qa.md
+++ b/general/development/process/testing/qa.md
@@ -261,6 +261,7 @@ If you have any questions or comments, please post in the [Testing and QA forum]
 
 Comments on tests from previous QA cycles:
 
+- [Moodle 5.0 QA](https://tracker.moodle.org/browse/MDLQA-19836)
 - [Moodle 4.5 QA](https://tracker.moodle.org/browse/MDLQA-18925)
 - [Moodle 4.4 QA](https://tracker.moodle.org/browse/MDLQA-18443)
 - [Moodle 4.3 QA](https://tracker.moodle.org/browse/MDLQA-17933)


### PR DESCRIPTION
As part of the QA test process, this PR includes the name of the QA testers and a link to the 5.0 QA cycle