### PR TITLE
Update accessibility policy for WCAG 2.2 accreditation

### DIFF
--- a/general/development/policies/accessibility.md
+++ b/general/development/policies/accessibility.md
@@ -16,16 +16,17 @@ As part of our ongoing commitment to accessibility and continuously improving co
 
 #### Moodle LMS
 
-Moodle LMS has been accredited to meet [WCAG 2.1 Level AA conformance](https://moodle.atlassian.net/secure/attachment/147694/Moodle%20Statement%20of%20Conformance%202024.pdf).
+Moodle LMS has been accredited to meet [WCAG 2.2 Level AA conformance](https://www.grackledocs.com/en/accreditations/13211/).
 
 The table below provides a history of the accessibility audits performed on the Moodle LMS.
 
-| Audit period   | Target conformance | Accreditation date | Tracker epic                                             | Fixed versions               |
-|----------------|--------------------|--------------------|----------------------------------------------------------|------------------------------|
+| Audit period   | Target conformance | Accreditation date | Tracker epic                                               | Fixed versions               |
+|----------------|--------------------|--------------------|------------------------------------------------------------|------------------------------|
 | January 2020   | WCAG 2.1 Level AA  | 10 November 2020   | [MDL-67688](https://moodle.atlassian.net/browse/MDL-67688) | v3.10, v3.9.3                |
 | September 2021 | WCAG 2.1 Level AA  | 8 November 2021    | [MDL-72657](https://moodle.atlassian.net/browse/MDL-72657) | v4.0, v3.11.5, v3.10.8       |
 | May 2022       | WCAG 2.1 Level AA  | 3 May 2023         | [MDL-74624](https://moodle.atlassian.net/browse/MDL-74624) | v4.2, v4.1.3, v4.0.8         |
 | August 2023    | WCAG 2.1 Level AA  | 24 January 2024    | [MDL-78185](https://moodle.atlassian.net/browse/MDL-78185) | v4.4, v4.3.1, v4.2.4, v4.1.7 |
+| January 2025   | WCAG 2.2 Level AA  | 3 October 2025     | [MDL-84362](https://moodle.atlassian.net/browse/MDL-84362) | v5.1, v5.0.3, v4.5.7         |
 
 <details>
 
@@ -45,13 +46,14 @@ The Moodle App was accredited to meet [WCAG 2.1 Level AA conformance](https://ww
 
 #### Moodle Workplace
 
-Moodle Workplace has been accredited to meet [WCAG 2.1 Level AA conformance](https://www.grackledocs.com/en/accreditations/12295) on 27 Jun 2024.
+Moodle Workplace has been accredited to meet [WCAG 2.2 Level AA conformance](https://www.grackledocs.com/en/accreditations/13211).
 
 The table below provides a history of the accessibility audits performed on Moodle Workplace.
 
-| Audit period   | Target conformance | Accreditation date | Fixed versions               |
-|----------------|--------------------|--------------------|------------------------------|
-| August 2023    | WCAG 2.1 Level AA  | 27 June 2024       | v4.4, v4.3, v4.2, v4.1       |
+| Audit period | Target conformance | Accreditation date | Fixed versions         |
+|--------------|--------------------|--------------------|------------------------|
+| August 2023  | WCAG 2.1 Level AA  | 27 June 2024       | v4.4, v4.3, v4.2, v4.1 |
+| January 2025 | WCAG 2.2 Level AA  | 3 October 2025     | v5.1, v5.0, v4.5       |
 
 <details>
 

--- a/general/development/policies/accessibility.md
+++ b/general/development/policies/accessibility.md
@@ -89,11 +89,11 @@ The WCAG accreditation expires after 12 months as it is recognised that software
 
 #### Moodle LMS
 
-An overview of Moodle LMS' conformance with the [WCAG 2.1](https://www.w3.org/TR/WCAG21/) guidelines can be found in our [accessibility conformance report](https://docs.moodle.org/en/VPAT#Moodle%20accessibility%20conformance%20report).
+An overview of Moodle LMS' conformance with the [WCAG 2.2](https://www.w3.org/TR/WCAG22/) guidelines can be found in the [accessibility conformance report for Moodle LMS](https://docs.moodle.org/en/VPAT#Moodle%20accessibility%20conformance%20report).
 
 #### Moodle Workplace
 
-An overview of Moodle Workplace's conformance with the [WCAG 2.1](https://www.w3.org/TR/WCAG21/) guidelines can be found in our [accessibility conformance report](https://docs.moodle.org/en/Moodle_Workplace_VPAT#WCAG_2.x_report).
+An overview of Moodle Workplace's conformance with the [WCAG 2.2](https://www.w3.org/TR/WCAG22/) guidelines can be found in the [accessibility conformance report for Moodle Workplace](https://docs.moodle.org/en/Moodle_Workplace_VPAT#WCAG_2.x_report).
 
 <!-- cspell:ignore IAAP -->
 <!-- cspell:ignore credly -->


### PR DESCRIPTION
Updates to the accessibility policy page for the recent WCAG 2.2 Level AA accreditation for LMS and Workplace.

Also, fix the links to the accessibility conformance reports of LMS and Workplace to have unique accessible names to prevent screen reader users from seeing two different links with the same name on the page.