### PR TITLE
[docs] Remove course-level linear navigation setting (MDL-89406)

### DIFF
--- a/docs/apis/plugintypes/format/index.md
+++ b/docs/apis/plugintypes/format/index.md
@@ -237,7 +237,7 @@ Webservices expect course format options to be passed in additional entities but
 
 | `core_courseformat\base` Overridable method  | Description  |
 |---|---|
-| `course_format_options()` | By overriding this method course format specifies which additional options it has for course. It can also be used to inject linear navigation defaults using `\core_courseformat\local\linearnavigationsettings::get_course_format_options_default()`. |
+| `course_format_options()` | By overriding this method course format specifies which additional options it has for course |
 | `section_format_options()` | By overriding this method course format specifies which additional options it has for course section. Note that since section information is cached you may want to cache some additional options as well. See PHPdocs for more information |
 | `get_format_options()` | (usually no need to override) low level function to retrieve course format options values. It is more convenient to use methods get_course() and get_section() |
 | `create_edit_form_elements()` | This function is called to alter course edit form and standard section edit form. The default implementation creates simple form elements for each option defined in either `course_format_options()` or `section_format_options()`. Overwrite it if you want to have more comprehensive form elements or if you do not want options to appear in edit forms, etc. |

--- a/docs/apis/plugintypes/format/linear_navigation.md
+++ b/docs/apis/plugintypes/format/linear_navigation.md
@@ -34,69 +34,24 @@ class format_mycustomformat extends \core_courseformat\base {
 }
 ```
 
-## Adding format-level configuration
+## Adding an administration setting
 
-If your course format requires configuration at the course settings level (similar to how `format_topics` and `format_weeks` handle it), you should integrate it into your format's native settings framework (`course_format_options`).
-
-```php title="course/format/mycustomformat/lib.php"
-    /**
-     * Define the format options for a course.
-     *
-     * @param bool $foreditform True if it's being requested for the course edit form.
-     * @return array Array of options.
-     */
-    public function course_format_options($foreditform = false) {
-        static $courseformatoptions = false;
-        // Initialise the course format options array if it hasn't been done yet with the default values.
-        if ($courseformatoptions === false) {
-            // Get course format's settings.
-            $courseformatoptions = [];
-
-            // Add linear navigation settings if enabled for the format.
-            $courseformatoptions = array_merge(
-                \core_courseformat\local\linearnavigationsettings::get_course_format_options_default(self::get_format()),
-                $courseformatoptions,
-            );
-
-        }
-
-        if ($foreditform) {
-            // Get the edit form options for the format.
-            $courseformatoptionsedit = [];
-
-            // Add course format settings.
-
-            // Append your format's explicit linear navigation setting override if desired,
-            // or rely on the core 'enablelinearnav' setting configuration.
-            $courseformatoptions = array_merge_recursive(
-                $courseformatoptionsedit,
-                \core_courseformat\local\linearnavigationsettings::get_course_format_options_edit_form(self::get_format()),
-            );
-        }
-        return $courseformatoptions;
-    }
-```
-
-:::info[Adding site-wide administration settings]
-
-To allow administrators to enable, disable, or define the default state for linear navigation within your custom format, add the configuration option to your plugin's settings.php file.
+Linear navigation is controlled by an `enablelinearnav` setting in each course format's own component. A format which does not define the setting has linear navigation enabled.
 
 ```php title="course/format/mycustomformat/settings.php"
-    $options = [
-        1 => get_string('yes'),
-        0 => get_string('no'),
-    ];
+$options = [
+    1 => get_string('yes'),
+    0 => get_string('no'),
+];
 
-    $settings->add(new admin_setting_configselect(
-        'format_mycustomformat/enablelinearnav',
-        new lang_string('linearnavigationsettings', 'core_courseformat'),
-        new lang_string('linearnavigationsettings_help', 'core_courseformat'),
-        1,
-        $options
-    ));
+$settings->add(new admin_setting_configselect(
+    'format_mycustomformat/enablelinearnav',
+    new lang_string('linearnavigationsettings', 'core_courseformat'),
+    new lang_string('linearnavigationsettings_help', 'core_courseformat'),
+    1,
+    $options,
+));
 ```
-
-:::
 
 ## Controlling the page state rendering
 
@@ -117,7 +72,7 @@ if (\core_courseformat\local\linearnavigationsettings::show_navigation_footer($P
 }
 
 // Check if linear navigation is enabled for the course.
-// It only checks the course format and the linear navigation format option, regardless of any
+// It only checks the course format and the site-level setting for that format, regardless of any
 // page-level state. It is useful for activities that need to adapt their output (for example,
 // hiding navigation controls of their own) when linear navigation is enabled.
 $linearnavigationenabled = \core_courseformat\local\linearnavigationsettings::is_linear_navigation_enabled($course);


### PR DESCRIPTION
Tracker: [MDL-89406](https://moodle.atlassian.net/browse/MDL-89406) — *Enable linear navigation for all courses and control it through a site-level setting*

[MDL-89406](https://moodle.atlassian.net/browse/MDL-89406) removes the `enablelinearnav` course format option and its course settings field, leaving linear navigation controlled solely by the per-format site setting. The option is absent from v5.2.0 and all earlier tags, so it never shipped in a stable release and is removed outright rather than deprecated.

This updates the developer documentation to match.

## Changes

**`docs/apis/plugintypes/format/linear_navigation.md`**

- Replace the *Adding format-level configuration* section. Its `course_format_options()` sample called `linearnavigationsettings::get_course_format_options_default()` and `::get_course_format_options_edit_form()`, both removed by the patch. The `settings.php` example previously nested inside it is still current and is promoted to be the section, since it is now the only way a format configures the feature.
- Document that a format which does not define the setting has linear navigation enabled, matching the fallback in `get_default_linear_navigation_value()`.
- Correct the description of `is_linear_navigation_enabled()`, which read "the linear navigation format option" and now reads the site-level setting for the format.

**`docs/apis/plugintypes/format/index.md`**

- Drop the reference to `get_course_format_options_default()` from the `course_format_options()` row, restoring the wording that preceded 0ca97eb.

## Notes

The page carries `<Since version="5.3" issueNumber="MDL-84921" />` and no new `Since` marker is added: as the course-level option never reached a stable release, there is nothing for a 5.3 reader to have known differently. For the same reason the text does not describe the removed course setting — it documents only current behaviour.

`docs/devupdate.md` was reviewed and left unchanged; its description of the `uses_linear_navigation()` opt-in remains accurate.

## Testing

- `yarn mdlint` — 0 errors
- `cspell` — 0 issues
- `yarn build` — succeeds (`onBrokenLinks: 'throw'`), no anchor warnings
- All methods referenced by the page verified present on the MDL-89406 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MDL-89406]: https://moodle.atlassian.net/browse/MDL-89406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MDL-89406]: https://moodle.atlassian.net/browse/MDL-89406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ