### PR TITLE
Calendar API: add "see also events API" note

### DIFF
--- a/docs/apis/core/calendar/index.md
+++ b/docs/apis/core/calendar/index.md
@@ -3,7 +3,9 @@ title: Calendar API
 tags: []
 ---
 
-This page documents the Calendar API as it is in Moodle 3.3 and later. For the API in older versions of Moodle, see [Calendar API old](https://docs.moodle.org/dev/Calendar_API_old).
+_This article is about **calendar events**, meant for conveying time-related information to users. For the unrelated concept of events used by **event handlers** / **observers** and **logging**, see **[Events API](https://moodledev.io/docs/5.3/apis#events-api-event)**._
+
+_This page documents the Calendar API as it is in Moodle 3.3 and later. For the API in older versions of Moodle, see [Calendar API old](https://docs.moodle.org/dev/Calendar_API_old)._
 
 The Calendar API allows you to add, modify and delete events in the calendar for user, groups, courses and the site. As of 3.3 it also allows you to provide actions for these events so that they are then displayed on block_myoverview, which by default is shown on users' dashboard.
 


### PR DESCRIPTION
While working on something dealing with the calendar recently, I encountered some confusion around the fact that Moodle has two types of entities it calls "events":

1. calendar events, used by the Calendar API and stored in the `mdl_event` table
2. events used by the Events API, for logging and event-handlers / observers

So I thought it might help other people in a similar situation if the calendar API page had a note about this.