### PR TITLE
Plugins Directory Checklist: Add policies to approval blockers

### DIFF
--- a/general/community/plugincontribution/checklist.md
+++ b/general/community/plugincontribution/checklist.md
@@ -208,6 +208,8 @@ Examples of issues that will prevent your plugin from being approved:
 1. It integrates with an external system and does not have the privacy API correctly implemented.
 1. It is an activity module and does not have the backup and restore API implemented.
 1. You must be in compliance with the [Moodle.org Site policy](https://moodle.org/admin/tool/policy/view.php?policyid=4).
+1. The plugin replicates or directly competes with functionality offered by Moodle commercial products (for example, Moodle Workplace). See the [Commercial Listing Policy](https://moodle.atlassian.net/wiki/external/Mjk2NzgwYjAzY2Q4NDAyNmJlYWY4OTRhOWVmY2ExYjc) for details.
+1. Use of Moodle trademarks in a way that violates the [Moodle Trademarks Policy](https://moodle.com/trademarks/).
 
 ## See also {/* #see-also */}
 


### PR DESCRIPTION
Ahead of the Moodle Marketplace launch, we are extending the Marketplace's commercial product protection policy to the existing Plugins Directory. This change prevents the listing or promoting of plugins that duplicate or directly compete with our commercial products, and avoids the downstream work of migrating non-compliant plugins out of the Marketplace after launch.

More details at https://moodle.atlassian.net/browse/MKPL-1026