### PR TITLE
[docs] Allow pages to not use require_login

### DIFF
--- a/docs/apis/subsystems/access.md
+++ b/docs/apis/subsystems/access.md
@@ -190,9 +190,9 @@ function is_viewing(context $context, $user = null, $withcapability = _)
 
 #### `require_login()`
 
-Each plugin script should include require_login() or require_course_login() after setting up PAGE->url.
+If using require_login() or require_course_login(), this should be used after setting PAGE->url.
 
-This function does following:
+These functions do the following:
 
 - it verifies that user is logged in before accessing any course or activities (not-logged-in users can not enter any courses).
 - user is logged in as gu


### PR DESCRIPTION
# Need

I think it should be possible (and not violate recommendations) to create a Moodle plugin that has a public web page. *No login. No access checks whatsoever. No dependency on turning on Guest User. No dependency on turning Guest User access to the course with id=1. No other dependencies whatsoever.*

If you care, a specific use case is documented below (“USE CASE”), but that is not germane to the discussion. And please do not shut down this discussion if you disagree with that specific use case.

# Problems

The [documentation page](https://moodledev.io/docs/5.1/apis/subsystems/access#require_login) for `require_login(...)` specifies that:

> Each plugin script \[on every non-internal page\] should include require_login() or require_course_login() after setting up PAGE->url.

I disagree with this because of the reasons above.

# Solution

I propose one of two alternative solutions:

a) Update that documentation to state the following:

> If you wish to allow the page to successfully load when the visitor is not logged in (and do not redirect to ask them to login) then call it this way `require_login(..., ..., ...)`. There is no scenario in which this will stop the visitor from seeing the page.

-or-

b) Add a new function called `do_not_require_login(...)` which does what I am describing above in “a)” (which may or may not do logging and associate this page access with the course, if provided). And also update the “should include `require_login()` or `require_course_login()`" prescription with “or `do_not_require_login(...)`".

# Use case

The imminent use case is that we have course completion certificates in Moodle. These certificates will have a QR code on them. And [we are implementing](https://github.com/mdjnelson/moodle-mod_customcert/pull/681) that a visitor can scan these QR codes (on mobile) without logging in.

The people that are scanning/verifying these certificates care that the student has completed the course, and they do not care about logging in. And we do not care about them logging in.

## Testing Instructions

**The [RequireLoginSniff](https://github.com/moodlehq/moodle-cs/blob/main/moodle/Sniffs/Files/RequireLoginSniff.php), part of the [Moodle Code Checker](https://github.com/moodlehq/moodle-local_codechecker) is now requiring the `require_login()` function on every page because of the documentation isssue above.**

## Automated test results

None

## Pre-check results

None

## Workaround

None

## Other notes

This all-important `require_login(...)` function has some problems:

- Typos
- Grammatical errors
- Relies on an implicit understanding (i.e. not referenced) of how Guest User works and its configuration settings, and/or overrides/conflicts with other documentation on Guest Mode
- Not clear about whether it actually does or does not “require” “login”
