### PR TITLE
Update 4.5.md bumping MySQL version

### DIFF
--- a/general/releases/4.5.md
+++ b/general/releases/4.5.md
@@ -31,7 +31,7 @@ Moodle supports the following database servers. Again, version numbers are just 
 | Database | Minimum version | Recommended |
 | --- | --- | --- |
 | [PostgreSQL](http://www.postgresql.org/) | 13 (increased since Moodle 4.1) | Latest |
-| [MySQL](http://www.mysql.com/) | 8.0 (increased since Moodle 4.1) | Latest |
+| [MySQL](http://www.mysql.com/) | 8.0.1 (increased since Moodle 4.1) | Latest |
 | [MariaDB](https://mariadb.org/) | 10.6.7 (increased since Moodle 4.1) | Latest |
 | [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 | Latest |
 | [Oracle Database](http://www.oracle.com/us/products/database/overview/index.html) | 19c (increased since Moodle 4.3) | Latest |


### PR DESCRIPTION
It looks like Moodle won't install with MySQL 8.0.0 because `role` was a reserved word, and is used by `mdl_course_completion_criteria.role`.

This restriction was removed in MySQL 8.0.1.

See https://dev.mysql.com/doc/mysqld-version-reference/en/keywords-8-0.html#keywords-8-0-detailed-R and https://moodle.org/mod/forum/discuss.php?d=467863 for more details.