### PR TITLE
Add keywords for the accessibility policy for SEO

### DIFF
--- a/general/development/policies/accessibility.md
+++ b/general/development/policies/accessibility.md
@@ -2,8 +2,16 @@
 title: Accessibility
 tags:
   - Accessibility
+  - Accessibility policy
   - Compliance
   - Certification
+keywords:
+  - accessibility
+  - accessibility policy
+  - accessibility accreditation
+  - WCAG
+  - VPAT
+  - IAAP
 ---
 
 Moodle is designed to provide equal functionality and information to all people. This means that there should be no barriers for people regardless of disabilities, assistive technologies that are used, different screen sizes and different input devices (for example mouse, keyboard and touchscreen).


### PR DESCRIPTION
I tried searching for "Moodle accessibility policy" and was somewhat expecting our accessibility policy page in the developer documentation to appear in the search results. However, it did not come up. It might be worth adding some keywords for SEO purposes.