### PR TITLE
[docs] Supplementary content in the sticky footer

### DIFF
--- a/docs/apis/plugintypes/format/linear_navigation.md
+++ b/docs/apis/plugintypes/format/linear_navigation.md
@@ -134,3 +134,24 @@ And the course linear navigation should be visible
 # Or to verify the disabled state:
 And the course linear navigation should not be visible
 ```
+
+## Adding supplementary content to the sticky footer
+
+<Since version="5.3" issueNumber="MDL-88601" />
+
+Independently of whether the current course format supports linear navigation, any part of Moodle can request additional content to be displayed in the sticky footer by calling `moodle_page->set_supplementary_content()` with an `action_link` instance:
+
+```php
+$PAGE->set_supplementary_content(
+    new action_link(
+        new moodle_url('/mod/forum/view.php', ['id' => $cm->id]),
+        get_string('gotoalldiscussions', 'mod_forum'),
+    )
+);
+```
+
+When supplementary content is set, the sticky footer is displayed even if the course format does not support linear navigation, or the setting is disabled, showing only the supplementary content. If linear navigation is also enabled, both the navigation controls and the supplementary content are rendered together in the footer, separated by a border.
+
+Use `moodle_page->get_supplementary_content()` to retrieve the current value, which returns `null` if none has been set. The value is automatically reset whenever `moodle_page->reset_theme_and_output()` is called.
+
+This feature is used, for example, by `mod_forum` to add a "Go to all discussions" link when viewing an individual discussion.

--- a/docs/devupdate.md
+++ b/docs/devupdate.md
@@ -16,3 +16,13 @@ This page highlights the important changes that are coming in Moodle 5.3 for dev
 Moodle 5.3 introduces support for sequential linear navigation controls within course views. By default, third-party course formats do not display linear navigation elements. To explicitly opt in and declare support for this feature, course formats must override the `uses_linear_navigation()` method.
 
 For a comprehensive integration guide, structural configuration examples, and page-state API controls, see the [Linear navigation support guide](./apis/plugintypes/format/linear_navigation.md).
+
+## Supplementary content in the sticky footer
+
+<Since version="5.3" issueNumber="MDL-88601" />
+
+The `moodle_page` class now includes `set_supplementary_content()` and `get_supplementary_content()` methods, allowing any part of Moodle to inject an `action_link` as supplementary content into the sticky footer, regardless of whether the current course format supports linear navigation.
+
+For instance, `mod_forum` uses this new mechanism to display a "Go to all discussions" link in the sticky footer when viewing an individual discussion.
+
+For more information, see the [Adding supplementary content to the sticky footer](./apis/plugintypes/format/linear_navigation.md#adding-supplementary-content-to-the-sticky-footer) section.


### PR DESCRIPTION
Document the new moodle_page::set_supplementary_content() and get_supplementary_content() methods introduced in MDL-88601, which allow injecting additional content into the sticky footer independently of course format linear navigation support, as used by mod_forum to link back to the discussion list.