### PR TITLE
Update regex to match code in core_component::is_valid_plugin_name()

### DIFF
--- a/docs/apis/plugintypes/index.md
+++ b/docs/apis/plugintypes/index.md
@@ -35,7 +35,7 @@ If a plugin does not meet these requirements then it will be silently ignored.
 Plugin name validation takes place in `core_component::is_valid_plugin_name()` and the following regular expression is used:
 
 ```
-/^[a-z](?:[a-z0-9_](?!__))*[](a-z0-9)+$/
+/^[a-z](?:[a-z0-9_](?!__))*[a-z0-9]+$/
 ```
 
 :::


### PR DESCRIPTION
I went from 5.1 back to 2.6 and only saw the regex

 /^[a-z](?:[a-z0-9_](?!__))*[a-z0-9]+$/ 

in core_component::is_valid_plugin_name()