### PR TITLE
php: MDL-84684 is the PHP 8.5 epic

### DIFF
--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -111,9 +111,9 @@ PHP 7.0 **can be used with** Moodle 3.0.1, Moodle 3.1 and later releases. It is 
 
 ## PHP versions under development {/* #php-versions-under-development */}
 
-### PHP 8.4 {/* #php-84-1 */}
+### PHP 8.5 {/* #php-next */}
 
-PHP 8.4 support **is currently being implemented** for Moodle 5.0 and later releases. Hence it's still **incomplete and only for development purposes**. See MDL-80117 for details.
+PHP 8.5 support **is currently being implemented** for Moodle 5.2 and later releases. Hence it's still **incomplete and only for development purposes**. See MDL-84684 for details.
 
 ## See also {/* #see-also */}
 


### PR DESCRIPTION
These changes align with the previous time this section changed: 5115b36c23fc93df723b0e180a78cc7d21525573.

I changed the header fragment format to `php-next`, because it seems more useful for people over time. Feel free to revert that or instruct me to do so. ❤️ 