### PR TITLE
Add missing mention of Moodle 5.2 requiring at least PHP 8.3. in `php.md`

### DIFF
--- a/general/development/policies/php.md
+++ b/general/development/policies/php.md
@@ -59,7 +59,7 @@ PHP 8.4 **can be used with** Moodle 5.0 and later releases. See MDL-80117 for de
 
 <Since versions={["4.4"]} issueNumber="MDL-76426" />
 
-PHP 8.3 **can be used with** Moodle 4.4 and later releases. See MDL-76426 for details.
+PHP 8.3 **can be used with** Moodle 4.4 and later releases. It is also the **minimum** supported version for Moodle 5.2. See MDL-76426 for details.
 
 ### PHP 8.2 {/* #php-82 */}
 


### PR DESCRIPTION
This tripped me up because I always used [that page](https://moodledev.io/general/development/policies/php#php-83) as a reference, yet my plugin CI runs failed during the composer setup. Then I saw the [release notes for 5.2](https://moodledev.io/general/releases/5.2) and [this part of the Installation docs](https://docs.moodle.org/502/en/PHP) mention the PHP 8.3+ requirement. This change just aligns the devdocs with the rest.