### PR TITLE
Fix typo in code example

### DIFF
--- a/docs/apis/subsystems/files/index.md
+++ b/docs/apis/subsystems/files/index.md
@@ -116,7 +116,7 @@ The complete function signature for this callback is as follows:
 function [component_name]_pluginfile(
     $course,
     $cm,
-    $context.
+    $context,
     string $filearea,
     array $args,
     bool $forcedownload,

--- a/versioned_docs/version-4.1/apis/subsystems/files/index.md
+++ b/versioned_docs/version-4.1/apis/subsystems/files/index.md
@@ -116,7 +116,7 @@ The complete function signature for this callback is as follows:
 function [component_name]_pluginfile(
     $course,
     $cm,
-    $context.
+    $context,
     string $filearea,
     array $args,
     bool $forcedownload,

--- a/versioned_docs/version-4.3/apis/subsystems/files/index.md
+++ b/versioned_docs/version-4.3/apis/subsystems/files/index.md
@@ -116,7 +116,7 @@ The complete function signature for this callback is as follows:
 function [component_name]_pluginfile(
     $course,
     $cm,
-    $context.
+    $context,
     string $filearea,
     array $args,
     bool $forcedownload,

--- a/versioned_docs/version-4.4/apis/subsystems/files/index.md
+++ b/versioned_docs/version-4.4/apis/subsystems/files/index.md
@@ -116,7 +116,7 @@ The complete function signature for this callback is as follows:
 function [component_name]_pluginfile(
     $course,
     $cm,
-    $context.
+    $context,
     string $filearea,
     array $args,
     bool $forcedownload,

--- a/versioned_docs/version-4.5/apis/subsystems/files/index.md
+++ b/versioned_docs/version-4.5/apis/subsystems/files/index.md
@@ -116,7 +116,7 @@ The complete function signature for this callback is as follows:
 function [component_name]_pluginfile(
     $course,
     $cm,
-    $context.
+    $context,
     string $filearea,
     array $args,
     bool $forcedownload,


### PR DESCRIPTION
parameters list with an dot instead of comma