### PR TITLE
[MDL-87117] Describe the new strings to improve activity descriptions

### DIFF
--- a/docs/devupdate.md
+++ b/docs/devupdate.md
@@ -20,3 +20,17 @@ To address these challenges, we're reorganising the API to significantly improve
 - Refactor JSON exporters to support multiple Open Badges schema versions (MDL-85621). This will allow for seamless integration with different schema requirements.
 
 More information about the Badges API can be found in the [Badges API documentation](./apis/subsystems/badges/index.md).
+
+## Activity chooser descriptions refinement
+
+<Since version="5.2" issueNumber="MDL-87117" />
+
+The help descriptions within the Activity Chooser have been significantly updated for all core Activities and Resources to provide richer guidance:
+
+- A new optional language string, `modulename_summary`, has been introduced to define a concise, single-paragraph introduction to the module.
+- The existing `modulename_help` string has been refined to contain the detailed description, now structured with dedicated sections for:
+  - **Key features** to highlight the module's primary functionalities.
+  - **Ways to use it** to provide practical, application-focused examples.
+- A new optional string, `modulename_tip`, is available for a supplemental section for best practices, advice, or effective usage tips.
+
+Third-party activity modules and resources can adopt the same structure by adding these language strings (`modulename_summary`, `modulename_help`, and `modulename_tip`) to their plugin's language files. These strings should be placed in the plugin's language file, for example, `mod/pluginname/lang/en/pluginname.php`.


### PR DESCRIPTION
Adds comprehensive documentation outlining the requirements and steps for third-party Activities and Resources to utilise the new help string structure (`_summary`,` _help`, and `_tip`) within the Activity Chooser introduced in [MDL-87117](https://moodle.atlassian.net/browse/MDL-87117). This allows plugins to offer the same rich, structured help as core modules.


[MDL-87117]: https://moodle.atlassian.net/browse/MDL-87117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ