### PR TITLE
Fix typo in code example

### DIFF
--- a/versioned_docs/version-4.5/guides/javascript/reactive/index.md
+++ b/versioned_docs/version-4.5/guides/javascript/reactive/index.md
@@ -566,8 +566,8 @@ export default class extends BaseComponent {
 
     // In this case we only want the affected element.
     _refreshStudent({element}) {
-        const element = this.getElement(this.selectors.ATTEMPTS, element.id);
-        element.innerHTML = element.attempts;
+        const domElement = this.getElement(this.selectors.ATTEMPTS, element.id);
+        domElement.innerHTML = element.attempts;
     }
 
 }
@@ -668,8 +668,8 @@ export default class extends BaseComponent {
     }
 
     _refreshStudent({element}) {
-        const element = this.getElement(this.selectors.ATTEMPTS, element.id);
-        element.innerHTML = element.attempts;
+        const domElement = this.getElement(this.selectors.ATTEMPTS, element.id);
+        domElement.innerHTML = element.attempts;
     }
 
     _submitAttempt(event) {


### PR DESCRIPTION
There looks to be a typo in the code sample.

The function param `element` is overwritten on the first line of the function, but the code then attempts to use the original parameter, on the second line (which won't work, unless this is some subtle bit of Javascript functionality that I'm missing - in which case, maybe it needs a comment in the code to explain it).