### PR TITLE
[config] Enable sitemap lastmod and align with Docusaurus v4 defaults

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -115,6 +115,11 @@ const config = {
                         trackingID: 'G-L9EE8RW5B1',
                     }
                     : undefined,
+                sitemap: {
+                    lastmod: 'date',
+                    priority: null,
+                    changefreq: null,
+                },
             }),
         ],
     ],


### PR DESCRIPTION
Configure the sitemap plugin (via classic preset) with lastmod: 'date', priority: null and changefreq: null, matching the upcoming v4.0 defaults as described in https://docusaurus.io/blog/releases/3.2#sitemap-lastmod.

Fixes #1579

I've tested it locally and is working well, all the URLs based on git files are getting the `<lastmod>YYYY-MM-13DD</lastmod>` element.

Obviously, those generated from JSON or other methods, not coming from git (tags, search page, ...) do not have that new information.

Also, at the same time, the old (and useless) `priority` and `changefreq` have been removed, aligning which the expected defaults for v4.0.

Ciao :-)