### PR TITLE
Fix typos on external services declaration examples

### DIFF
--- a/docs/apis/subsystems/external/description.md
+++ b/docs/apis/subsystems/external/description.md
@@ -49,8 +49,8 @@ $functions = [
             // use in the Moodle Mobile App.
             MOODLE_OFFICIAL_MOBILE_SERVICE,
         ],
-    ),
-);
+    ],
+];
 ```
 
 <details>
@@ -76,8 +76,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/docs/apis/subsystems/external/writing-a-service.md
+++ b/docs/apis/subsystems/external/writing-a-service.md
@@ -114,8 +114,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         // 'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/versioned_docs/version-4.1/apis/subsystems/external/description.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/description.md
@@ -47,8 +47,8 @@ $functions = [
             // use in the Moodle Mobile App.
             MOODLE_OFFICIAL_MOBILE_SERVICE,
         ],
-    ),
-);
+    ],
+];
 ```
 
 <details>
@@ -74,8 +74,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/versioned_docs/version-4.1/apis/subsystems/external/writing-a-service.md
+++ b/versioned_docs/version-4.1/apis/subsystems/external/writing-a-service.md
@@ -114,8 +114,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         // 'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/versioned_docs/version-4.3/apis/subsystems/external/description.md
+++ b/versioned_docs/version-4.3/apis/subsystems/external/description.md
@@ -49,8 +49,8 @@ $functions = [
             // use in the Moodle Mobile App.
             MOODLE_OFFICIAL_MOBILE_SERVICE,
         ],
-    ),
-);
+    ],
+];
 ```
 
 <details>
@@ -76,8 +76,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/versioned_docs/version-4.3/apis/subsystems/external/writing-a-service.md
+++ b/versioned_docs/version-4.3/apis/subsystems/external/writing-a-service.md
@@ -114,8 +114,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         // 'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/versioned_docs/version-4.4/apis/subsystems/external/description.md
+++ b/versioned_docs/version-4.4/apis/subsystems/external/description.md
@@ -49,8 +49,8 @@ $functions = [
             // use in the Moodle Mobile App.
             MOODLE_OFFICIAL_MOBILE_SERVICE,
         ],
-    ),
-);
+    ],
+];
 ```
 
 <details>
@@ -76,8 +76,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/versioned_docs/version-4.4/apis/subsystems/external/writing-a-service.md
+++ b/versioned_docs/version-4.4/apis/subsystems/external/writing-a-service.md
@@ -114,8 +114,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         // 'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/versioned_docs/version-4.5/apis/subsystems/external/description.md
+++ b/versioned_docs/version-4.5/apis/subsystems/external/description.md
@@ -49,8 +49,8 @@ $functions = [
             // use in the Moodle Mobile App.
             MOODLE_OFFICIAL_MOBILE_SERVICE,
         ],
-    ),
-);
+    ],
+];
 ```
 
 <details>
@@ -76,8 +76,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>

--- a/versioned_docs/version-4.5/apis/subsystems/external/writing-a-service.md
+++ b/versioned_docs/version-4.5/apis/subsystems/external/writing-a-service.md
@@ -114,8 +114,8 @@ $functions = [
         // The file containing the class/external function.
         // Do not use if using namespaced auto-loading classes.
         // 'classpath'   => 'local/groupmanager/externallib.php',
-    ),
-);
+    ],
+];
 ```
 
 </details>


### PR DESCRIPTION
Some declarations had closing parenthesis when closing brackets needed.

[Check Actual External Function Declarations Docs](https://moodledev.io/docs/5.0/apis/subsystems/external/description)