### PR TITLE
[docs] Provide full example for Forms API

### DIFF
--- a/docs/apis/subsystems/form/index.md
+++ b/docs/apis/subsystems/form/index.md
@@ -34,10 +34,14 @@ To create a form in Moodle, you create a class that defines the form, including 
 <summary>An example of a form definition</summary>
 
 ```php title="[path/to/plugin]/classes/form/myform.php"
+<?php
+
+namespace [plugintype]_[pluginname]\form;
+
 // moodleform is defined in formslib.php
 require_once("$CFG->libdir/formslib.php");
 
-class simplehtml_form extends moodleform {
+class simplehtml_form extends \moodleform {
     // Add elements to form.
     public function definition() {
         // A reference to the form is stored in $this->form.

--- a/versioned_docs/version-4.1/apis/subsystems/form/index.md
+++ b/versioned_docs/version-4.1/apis/subsystems/form/index.md
@@ -34,10 +34,14 @@ To create a form in Moodle, you create a class that defines the form, including 
 <summary>An example of a form definition</summary>
 
 ```php title="[path/to/plugin]/classes/form/myform.php"
+<?php
+
+namespace [plugintype]_[pluginname]\form;
+
 // moodleform is defined in formslib.php
 require_once("$CFG->libdir/formslib.php");
 
-class simplehtml_form extends moodleform {
+class simplehtml_form extends \moodleform {
     // Add elements to form.
     public function definition() {
         // A reference to the form is stored in $this->form.

--- a/versioned_docs/version-4.4/apis/subsystems/form/index.md
+++ b/versioned_docs/version-4.4/apis/subsystems/form/index.md
@@ -34,10 +34,14 @@ To create a form in Moodle, you create a class that defines the form, including 
 <summary>An example of a form definition</summary>
 
 ```php title="[path/to/plugin]/classes/form/myform.php"
+<?php
+
+namespace [plugintype]_[pluginname]\form;
+
 // moodleform is defined in formslib.php
 require_once("$CFG->libdir/formslib.php");
 
-class simplehtml_form extends moodleform {
+class simplehtml_form extends \moodleform {
     // Add elements to form.
     public function definition() {
         // A reference to the form is stored in $this->form.

--- a/versioned_docs/version-4.5/apis/subsystems/form/index.md
+++ b/versioned_docs/version-4.5/apis/subsystems/form/index.md
@@ -34,10 +34,14 @@ To create a form in Moodle, you create a class that defines the form, including 
 <summary>An example of a form definition</summary>
 
 ```php title="[path/to/plugin]/classes/form/myform.php"
+<?php
+
+namespace [plugintype]_[pluginname]\form;
+
 // moodleform is defined in formslib.php
 require_once("$CFG->libdir/formslib.php");
 
-class simplehtml_form extends moodleform {
+class simplehtml_form extends \moodleform {
     // Add elements to form.
     public function definition() {
         // A reference to the form is stored in $this->form.

--- a/versioned_docs/version-5.0/apis/subsystems/form/index.md
+++ b/versioned_docs/version-5.0/apis/subsystems/form/index.md
@@ -34,10 +34,14 @@ To create a form in Moodle, you create a class that defines the form, including 
 <summary>An example of a form definition</summary>
 
 ```php title="[path/to/plugin]/classes/form/myform.php"
+<?php
+
+namespace [plugintype]_[pluginname]\form;
+
 // moodleform is defined in formslib.php
 require_once("$CFG->libdir/formslib.php");
 
-class simplehtml_form extends moodleform {
+class simplehtml_form extends \moodleform {
     // Add elements to form.
     public function definition() {
         // A reference to the form is stored in $this->form.


### PR DESCRIPTION
- provide full example including `<?php` tag when providing an example file. If an example references a filename the code block should contain a complete example of this file.
- specify namespace according to the automatic class loading rules
- add backslash to `moodleform` for namespaced reference (`use moodleform` would also be fine)

---

Not sure if `use moodleform` is preferred to `extends \moodleform`. The [style guide](https://moodledev.io/general/development/policies/codingstyle#further-notes) seems to say that both variants are fine?