### PR TITLE
Update Minimum PHP verion for Moodle 5.0+

### DIFF
--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -65,7 +65,7 @@ PHP 8.3 **can be used with** Moodle 4.4 and later releases. See MDL-76426 for de
 
 <Since versions={["4.2.3", "4.3"]} issueNumber="MDL-76405" />
 
-PHP 8.2 **can be used with** Moodle 4.2.3, Moodle 4.3 and later releases. See MDL-76405 for details.
+PHP 8.2 **can be used with** Moodle 4.2.3, Moodle 4.3 and later releases. It is also the **minimum** supported version for Moodle 5.0. See MDL-76405 for details.
 
 ### PHP 8.1
 


### PR DESCRIPTION
According to the composer.json file in the MOODLE_500_STABLE branch PHP 8.2 is the minimum version for Moodle 5.0+

I am not sure, if this is a misunderstanding by me, but I found it to be confusing.