### PR TITLE
Update 4.5.md

### DIFF
--- a/general/releases/4.5.md
+++ b/general/releases/4.5.md
@@ -19,7 +19,7 @@ If you are upgrading from a previous version, please see [Upgrading](https://doc
 These are just the minimum supported versions. We recommend keeping all of your software and operating systems up-to-date.
 
 - Moodle upgrade: Moodle 4.1.2 or later.
-- PHP version: minimum PHP 8.1.0 *Note: minimum PHP version was increased in Moodle 4.4*. PHP 8.3.x is supported too. See [PHP](../development/policies/php.md) for details.
+- PHP version: minimum PHP 8.1.0 *Note: minimum PHP version was increased in Moodle 4.4*. PHP 8.3.x is supported too. PHP versions 8.4 and above are not supported in Moodle 4.5. See [PHP](../development/policies/php.md) for details.
 - PHP extension **sodium** is required. See [Environment - PHP extension sodium](https://docs.moodle.org/en/Environment_-_PHP_extension_sodium).
 - PHP setting **max_input_vars** must be >= 5000. For further details, see [Environment - max input vars](https://docs.moodle.org/en/Environment_-_max_input_vars).
 - PHP variants: Only 64-bit versions of PHP are supported. *Note: Changed since 4.1*.


### PR DESCRIPTION
Docs should explain that PHP 8.4 is not supported in Moodle 4.5 and older versions.