### PR TITLE
[docs] Make system requirement bumps clearer in supported versions

### DIFF
--- a/general/releases/4.1.md
+++ b/general/releases/4.1.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 3.9 or later.
-- PHP version: minimum PHP 7.4.0 *Note: minimum PHP version has increased since Moodle 4.0*. PHP 8.0.x and 8.1.x are supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 7.4.0 *Note: minimum PHP version has increased in this Moodle version*. PHP 8.0.x and 8.1.x are supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is recommended. It will be required in Moodle 4.2. For further details, see [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP extension **exif** is recommended.
 - PHP setting **max_input_vars** is recommended to be >= 5000 for PHP 7.x installations. It's a requirement for PHP 8.x installations. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
@@ -30,11 +30,11 @@ Moodle supports the following database servers. Again, version numbers are just 
 
 | Database | Minimum version | Recommended |
 | --- | --- | --- |
-| [PostgreSQL](http://www.postgresql.org/) | 12 (increased since Moodle 4.0) | Latest |
+| [PostgreSQL](http://www.postgresql.org/) | 12 (increased in this Moodle version) | Latest |
 | [MySQL](http://www.mysql.com/) | 5.7 | Latest |
-| [MariaDB](https://mariadb.org/) | 10.4 (increased since Moodle 4.0) | Latest |
-| [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 (increased since Moodle 3.10) | Latest |
-| [Oracle Database](http://www.oracle.com/us/products/database/overview/index.html) | 19 (increased since Moodle 4.0) | Latest |
+| [MariaDB](https://mariadb.org/) | 10.4 (increased in this Moodle version) | Latest |
+| [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 (increased in Moodle 4.0) | Latest |
+| [Oracle Database](http://www.oracle.com/us/products/database/overview/index.html) | 19 (increased in this Moodle version) | Latest |
 
 ## Client requirements
 

--- a/general/releases/4.4.md
+++ b/general/releases/4.4.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 4.1.2 or later.
-- PHP version: minimum PHP 8.1.0 *Note: minimum PHP version has increased since Moodle 4.3*. PHP 8.3.x is supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.1.0 *Note: minimum PHP version has increased in this Moodle version*. PHP 8.3.x is supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
 - PHP variants: Only 64-bit versions of PHP are supported. *Note: Changed since 4.1*.
@@ -30,11 +30,11 @@ Moodle supports the following database servers. Again, version numbers are just 
 
 | Database | Minimum version | Recommended |
 | --- | --- | --- |
-| [PostgreSQL](http://www.postgresql.org/) | 13 (increased since Moodle 4.1) | Latest |
-| [MySQL](http://www.mysql.com/) | 8.0 (increased since Moodle 4.1) | Latest |
-| [MariaDB](https://mariadb.org/) | 10.6.7 (increased since Moodle 4.1) | Latest |
+| [PostgreSQL](http://www.postgresql.org/) | 13 (last increased in Moodle 4.2) | Latest |
+| [MySQL](http://www.mysql.com/) | 8.0 (last increased in Moodle 4.2) | Latest |
+| [MariaDB](https://mariadb.org/) | 10.6.7 (last increased in Moodle 4.2) | Latest |
 | [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 | Latest |
-| [Oracle Database](http://www.oracle.com/us/products/database/overview/index.html) | 19c (increased since Moodle 4.3) | Latest |
+| [Oracle Database](http://www.oracle.com/us/products/database/overview/index.html) | 19c (increased in this Moodle version) | Latest |
 
 :::note Database prefixes
 

--- a/general/releases/4.5.md
+++ b/general/releases/4.5.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 4.1.2 or later.
-- PHP version: minimum PHP 8.1.0 *Note: minimum PHP version has increased since Moodle 4.3*. PHP 8.3.x is supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.1.0 *Note: minimum PHP version was increased in Moodle 4.4*. PHP 8.3.x is supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
 - PHP variants: Only 64-bit versions of PHP are supported. *Note: Changed since 4.1*.
@@ -30,11 +30,11 @@ Moodle supports the following database servers. Again, version numbers are just 
 
 | Database | Minimum version | Recommended |
 | --- | --- | --- |
-| [PostgreSQL](http://www.postgresql.org/) | 13 (increased since Moodle 4.1) | Latest |
-| [MySQL](http://www.mysql.com/) | 8.0 (increased since Moodle 4.1) | Latest |
-| [MariaDB](https://mariadb.org/) | 10.6.7 (increased since Moodle 4.1) | Latest |
+| [PostgreSQL](http://www.postgresql.org/) | 13 (last increased in Moodle 4.2) | Latest |
+| [MySQL](http://www.mysql.com/) | 8.0 (last increased in Moodle 4.2) | Latest |
+| [MariaDB](https://mariadb.org/) | 10.6.7 (last increased in Moodle 4.2) | Latest |
 | [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 | Latest |
-| [Oracle Database](http://www.oracle.com/us/products/database/overview/index.html) | 19c (increased since Moodle 4.3) | Latest |
+| [Oracle Database](http://www.oracle.com/us/products/database/overview/index.html) | 19c (last increased in Moodle 4.4) | Latest |
 
 :::note Database prefixes
 

--- a/general/releases/5.0.md
+++ b/general/releases/5.0.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 4.2.3 or later.
-- PHP version: minimum PHP 8.2.0 *Note: minimum PHP version has increased since Moodle 4.5*. PHP 8.3.x and 8.4.x are supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.2.0 *Note: minimum PHP version has increased in this Moodle version*. PHP 8.3.x and 8.4.x are supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
 - PHP variants: Only 64-bit versions of PHP are supported. *Note: Changed since 4.1*.
@@ -30,9 +30,9 @@ Moodle supports the following database servers. Again, version numbers are just 
 
 | Database | Minimum version | Recommended |
 | --- | --- | --- |
-| [PostgreSQL](http://www.postgresql.org/) | 14 (increased since Moodle 4.5) | Latest |
-| [MySQL](http://www.mysql.com/) | 8.4 (increased since Moodle 4.5) | Latest |
-| [MariaDB](https://mariadb.org/) | 10.11.0 (increased since Moodle 4.5) | Latest |
+| [PostgreSQL](http://www.postgresql.org/) | 14 (increased in this Moodle version) | Latest |
+| [MySQL](http://www.mysql.com/) | 8.4 (increased in this Moodle version) | Latest |
+| [MariaDB](https://mariadb.org/) | 10.11.0 (increased in this Moodle version) | Latest |
 | [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 | Latest |
 
 Please note that Oracle Database is no longer supported from Moodle LMS 5.0.

--- a/general/releases/5.1.md
+++ b/general/releases/5.1.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 4.2.3 or later.
-- PHP version: minimum PHP 8.2.0 *Note: minimum PHP version has increased since Moodle 4.5*. PHP 8.3.x and 8.4.x are supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.2.0 *Note: minimum PHP version was increased in Moodle 5.0*. PHP 8.3.x and 8.4.x are supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
 - PHP variants: Only 64-bit versions of PHP are supported.
@@ -30,9 +30,9 @@ Moodle supports the following database servers. Again, version numbers are just 
 
 | Database | Minimum version | Recommended |
 | --- | --- | --- |
-| [PostgreSQL](http://www.postgresql.org/) | 15 (increased since Moodle 5.0) | Latest |
-| [MySQL](http://www.mysql.com/) | 8.4 (increased since Moodle 4.5) | Latest |
-| [MariaDB](https://mariadb.org/) | 10.11.0 (increased since Moodle 4.5) | Latest |
+| [PostgreSQL](http://www.postgresql.org/) | 15 (increased in this Moodle version) | Latest |
+| [MySQL](http://www.mysql.com/) | 8.4 (last increased in Moodle 5.0) | Latest |
+| [MariaDB](https://mariadb.org/) | 10.11.0 (last increased in Moodle 5.0) | Latest |
 | [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 | Latest |
 
 Please note that Oracle Database is no longer supported from Moodle LMS 5.0.

--- a/general/releases/5.2.md
+++ b/general/releases/5.2.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 4.2.3 or later.
-- PHP version: minimum PHP 8.3.0 *Note: minimum PHP version has increased since Moodle 4.5*. PHP 8.4.x is supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.3.0 *Note: minimum PHP version has increased in this Moodle version*. PHP 8.4.x is supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
 - PHP variants: Only 64-bit versions of PHP are supported.
@@ -30,9 +30,9 @@ Moodle supports the following database servers. Again, version numbers are just 
 
 | Database | Minimum version | Recommended |
 | --- | --- | --- |
-| [PostgreSQL](http://www.postgresql.org/) | 14 (increased since Moodle 4.5) | Latest |
-| [MySQL](http://www.mysql.com/) | 8.4 (increased since Moodle 4.5) | Latest |
-| [MariaDB](https://mariadb.org/) | 10.11.0 (increased since Moodle 4.5) | Latest |
+| [PostgreSQL](http://www.postgresql.org/) | 15 (last increased in Moodle 5.1) | Latest |
+| [MySQL](http://www.mysql.com/) | 8.4 (last increased in Moodle 5.0) | Latest |
+| [MariaDB](https://mariadb.org/) | 10.11.0 (last increased in Moodle 5.0) | Latest |
 | [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 | Latest |
 
 Please note that Oracle Database is no longer supported from Moodle LMS 5.0.

--- a/general/releases/5.3.md
+++ b/general/releases/5.3.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 4.5 or later.
-- PHP version: minimum PHP 8.3.0 *Note: minimum PHP version has increased since Moodle 4.5*. PHP 8.4.x is supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.3.0 *Note: minimum PHP version was increased in Moodle 5.2*. PHP 8.4.x is supported too. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
 - PHP variants: Only 64-bit versions of PHP are supported. *Note: Changed since 4.1*.
@@ -30,9 +30,9 @@ Moodle supports the following database servers. Again, version numbers are just 
 
 | Database | Minimum version | Recommended |
 | --- | --- | --- |
-| [PostgreSQL](http://www.postgresql.org/) | 14 (increased since Moodle 4.5) | Latest |
-| [MySQL](http://www.mysql.com/) | 8.4 (increased since Moodle 4.5) | Latest |
-| [MariaDB](https://mariadb.org/) | 10.11.0 (increased since Moodle 4.5) | Latest |
+| [PostgreSQL](http://www.postgresql.org/) | 15 (last increased in Moodle 5.1) | Latest |
+| [MySQL](http://www.mysql.com/) | 8.4 (last increased in Moodle 5.0) | Latest |
+| [MariaDB](https://mariadb.org/) | 10.11.0 (last increased in Moodle 5.0) | Latest |
 | [Microsoft SQL Server](http://www.microsoft.com/en-us/server-cloud/products/sql-server/) | 2017 | Latest |
 
 Please note that Oracle Database is no longer supported from Moodle LMS 5.0.


### PR DESCRIPTION
The language previously used to describe when a system requirement version was bumped was really confusing: "increase since" mean "has increased since", which is confusing when you are looking at notes for a version beyond where it was bumped, because it sounds like the version listed is when it changed, when i twas actually changed in the release after that. For example  the 4.5 notes had "increased since Moodle 4.1" which actually meant something increased in 4.2...

I have updated all of the currently supported versions and the documented future versions (4.1, 4.4, 4.5, 5.0, 5.1, 5.2, 5.3) so that they say "increased in this Moodle version" in the initial version where a bump has occurred, and in subsequent versions it now says "last increased in Moodle X.Y" and lists the specific version where the change took place.