### PR TITLE
Document differences between Events and Hooks APIs

### DIFF
--- a/versioned_docs/version-5.1/apis/core/hooks/index.md
+++ b/versioned_docs/version-5.1/apis/core/hooks/index.md
@@ -43,7 +43,7 @@ New hooks added to Moodle from Moodle 4.4 onwards must meet the following rules:
 The [Events API](https://docs.moodle.org/dev/Events_API) and the Hooks API share similarities, but they serve distinct purposes and operate differently. Key differences include:
 
 - **Communication Flow**: Events use one-way communication (from one to many), while hooks enable two-way communication (typically many to one).
-- **Data Mutation**: Event data is must not be modified, whereas hook callbacks can modify hook instance data.
+- **Data Mutation**: Event data must not be modified, whereas hook callbacks can modify hook instance data.
 - **Execution Timing**: Events are triggered after actions, whereas hooks can be executed at any useful stage (e.g., pre-action, validation, post-action, etc.).
 - **Structure**: Events follow a fixed structure, but hooks can be arbitrary classes that may extend the base.
 - **DB Transactions**: Database transactions may cause event buffering, but the hook manager does not account for transactions.


### PR DESCRIPTION
based on https://docs.moodle.org/dev/Hooks_spec#Comparison_with_Moodle_Events

I think this information, as well as the Events API in general is missing in the devdocs. I think it is crucial though, I once found it understood it. But after a few years I needed to refresh my knowledge and struggled to even find that piece of information.