### PR TITLE
Fix name for popup message processor in sample code

### DIFF
--- a/docs/apis/core/message/index.md
+++ b/docs/apis/core/message/index.md
@@ -80,7 +80,7 @@ Once your `messages.php` is complete you need to increase the version number of 
 ```php title="The default processor can be set using an element of the array"
 'mynotification' => [
     'defaults' => [
-        'pop-up' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+        'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         'email' => MESSAGE_PERMITTED,
     ],
 ],

--- a/versioned_docs/version-4.5/apis/core/message/index.md
+++ b/versioned_docs/version-4.5/apis/core/message/index.md
@@ -80,7 +80,7 @@ Once your `messages.php` is complete you need to increase the version number of 
 ```php title="The default processor can be set using an element of the array"
 'mynotification' => [
     'defaults' => [
-        'pop-up' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+        'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         'email' => MESSAGE_PERMITTED,
     ],
 ],

--- a/versioned_docs/version-5.0/apis/core/message/index.md
+++ b/versioned_docs/version-5.0/apis/core/message/index.md
@@ -80,7 +80,7 @@ Once your `messages.php` is complete you need to increase the version number of 
 ```php title="The default processor can be set using an element of the array"
 'mynotification' => [
     'defaults' => [
-        'pop-up' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+        'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         'email' => MESSAGE_PERMITTED,
     ],
 ],

--- a/versioned_docs/version-5.1/apis/core/message/index.md
+++ b/versioned_docs/version-5.1/apis/core/message/index.md
@@ -80,7 +80,7 @@ Once your `messages.php` is complete you need to increase the version number of 
 ```php title="The default processor can be set using an element of the array"
 'mynotification' => [
     'defaults' => [
-        'pop-up' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
+        'popup' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         'email' => MESSAGE_PERMITTED,
     ],
 ],


### PR DESCRIPTION
The popup message processor in the sample code is refered to as `pop-up`, but should be `popup` (See for example https://github.com/moodle/moodle/blob/main/public/lib/db/messages.php).