### PR TITLE
[docs] Correct Hooks examples to use callable notation

### DIFF
--- a/docs/apis/core/di/index.md
+++ b/docs/apis/core/di/index.md
@@ -83,7 +83,7 @@ The callback must be linked to the hook by specifying a callback in the plugin's
 $callbacks = [
     [
         'hook' => \core\hook\di_configuration::class,
-        'callback' => \mod_example\hook_listener::class . '::inject_dependencies',
+        'callback' => [\mod_example\hook_listener::class, 'inject_dependencies'],
     ],
 ];
 ```

--- a/docs/apis/plugintypes/ai/provider.md
+++ b/docs/apis/plugintypes/ai/provider.md
@@ -221,7 +221,7 @@ defined('MOODLE_INTERNAL') || die();
 $callbacks = [
     [
         'hook' => \core_ai\hook\after_ai_provider_form_hook::class,
-        'callback' => \aiprovider_openai\hook_listener::class . '::set_form_definition_for_aiprovider_openai',
+        'callback' => [\aiprovider_openai\hook_listener::class, 'set_form_definition_for_aiprovider_openai'],
     ],
 ];
 ```
@@ -439,7 +439,7 @@ For example, the `aiprovider_openai` plugin does these:
     $callbacks = [
         [
             'hook' => \core_ai\hook\after_ai_action_settings_form_hook::class,
-            'callback' => \aiprovider_openai\hook_listener::class . '::set_model_form_definition_for_aiprovider_openai',
+            'callback' => [\aiprovider_openai\hook_listener::class, 'set_model_form_definition_for_aiprovider_openai'],
         ],
     ];
     ```

--- a/versioned_docs/version-4.5/apis/core/di/index.md
+++ b/versioned_docs/version-4.5/apis/core/di/index.md
@@ -83,7 +83,7 @@ The callback must be linked to the hook by specifying a callback in the plugin's
 $callbacks = [
     [
         'hook' => \core\hook\di_configuration::class,
-        'callback' => \mod_example\hook_listener::class . '::inject_dependencies',
+        'callback' => [\mod_example\hook_listener::class, 'inject_dependencies'],
     ],
 ];
 ```

--- a/versioned_docs/version-5.0/apis/core/di/index.md
+++ b/versioned_docs/version-5.0/apis/core/di/index.md
@@ -83,7 +83,7 @@ The callback must be linked to the hook by specifying a callback in the plugin's
 $callbacks = [
     [
         'hook' => \core\hook\di_configuration::class,
-        'callback' => \mod_example\hook_listener::class . '::inject_dependencies',
+        'callback' => [\mod_example\hook_listener::class, 'inject_dependencies'],
     ],
 ];
 ```

--- a/versioned_docs/version-5.0/apis/plugintypes/ai/provider.md
+++ b/versioned_docs/version-5.0/apis/plugintypes/ai/provider.md
@@ -221,7 +221,7 @@ defined('MOODLE_INTERNAL') || die();
 $callbacks = [
     [
         'hook' => \core_ai\hook\after_ai_provider_form_hook::class,
-        'callback' => \aiprovider_openai\hook_listener::class . '::set_form_definition_for_aiprovider_openai',
+        'callback' => [\aiprovider_openai\hook_listener::class, 'set_form_definition_for_aiprovider_openai'],
     ],
 ];
 ```
@@ -439,7 +439,7 @@ For example, the `aiprovider_openai` plugin does these:
     $callbacks = [
         [
             'hook' => \core_ai\hook\after_ai_action_settings_form_hook::class,
-            'callback' => \aiprovider_openai\hook_listener::class . '::set_model_form_definition_for_aiprovider_openai',
+            'callback' => [\aiprovider_openai\hook_listener::class, 'set_model_form_definition_for_aiprovider_openai'],
         ],
     ];
     ```

--- a/versioned_docs/version-5.1/apis/core/di/index.md
+++ b/versioned_docs/version-5.1/apis/core/di/index.md
@@ -83,7 +83,7 @@ The callback must be linked to the hook by specifying a callback in the plugin's
 $callbacks = [
     [
         'hook' => \core\hook\di_configuration::class,
-        'callback' => \mod_example\hook_listener::class . '::inject_dependencies',
+        'callback' => [\mod_example\hook_listener::class, 'inject_dependencies'],
     ],
 ];
 ```

--- a/versioned_docs/version-5.1/apis/plugintypes/ai/provider.md
+++ b/versioned_docs/version-5.1/apis/plugintypes/ai/provider.md
@@ -221,7 +221,7 @@ defined('MOODLE_INTERNAL') || die();
 $callbacks = [
     [
         'hook' => \core_ai\hook\after_ai_provider_form_hook::class,
-        'callback' => \aiprovider_openai\hook_listener::class . '::set_form_definition_for_aiprovider_openai',
+        'callback' => [\aiprovider_openai\hook_listener::class, 'set_form_definition_for_aiprovider_openai'],
     ],
 ];
 ```
@@ -439,7 +439,7 @@ For example, the `aiprovider_openai` plugin does these:
     $callbacks = [
         [
             'hook' => \core_ai\hook\after_ai_action_settings_form_hook::class,
-            'callback' => \aiprovider_openai\hook_listener::class . '::set_model_form_definition_for_aiprovider_openai',
+            'callback' => [\aiprovider_openai\hook_listener::class, 'set_model_form_definition_for_aiprovider_openai'],
         ],
     ];
     ```


### PR DESCRIPTION
This change updates the hook callback notation to use callback notation instead of string notation. This is the recommended approach.